### PR TITLE
Run on Linux

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
-  "name": "cosmo-builder",
+  "name": "bot-crossing",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "cosmo-builder",
+      "name": "bot-crossing",
       "version": "1.0.0",
       "license": "MIT",
       "os": [
-        "darwin"
+        "darwin",
+        "linux"
       ],
       "dependencies": {
         "@mdi/js": "^7.4.47",
@@ -1629,7 +1630,6 @@
       "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "node": ">=20"
   },
   "os": [
-    "darwin"
+    "darwin",
+    "linux"
   ],
   "scripts": {
     "dev": "npm run assets --silent && vite",

--- a/server/api.mjs
+++ b/server/api.mjs
@@ -1,4 +1,5 @@
 import fsp from 'node:fs/promises'
+import os from 'node:os'
 import path from 'node:path'
 import { spawn } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
@@ -78,9 +79,24 @@ async function writeState(next) {
   return state
 }
 
-/** Hand a `harness://…` deep link to the OS. `open` gets an argument list, never a shell string. */
+/**
+ * Hand a `harness://…` deep link (or a folder path for reveal) to the OS.
+ * The launcher gets an argument list, never a shell string. macOS uses
+ * `open(1)`, Linux uses `xdg-open`. A missing launcher — a headless box has
+ * no `xdg-open` — fails silently: there is nothing the page could do with
+ * the error, and the scan path must never depend on presentation.
+ */
+function opener() {
+  if (process.platform === 'darwin') return 'open'
+  if (process.platform === 'linux') return 'xdg-open'
+  return null
+}
+
 function launch(url) {
-  const child = spawn('open', [url], { stdio: 'ignore', detached: true })
+  const cmd = opener()
+  if (!cmd) return
+  const child = spawn(cmd, [url], { stdio: 'ignore', detached: true })
+  child.on('error', () => {})
   child.unref()
 }
 
@@ -138,6 +154,16 @@ function send(res, status, body) {
 }
 
 const LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '::1'])
+
+// The machine's own LAN addresses count as local too, so the colony can be
+// served to the home network with BOT_CROSSING_HOST set. Harmless when bound
+// to loopback (those hosts can't reach the server anyway), and the Host +
+// Origin pairing still stops DNS rebinding and CSRF exactly as before.
+for (const addrs of Object.values(os.networkInterfaces())) {
+  for (const a of addrs || []) {
+    if (a && a.family === 'IPv4' && !a.internal && a.address) LOCAL_HOSTS.add(a.address)
+  }
+}
 
 /** Hostname out of a `Host:` or `Origin:` value, with the port and any brackets stripped. */
 function hostnameOf(value) {

--- a/server/serve.mjs
+++ b/server/serve.mjs
@@ -7,6 +7,7 @@ import { apiMiddleware } from './api.mjs'
 const here = path.dirname(fileURLToPath(import.meta.url))
 const DIST = path.join(here, '..', 'dist')
 const PORT = Number(process.env.PORT) || 5274
+const HOST = process.env.BOT_CROSSING_HOST || '127.0.0.1'
 
 const TYPES = {
   '.html': 'text/html; charset=utf-8',
@@ -57,6 +58,6 @@ const server = http.createServer(async (req, res) => {
   }
 })
 
-server.listen(PORT, '127.0.0.1', () => {
-  console.log(`Bot Crossing → http://127.0.0.1:${PORT}`)
+server.listen(PORT, HOST, () => {
+  console.log(`Bot Crossing → http://${HOST}:${PORT}`)
 })


### PR DESCRIPTION
Runs the colony on Linux, verified with a production build plus serve on a headless Linux box (Node v22).

- launcher: xdg-open on linux, null elsewhere (was hardcoded macOS open); a missing launcher fails silently with an error guard on the child
- install: linux added to the os field
- serve: BOT_CROSSING_HOST env (default still 127.0.0.1); the Host/Origin local check also accepts the machine's own LAN addresses, so a LAN-bound server answers its own page - rebinding/CSRF model unchanged
- lockfile: still named cosmo-builder pre-rename; synced, plus the os field

Verified: node --check clean, / and /api/threads and /api/harnesses 200 over loopback and LAN. No changes to scan.mjs, the API shape, or anything under src/.