### PR TITLE
Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ second process. For a built version, `npm start` (build + serve) or `npm run ser
 `dist/` already exists. Binds to `127.0.0.1`, and answers only its own page — see
 [Keeping it local](#keeping-it-local).
 
-**macOS only, for now.** Opening a thread, revealing a folder and starting a new session all
-go through `open(1)` and a `harness://` deep link. The scanning half is portable; nobody has
-done the Linux or Windows side of the opener yet.
+**macOS and Windows.** Opening a thread, revealing a folder and starting a new session all go
+through the OS opener — `open(1)` on macOS, ShellExecute on Windows — and a `harness://`
+deep link. The scanning half is portable. On Linux the opener is wired to `xdg-open`, but
+nobody has verified it, and there is no Claude desktop app there for the deep link to reach.
 
 ## Which harnesses work
 
@@ -177,7 +178,7 @@ into the same repo. Picking somebody is also picking the zone they are standing 
   `claude://code/new?folder=…` deep link Finder's "New Claude Code Session Here" quick
   action uses, so the desktop app opens an empty session with the repo as its workspace —
   nothing is resumed and nothing is written.
-- **Finder** opens the folder, **Copy path** copies it.
+- **Finder** (Explorer on Windows) opens the folder, **Copy path** copies it.
 - Underneath, everything running in that repo, whoever wants something first. Clicking one
   flies to its astronaut and selects it.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,17 @@
 {
-  "name": "cosmo-builder",
+  "name": "bot-crossing",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "cosmo-builder",
+      "name": "bot-crossing",
       "version": "1.0.0",
       "license": "MIT",
       "os": [
-        "darwin"
+        "darwin",
+        "win32",
+        "linux"
       ],
       "dependencies": {
         "@mdi/js": "^7.4.47",
@@ -1629,7 +1631,6 @@
       "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "node": ">=20"
   },
   "os": [
-    "darwin"
+    "darwin",
+    "win32",
+    "linux"
   ],
   "scripts": {
     "dev": "npm run assets --silent && vite",

--- a/server/api.mjs
+++ b/server/api.mjs
@@ -78,19 +78,40 @@ async function writeState(next) {
   return state
 }
 
-/** Hand a `harness://…` deep link to the OS. `open` gets an argument list, never a shell string. */
-function launch(url) {
-  const child = spawn('open', [url], { stdio: 'ignore', detached: true })
+/**
+ * Hand a `harness://…` deep link, or a folder, to whatever opens things on this OS. The
+ * opener gets an argument list, never a shell string.
+ *
+ * macOS's `open(1)` does both jobs. On Windows the equivalent is ShellExecute, reached
+ * through `rundll32 url.dll,FileProtocolHandler`: a registered protocol URL goes to its app
+ * and a folder opens in Explorer, with the argument passed through untouched. Two more
+ * obvious routes were tried and rejected — `explorer.exe <url>` silently drops any URL that
+ * carries a query string, so `code/new?folder=…` never arrived, and `cmd /c start` parses
+ * its own argument line, where the `%3A%5C` escapes in that same link are exactly what it
+ * expands. `xdg-open` is the Linux equivalent; nobody has verified it yet.
+ */
+const OPENERS = {
+  darwin: ['open'],
+  win32: ['rundll32', 'url.dll,FileProtocolHandler'],
+  linux: ['xdg-open'],
+}
+
+function launch(target) {
+  const opener = OPENERS[process.platform]
+  if (!opener) throw new Error(`No opener for ${process.platform}`)
+  const [cmd, ...args] = opener
+  const child = spawn(cmd, [...args, target], { stdio: 'ignore', detached: true })
   child.unref()
 }
 
 /**
  * A folder is openable only if it is still on this machine and still a directory. Paths
  * arrive from the page, which got them from a scan that may be minutes old — a repo that
- * has since been moved or deleted must fail here rather than hand `open` a dead path.
+ * has since been moved or deleted must fail here rather than hand the opener a dead path.
+ * Absolute is judged by `path.isAbsolute` rather than a leading `/`, which no Windows path has.
  */
 async function resolveFolder(folder) {
-  if (typeof folder !== 'string' || !folder.startsWith('/')) return null
+  if (typeof folder !== 'string' || !path.isAbsolute(folder)) return null
   const dir = path.resolve(folder)
   const stat = await fsp.stat(dir).catch(() => null)
   return stat && stat.isDirectory() ? dir : null

--- a/server/harnesses/README.md
+++ b/server/harnesses/README.md
@@ -133,8 +133,9 @@ Do not put a file handle, a class instance, or a secret in it.
 Verified on a real machine:
 
 - **Claude Code** — desktop records in
-  `~/Library/Application Support/Claude/claude-code-sessions/<account>/<org>/local_*.json`;
-  CLI transcripts in `~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl`; live processes in
+  `~/Library/Application Support/Claude/claude-code-sessions/<account>/<org>/local_*.json`
+  (`%APPDATA%\Claude\claude-code-sessions\…` on Windows); CLI transcripts in
+  `~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl`; live processes in
   `~/.claude/sessions/*.json`. Implemented in `claude-code.mjs`.
 - **Codex CLI** — transcripts in `~/.codex/sessions/YYYY/MM/DD/rollout-<iso>-<uuid>.jsonl`,
   with records shaped `{ timestamp, type, payload }`, and what looks like an index at

--- a/server/harnesses/claude-code.mjs
+++ b/server/harnesses/claude-code.mjs
@@ -20,8 +20,23 @@ import { exists, jsonLines, listDirs, listFiles, num, readHead } from '../lib/fs
 const execFileAsync = promisify(execFile)
 const HOME = os.homedir()
 
+/**
+ * Where the Claude desktop app keeps its data: Electron's `userData` for an app named
+ * "Claude", which lands somewhere different on each OS.
+ */
+function desktopDataDir() {
+  switch (process.platform) {
+    case 'win32':
+      return path.join(process.env.APPDATA || path.join(HOME, 'AppData', 'Roaming'), 'Claude')
+    case 'linux':
+      return path.join(process.env.XDG_CONFIG_HOME || path.join(HOME, '.config'), 'Claude')
+    default:
+      return path.join(HOME, 'Library', 'Application Support', 'Claude')
+  }
+}
+
 /** Where the Claude desktop app keeps one JSON record per thread. */
-const DESKTOP_SESSIONS = path.join(HOME, 'Library', 'Application Support', 'Claude', 'claude-code-sessions')
+const DESKTOP_SESSIONS = path.join(desktopDataDir(), 'claude-code-sessions')
 /** Where the CLI keeps the raw transcript: ~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl */
 const CLI_PROJECTS = path.join(HOME, '.claude', 'projects')
 /** One file per live CLI process: {pid, sessionId, cwd, ...}. Stale files outlive their pid. */
@@ -83,12 +98,15 @@ function readTranscriptMeta(records) {
   return meta
 }
 
-/** `/repo/.claude/worktrees/feature-abc` -> project `/repo`, worktree `feature-abc`. */
+/**
+ * `/repo/.claude/worktrees/feature-abc` -> project `/repo`, worktree `feature-abc`.
+ * Either separator: on Windows the same cwd arrives as `C:\repo\.claude\worktrees\…`.
+ */
+const WORKTREE = /[\\/]\.claude[\\/]worktrees[\\/]([^\\/]+)/
 function splitWorktree(cwd) {
-  const marker = '/.claude/worktrees/'
-  const i = cwd.indexOf(marker)
-  if (i === -1) return { root: cwd, worktree: '' }
-  return { root: cwd.slice(0, i), worktree: cwd.slice(i + marker.length).split('/')[0] }
+  const m = WORKTREE.exec(cwd)
+  if (!m) return { root: cwd, worktree: '' }
+  return { root: cwd.slice(0, m.index), worktree: m[1] }
 }
 
 function projectOf(cwd, originCwd) {
@@ -97,8 +115,13 @@ function projectOf(cwd, originCwd) {
   return { projectPath, project: path.basename(projectPath) || projectPath || 'unknown', worktree }
 }
 
-/** Best-effort reverse of the `-Users-you-Some-Dir` encoding used for project folder names. */
+/**
+ * Best-effort reverse of the encoding used for project folder names: `-Users-you-Some-Dir`
+ * on macOS, `C--Users-you-Some-Dir` on Windows, where the drive's colon became a dash too.
+ */
 function decodeProjectDir(name) {
+  const drive = /^([A-Za-z])--(.*)$/.exec(name)
+  if (drive) return `${drive[1]}:\\${drive[2].replace(/-/g, '\\')}`
   return name.startsWith('-') ? '/' + name.slice(1).replace(/-/g, '/') : name
 }
 
@@ -417,22 +440,57 @@ async function appStartedAt() {
 
   let started = 0
   try {
-    const { stdout } = await execFileAsync('ps', ['-axo', 'pid=,lstart=,command='], { maxBuffer: 8 * 1024 * 1024 })
-    for (const line of stdout.split('\n')) {
-      const m = line.match(/^\s*\d+\s+(\w{3} \w{3}\s+\d+ \d{2}:\d{2}:\d{2} \d{4})\s+(\/.*)$/)
-      if (!m) continue
-      const [, when, command] = m
-      // The main process only — helper processes carry a --type= flag.
-      if (!command.includes('/Claude.app/Contents/MacOS/Claude') || command.includes('--type=')) continue
-      const parsed = Date.parse(when)
-      if (!Number.isNaN(parsed)) started = parsed
-      break
-    }
+    started = process.platform === 'win32' ? await windowsAppStartedAt() : await darwinAppStartedAt()
   } catch {
-    /* ps unavailable — treat the app as never having restarted */
+    /* no process listing — treat the app as never having restarted */
   }
   appStartCache = { at: started, checkedAt: now }
   return started
+}
+
+async function darwinAppStartedAt() {
+  const { stdout } = await execFileAsync('ps', ['-axo', 'pid=,lstart=,command='], { maxBuffer: 8 * 1024 * 1024 })
+  for (const line of stdout.split('\n')) {
+    const m = line.match(/^\s*\d+\s+(\w{3} \w{3}\s+\d+ \d{2}:\d{2}:\d{2} \d{4})\s+(\/.*)$/)
+    if (!m) continue
+    const [, when, command] = m
+    // The main process only — helper processes carry a --type= flag.
+    if (!command.includes('/Claude.app/Contents/MacOS/Claude') || command.includes('--type=')) continue
+    const parsed = Date.parse(when)
+    return Number.isNaN(parsed) ? 0 : parsed
+  }
+  return 0
+}
+
+/**
+ * The same answer on Windows. There is no `ps`, and `tasklist` knows neither start times nor
+ * command lines, so this asks CIM, which knows both. The desktop app and the CLI are both
+ * `claude.exe` here, so the main process is picked out by shape rather than by path: the one
+ * with no `--type=` flag whose children (the helpers, which all carry one) point back at it.
+ * A PowerShell round trip is a few hundred milliseconds, which the 15s cache above absorbs.
+ */
+async function windowsAppStartedAt() {
+  const script = [
+    "Get-CimInstance Win32_Process -Filter \"Name='claude.exe'\" | ForEach-Object {",
+    "  if ($_.CreationDate) { '{0}|{1}|{2}|{3}' -f $_.ProcessId, $_.ParentProcessId,",
+    "    $_.CreationDate.ToUniversalTime().ToString('o'), $_.CommandLine } }",
+  ].join(' ')
+  const { stdout } = await execFileAsync('powershell', ['-NoProfile', '-NonInteractive', '-Command', script], {
+    maxBuffer: 8 * 1024 * 1024,
+  })
+  const rows = stdout
+    .split(/\r?\n/)
+    .map((line) => line.split('|'))
+    .filter((parts) => parts.length >= 4)
+    .map(([pid, ppid, when, ...command]) => ({
+      pid,
+      ppid,
+      when: Date.parse(when),
+      command: command.join('|'),
+    }))
+  const helperParents = new Set(rows.filter((r) => r.command.includes('--type=')).map((r) => r.ppid))
+  const main = rows.find((r) => helperParents.has(r.pid) && !r.command.includes('--type='))
+  return main && !Number.isNaN(main.when) ? main.when : 0
 }
 
 export default {

--- a/src/ui/hud.js
+++ b/src/ui/hud.js
@@ -16,6 +16,14 @@ import { FACE, FRAME_COLS, FRAME_ROWS } from '../agents/faces.js'
  * not in here.
  */
 
+/**
+ * The page only ever runs on the machine the server is on — it answers nothing else — so the
+ * browser's OS is the server's OS, and the name of the thing that shows a folder can be read
+ * here rather than asked for.
+ */
+const IS_MAC = /Mac/.test(navigator.platform)
+const FILE_MANAGER = IS_MAC ? 'Finder' : /Win/.test(navigator.platform) ? 'Explorer' : 'Files'
+
 const ICON = {
   settings: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.6a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>`,
   eye: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"><path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7z"/><circle cx="12" cy="12" r="3"/></svg>`,
@@ -833,7 +841,7 @@ const TEMPLATE = `
       <div class="project-actions">
         <button class="btn primary" id="btn-new-session" title="Start a new thread in this folder (C)">${ICON.plus} New conversation</button>
         <div class="pair">
-          <button class="btn" id="btn-reveal" title="Show this folder in Finder">${ICON.folder} Finder</button>
+          <button class="btn" id="btn-reveal" title="Show this folder in ${FILE_MANAGER}">${ICON.folder} ${FILE_MANAGER}</button>
           <button class="btn" id="btn-copy-path" title="Copy the folder path">${ICON.copy} Copy path</button>
         </div>
       </div>
@@ -890,7 +898,7 @@ const TEMPLATE = `
         <div class="k"><span>Zoom to cursor</span><kbd>scroll</kbd></div>
         <div class="k"><span>Move / zoom</span><kbd>arrows</kbd> <kbd>+ −</kbd></div>
         <div class="k"><span>Reset view</span><kbd>0</kbd></div>
-        <div class="k"><span>Hide all UI</span><kbd>H</kbd> <kbd>⌘\\</kbd></div>
+        <div class="k"><span>Hide all UI</span><kbd>H</kbd> <kbd>${IS_MAC ? '⌘' : 'Ctrl'}\\</kbd></div>
         <div class="k"><span>Settings</span><kbd>S</kbd></div>
         <div class="k"><span>Screenshot</span><kbd>P</kbd></div>
       </div>


### PR DESCRIPTION
## Windows support

The scanning half was already portable, as the README says; this is the opener and three path
assumptions that sat next to it. macOS is untouched: `open(1)` stays, behind a platform switch.

Rebased onto current `main` (through "Drop the pre-rename settings migration"); the one commit applies cleanly and the scan runs against this machine's data after the rebase.

### What changed

- **Opener** (`server/api.mjs`): Windows goes through ShellExecute via
  `rundll32 url.dll,FileProtocolHandler`, which hands the argument over untouched. Two obvious
  routes were tried and rejected, and the comment says why: `explorer.exe <url>` silently drops
  any URL carrying a query string, so `code/new?folder=…` never reached the app (the app's own
  log shows no activation), and `cmd /c start` expands the `%3A%5C` escapes in that same link.
  Linux is wired to `xdg-open` but nobody has verified it, and there is no Claude desktop app
  there for the deep link to reach.
- **`resolveFolder`** judges absolute paths with `path.isAbsolute` instead of a leading `/`.
- **Claude Code adapter** (`server/harnesses/claude-code.mjs`): the desktop app's data dir per
  OS (`%APPDATA%\Claude` on Windows, `~/.config/Claude` on Linux); a worktree marker that accepts
  either separator; the `C--Users-…` form of the encoded project dir; and `appStartedAt` through
  CIM, since there is no `ps` and `tasklist` knows neither start times nor command lines. The
  desktop app and the CLI are both `claude.exe` on Windows, so the main process is picked by
  shape: the one without `--type=` whose helpers point back at it. The existing `ps` path moved
  into `darwinAppStartedAt()` unchanged.
- **UI** (`src/ui/hud.js`): the folder button reads Finder / Explorer / Files from
  `navigator.platform`, which is sound because the page only ever runs on the machine the server
  is on. The help sheet shows Ctrl instead of ⌘ off a Mac. I know the harness README says
  nothing under `src/` should change for a harness; this is not a harness, and a Windows user
  reading "Finder" seemed worse than a two-line label.
- `package.json` allows `win32` and `linux`; `npm install` also rewrote the lockfile's stale
  package name (`cosmo-builder` → `bot-crossing`).

### What I verified, and how

Windows 11, Node 23, Claude desktop 1.44121 (MSIX) plus the CLI, against this machine's real
data: **1,662 threads across 152 repos, scanned in about 3 s**, no `undefined` fields.
`GET /api/harnesses` detects Claude Code. `appStartedAt()` returns the desktop app's launch time
to the second (checked against `Get-CimInstance`).

Each opener path through the running server, with `Origin` set:

- `POST /api/open` → the desktop app navigated to that thread; its session record's
  `lastFocusedAt` went from unset to the moment of the call.
- `POST /api/new-session` → the desktop app opened a new session and raised its
  "Trust this workspace?" prompt for exactly the folder in the link.
- `POST /api/reveal` → an Explorer window opened at the folder (checked through
  `Shell.Application.Windows()`), for both `C:\…` and `C:/…` spellings. A relative path,
  a missing folder, and a request without `Origin` are all still refused.

The page renders; the only console output is three Direct3D shader-compile
warnings from three.js, no errors.

**Not verified:** macOS (no Mac here; the darwin code paths are the original lines behind a
platform check) and Linux.

### One thing I noticed but left alone

On this machine Claude Code puts worktrees under `~/.claude-worktrees/<repo>/<name>` with the
repo in the record's `originCwd`, not under `<repo>/.claude/worktrees/`. The adapter already
falls back to `originCwd` so the project is right, but `worktree` comes out empty for those.
That is a Claude Code layout change rather than a Windows thing, so it is not in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XoWzeoyVz2maLm2963eGMP
