### PR TITLE
Add Codex harness support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ somebody writing that adapter.
 | Harness | Status |
 | --- | --- |
 | **[Claude Code](https://claude.com/claude-code)** (Anthropic) | ✅ **Supported** — desktop app and CLI, including worktrees, live-process detection and archiving |
-| [Codex CLI](https://developers.openai.com/codex/cli) (OpenAI) | ⬜ Not yet — transcripts found at `~/.codex/sessions/`, [notes here](server/harnesses/README.md#starting-points) |
+| **[Codex](https://developers.openai.com/codex) (OpenAI)** | ✅ **Supported** — desktop app and CLI, including worktrees, live-turn detection and archiving |
 | [OpenCode](https://opencode.ai) | ⬜ Not yet |
 | [Antigravity CLI](https://antigravity.google) (Google) | ⬜ Not yet — the successor to Gemini CLI, which Google stopped serving individual accounts on 18 June 2026 |
 | [Cursor](https://cursor.com) (`cursor-agent`) | ⬜ Not yet |

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ somebody writing that adapter.
 | Harness | Status |
 | --- | --- |
 | **[Claude Code](https://claude.com/claude-code)** (Anthropic) | ✅ **Supported** — desktop app and CLI, including worktrees, live-process detection and archiving |
-| **[Codex](https://developers.openai.com/codex) (OpenAI)** | ✅ **Supported** — desktop app and CLI, including worktrees, live-turn detection and archiving |
+| **[Codex](https://developers.openai.com/codex) (OpenAI)** | ✅ **Supported** — desktop app and CLI, including live-turn detection and archiving (Node 22.13+) |
 | [OpenCode](https://opencode.ai) | ⬜ Not yet |
 | [Antigravity CLI](https://antigravity.google) (Google) | ⬜ Not yet — the successor to Gemini CLI, which Google stopped serving individual accounts on 18 June 2026 |
 | [Cursor](https://cursor.com) (`cursor-agent`) | ⬜ Not yet |

--- a/server/harnesses/README.md
+++ b/server/harnesses/README.md
@@ -136,9 +136,9 @@ Verified on a real machine:
   `~/Library/Application Support/Claude/claude-code-sessions/<account>/<org>/local_*.json`;
   CLI transcripts in `~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl`; live processes in
   `~/.claude/sessions/*.json`. Implemented in `claude-code.mjs`.
-- **Codex CLI** — transcripts in `~/.codex/sessions/YYYY/MM/DD/rollout-<iso>-<uuid>.jsonl`,
-  with records shaped `{ timestamp, type, payload }`, and what looks like an index at
-  `~/.codex/session_index.jsonl`. Not implemented yet.
+- **Codex** — transcripts in `~/.codex/sessions/YYYY/MM/DD/rollout-<iso>-<uuid>.jsonl`,
+  with records shaped `{ timestamp, type, payload }`; titles in `~/.codex/session_index.jsonl`;
+  desktop unread state in `~/.codex/.codex-global-state.json`. Implemented in `codex.mjs`.
 
 For anything else, the fastest way in is usually to start a throwaway session in that harness
 and watch which files change:

--- a/server/harnesses/README.md
+++ b/server/harnesses/README.md
@@ -136,9 +136,12 @@ Verified on a real machine:
   `~/Library/Application Support/Claude/claude-code-sessions/<account>/<org>/local_*.json`;
   CLI transcripts in `~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl`; live processes in
   `~/.claude/sessions/*.json`. Implemented in `claude-code.mjs`.
-- **Codex** — transcripts in `~/.codex/sessions/YYYY/MM/DD/rollout-<iso>-<uuid>.jsonl`,
-  with records shaped `{ timestamp, type, payload }`; titles in `~/.codex/session_index.jsonl`;
-  desktop unread state in `~/.codex/.codex-global-state.json`. Implemented in `codex.mjs`.
+- **Codex** — canonical thread metadata in the newest `~/.codex/state_*.sqlite`; live/error
+  lifecycle events in the tail of the database's `rollout_path`; desktop unread state in
+  `~/.codex/.codex-global-state.json`. The database is opened read-only, scans never launch a
+  process, and archive actions resolve a standalone `codex` only from `PATH` or
+  `BOT_CROSSING_CODEX_BIN`; executables inside app bundles are always rejected. Implemented in
+  `codex.mjs`; requires Node 22.13+ for the unflagged built-in SQLite module.
 
 For anything else, the fastest way in is usually to start a throwaway session in that harness
 and watch which files change:

--- a/server/harnesses/codex.mjs
+++ b/server/harnesses/codex.mjs
@@ -1,53 +1,176 @@
 /**
- * Harness adapter: Codex (OpenAI) — the desktop app and CLI share one local session store.
+ * Harness adapter: Codex (OpenAI) — the desktop app and CLI share one local state database.
  *
- * Codex writes append-only JSONL transcripts under ~/.codex/sessions. The first records hold
- * stable session metadata and the tail holds the current turn state, so neither side requires
- * reading a whole transcript on every poll. User-facing names and unread state are best-effort
- * additions from the two small files the desktop app maintains alongside those transcripts.
+ * Codex publishes its thread index in the newest ~/.codex/state_*.sqlite database. Metadata
+ * comes from that database through Node's read-only SQLite mode; only the tail of a rollout is
+ * read for live/error state, which the index does not currently expose. No scan runs a process
+ * or reaches into an application bundle.
  */
 import fsp from 'node:fs/promises'
-import { existsSync } from 'node:fs'
+import { constants as fsConstants } from 'node:fs'
 import path from 'node:path'
 import os from 'node:os'
 import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
-import { exists, jsonLines, readHead } from '../lib/fsutil.mjs'
+import { jsonLines, num } from '../lib/fsutil.mjs'
 
 const execFileAsync = promisify(execFile)
 const HOME = os.homedir()
 const CODEX_HOME = process.env.CODEX_HOME || path.join(HOME, '.codex')
-const SESSIONS = path.join(CODEX_HOME, 'sessions')
-const SESSION_INDEX = path.join(CODEX_HOME, 'session_index.jsonl')
 const APP_STATE = path.join(CODEX_HOME, '.codex-global-state.json')
-const DESKTOP_APPS = [
-  '/Applications/ChatGPT.app',
-  '/Applications/Codex.app',
-  path.join(HOME, 'Applications', 'ChatGPT.app'),
-  path.join(HOME, 'Applications', 'Codex.app'),
-]
+const CODEX_BINARY_ENV = 'BOT_CROSSING_CODEX_BIN'
 
-const HEAD_BYTES = 192 * 1024
 const TAIL_BYTES = 512 * 1024
 const MAX_ACTIVE_TAIL_BYTES = 2 * 1024 * 1024
 const ACTIVE_WINDOW_MS = 30 * 60 * 1000
-
+const STATE_DATABASE = /^state_(\d+)\.sqlite$/
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+const APP_BUNDLE_EXECUTABLE = /\.app[/\\]Contents[/\\]/i
 
-function firstText(content) {
-  if (typeof content === 'string') return content
-  if (Array.isArray(content)) {
-    for (const part of content) {
-      if (typeof part === 'string') return part
-      if (part && typeof part.text === 'string' && ['text', 'input_text'].includes(part.type)) {
-        return part.text
-      }
-    }
-  }
-  return ''
+let sqlitePromise
+async function sqliteApi() {
+  if (!sqlitePromise) sqlitePromise = import('node:sqlite').catch(() => null)
+  return sqlitePromise
 }
 
-/** Drop UI context injected ahead of the prompt; it is not the title a person gave the task. */
+let codexHomeRealPromise
+async function safeCodexFile(file) {
+  if (typeof file !== 'string' || !file) return ''
+  if (!codexHomeRealPromise) {
+    codexHomeRealPromise = fsp.realpath(CODEX_HOME).catch(() => path.resolve(CODEX_HOME))
+  }
+  try {
+    const [home, real] = await Promise.all([codexHomeRealPromise, fsp.realpath(file)])
+    const relative = path.relative(home, real)
+    if (relative === '..' || relative.startsWith('..' + path.sep) || path.isAbsolute(relative)) {
+      return ''
+    }
+    return real
+  } catch {
+    return ''
+  }
+}
+
+/** Pick the highest schema version, not the most recently touched WAL sibling. */
+async function latestStateDatabase() {
+  let entries
+  try {
+    entries = await fsp.readdir(CODEX_HOME, { withFileTypes: true })
+  } catch {
+    return ''
+  }
+  return entries
+    .filter((entry) => entry.isFile() && STATE_DATABASE.test(entry.name))
+    .map((entry) => ({
+      file: path.join(CODEX_HOME, entry.name),
+      version: Number(entry.name.match(STATE_DATABASE)[1]),
+    }))
+    .sort((a, b) => b.version - a.version)[0]?.file || ''
+}
+
+const column = (columns, name, fallback = "''") =>
+  columns.has(name) ? `t.${name}` : fallback
+
+function timestampExpression(columns, milliseconds, seconds) {
+  if (columns.has(milliseconds) && columns.has(seconds)) {
+    return `COALESCE(t.${milliseconds}, t.${seconds} * 1000)`
+  }
+  if (columns.has(milliseconds)) return `t.${milliseconds}`
+  if (columns.has(seconds)) return `t.${seconds} * 1000`
+  return '0'
+}
+
+/** Read the canonical thread index. The connection itself refuses writes. */
+async function databaseThreads() {
+  const [databaseFile, sqlite] = await Promise.all([latestStateDatabase(), sqliteApi()])
+  if (!databaseFile || !sqlite?.DatabaseSync) return { rows: [], projectRoots: new Map() }
+
+  const database = new sqlite.DatabaseSync(databaseFile, { readOnly: true })
+  try {
+    const tables = new Set(
+      database
+        .prepare("SELECT name FROM sqlite_master WHERE type = 'table'")
+        .all()
+        .map((row) => row.name)
+    )
+    if (!tables.has('threads')) return { rows: [], projectRoots: new Map() }
+
+    const columns = new Set(database.prepare('PRAGMA table_info(threads)').all().map((row) => row.name))
+    if (!['id', 'cwd', 'source'].every((name) => columns.has(name))) {
+      throw new Error('Codex state database is missing required thread columns')
+    }
+
+    const children = new Set()
+    if (tables.has('thread_spawn_edges')) {
+      const edgeColumns = new Set(
+        database.prepare('PRAGMA table_info(thread_spawn_edges)').all().map((row) => row.name)
+      )
+      if (edgeColumns.has('child_thread_id')) {
+        for (const row of database.prepare('SELECT child_thread_id FROM thread_spawn_edges').all()) {
+          if (typeof row.child_thread_id === 'string') children.add(row.child_thread_id)
+        }
+      }
+    }
+
+    const projectRoots = new Map()
+    if (columns.has('project_id') && tables.has('project_roots')) {
+      const rootColumns = new Set(
+        database.prepare('PRAGMA table_info(project_roots)').all().map((row) => row.name)
+      )
+      if (['project_id', 'path', 'position'].every((name) => rootColumns.has(name))) {
+        const roots = database
+          .prepare('SELECT project_id, path FROM project_roots ORDER BY project_id, position')
+          .all()
+        for (const root of roots) {
+          if (!projectRoots.has(root.project_id) && typeof root.path === 'string') {
+            projectRoots.set(root.project_id, root.path)
+          }
+        }
+      }
+    }
+
+    const createdAt = timestampExpression(columns, 'created_at_ms', 'created_at')
+    const updatedAt = timestampExpression(columns, 'updated_at_ms', 'updated_at')
+    const rows = database
+      .prepare(`
+        SELECT
+          t.id,
+          ${column(columns, 'name')} AS name,
+          ${column(columns, 'title')} AS title,
+          ${column(columns, 'preview')} AS preview,
+          ${column(columns, 'first_user_message')} AS first_user_message,
+          t.cwd,
+          t.source,
+          ${column(columns, 'thread_source')} AS thread_source,
+          ${column(columns, 'git_branch')} AS git_branch,
+          ${column(columns, 'git_origin_url')} AS git_origin_url,
+          ${column(columns, 'model')} AS model,
+          ${column(columns, 'reasoning_effort')} AS reasoning_effort,
+          ${column(columns, 'rollout_path')} AS rollout_path,
+          ${column(columns, 'project_id')} AS project_id,
+          ${column(columns, 'tokens_used', '0')} AS tokens_used,
+          ${column(columns, 'archived', '0')} AS archived,
+          ${column(columns, 'is_pinned', '0')} AS is_pinned,
+          ${createdAt} AS created_at_ms,
+          ${updatedAt} AS updated_at_ms
+        FROM threads t
+        WHERE t.source IN ('cli', 'vscode')
+      `)
+      .all()
+      .filter(
+        (row) =>
+          UUID.test(row.id || '') &&
+          !children.has(row.id) &&
+          !['subagent', 'guardian_review'].includes(row.thread_source)
+      )
+
+    return { rows, projectRoots }
+  } finally {
+    database.close()
+  }
+}
+
+/** Drop UI context injected ahead of the prompt; it is not card copy a person authored. */
 function cleanPrompt(value) {
   const text = String(value || '')
     .replace(/<(in-app-browser-context|environment_context)\b[^>]*>[\s\S]*?<\/\1>/gi, ' ')
@@ -57,156 +180,12 @@ function cleanPrompt(value) {
     .trim()
 }
 
-function shortTitle(prompt) {
-  if (prompt.length <= 120) return prompt
-  const cut = prompt.slice(0, 117)
+function shortTitle(value) {
+  const title = cleanPrompt(value)
+  if (title.length <= 120) return title
+  const cut = title.slice(0, 117)
   const boundary = cut.lastIndexOf(' ')
   return (boundary > 72 ? cut.slice(0, boundary) : cut).trimEnd() + '…'
-}
-
-function readTranscriptMeta(records) {
-  const out = { id: '', cwd: '', source: '', startedAt: 0, firstPrompt: '', gitBranch: '' }
-  for (const record of records) {
-    const payload = record?.payload || {}
-    if (record.type === 'session_meta' && !out.id) {
-      out.id = typeof payload.id === 'string' ? payload.id : ''
-      out.cwd = typeof payload.cwd === 'string' ? payload.cwd : ''
-      out.source = typeof payload.source === 'string' ? payload.source : ''
-      out.startedAt = Date.parse(payload.timestamp || record.timestamp || '') || 0
-      out.gitBranch = typeof payload.git?.branch === 'string' ? payload.git.branch : ''
-    }
-    if (out.firstPrompt) continue
-    if (record.type === 'event_msg' && payload.type === 'user_message') {
-      out.firstPrompt = cleanPrompt(payload.message)
-    } else if (record.type === 'response_item' && payload.type === 'message' && payload.role === 'user') {
-      out.firstPrompt = cleanPrompt(firstText(payload.content))
-    }
-  }
-  return out
-}
-
-function readTailMeta(records) {
-  const out = { model: '', effort: '', lifecycle: null }
-  for (const record of records) {
-    const payload = record?.payload || {}
-    if (record.type === 'turn_context') {
-      if (typeof payload.model === 'string') out.model = payload.model
-      if (typeof payload.effort === 'string') out.effort = payload.effort
-    }
-    if (
-      record.type === 'event_msg' &&
-      ['task_started', 'task_complete', 'turn_aborted'].includes(payload.type)
-    ) {
-      out.lifecycle = { type: payload.type, error: Boolean(payload.error) }
-    }
-  }
-  return out
-}
-
-async function listTranscripts(root) {
-  const files = []
-  const pending = [root]
-  while (pending.length) {
-    const dir = pending.pop()
-    let entries
-    try {
-      entries = await fsp.readdir(dir, { withFileTypes: true })
-    } catch {
-      continue
-    }
-    for (const entry of entries) {
-      const file = path.join(dir, entry.name)
-      if (entry.isDirectory()) pending.push(file)
-      // session-map tools can project another machine's transcript into this picker. Those
-      // imported-*.jsonl files duplicate the real session and must not become two astronauts.
-      else if (entry.isFile() && entry.name.endsWith('.jsonl') && !entry.name.startsWith('imported-')) {
-        files.push(file)
-      }
-    }
-  }
-  return files
-}
-
-async function transcriptEntries() {
-  const entries = []
-  for (const file of await listTranscripts(SESSIONS)) {
-    try {
-      const stat = await fsp.stat(file)
-      entries.push({ file, size: stat.size, mtime: stat.mtimeMs })
-    } catch {
-      /* archived between readdir and stat — it will be gone on the next pass */
-    }
-  }
-  return entries
-}
-
-async function readTail(file, size, bytes) {
-  const length = Math.min(size, bytes)
-  const start = Math.max(0, size - length)
-  const handle = await fsp.open(file, 'r')
-  try {
-    const buffer = Buffer.allocUnsafe(length)
-    const { bytesRead } = await handle.read(buffer, 0, length, start)
-    let text = buffer.subarray(0, bytesRead).toString('utf8')
-    if (start) text = text.slice(text.indexOf('\n') + 1)
-    // A live task may be halfway through its final JSON record.
-    if (!text.endsWith('\n')) text = text.slice(0, text.lastIndexOf('\n') + 1)
-    return text
-  } finally {
-    await handle.close()
-  }
-}
-
-/** The immutable head is cached forever; Codex only appends to a rollout while it is active. */
-const headCache = new Map()
-async function transcriptMeta(entry) {
-  const cached = headCache.get(entry.file)
-  if (cached) return cached
-  let meta
-  try {
-    meta = readTranscriptMeta(jsonLines(await readHead(entry.file, HEAD_BYTES)))
-  } catch {
-    meta = readTranscriptMeta([])
-  }
-  // A brand-new rollout can be observed before its first record is complete. Do not make that
-  // empty read permanent; the next poll should get another chance.
-  if (meta.id) headCache.set(entry.file, meta)
-  return meta
-}
-
-/** The tail changes during a turn, so cache it only until the file mtime or size moves. */
-const tailCache = new Map()
-async function transcriptTail(entry) {
-  const cached = tailCache.get(entry.file)
-  if (cached && cached.mtime === entry.mtime && cached.size === entry.size) return cached.meta
-
-  let meta = readTailMeta(jsonLines(await readTail(entry.file, entry.size, TAIL_BYTES)))
-  // A very chatty active turn can push task_started out of the first tail window. Widen only
-  // for a recently changing file, and only when an earlier pass cannot supply the lifecycle.
-  if (!meta.lifecycle && !cached?.meta.lifecycle && Date.now() - entry.mtime < ACTIVE_WINDOW_MS) {
-    meta = readTailMeta(jsonLines(await readTail(entry.file, entry.size, MAX_ACTIVE_TAIL_BYTES)))
-  }
-  if (!meta.model && cached?.meta.model) meta.model = cached.meta.model
-  if (!meta.effort && cached?.meta.effort) meta.effort = cached.meta.effort
-  if (!meta.lifecycle && cached?.meta.lifecycle) meta.lifecycle = cached.meta.lifecycle
-  tailCache.set(entry.file, { mtime: entry.mtime, size: entry.size, meta })
-  return meta
-}
-
-async function threadNames() {
-  const names = new Map()
-  let records
-  try {
-    records = jsonLines(await fsp.readFile(SESSION_INDEX, 'utf8'))
-  } catch {
-    return names
-  }
-  for (const record of records) {
-    if (UUID.test(record.id || '') && typeof record.thread_name === 'string' && record.thread_name.trim()) {
-      names.set(record.id, record.thread_name.trim())
-    }
-  }
-  return names
 }
 
 /** The desktop app owns unread state. CLI-only installs simply report no unread sessions. */
@@ -220,105 +199,106 @@ async function unreadThreadIds() {
   }
 }
 
-/** Map a Git worktree back to the repo whose zone it belongs on, without spawning git per task. */
-async function projectOf(cwd) {
-  let projectPath = cwd || ''
-  let worktree = ''
-  if (cwd) {
-    try {
-      const dotGit = path.join(cwd, '.git')
-      if ((await fsp.stat(dotGit)).isFile()) {
-        const match = (await fsp.readFile(dotGit, 'utf8')).match(/^gitdir:\s*(.+)$/m)
-        if (match) {
-          const gitDir = path.resolve(cwd, match[1])
-          const marker = path.sep + '.git' + path.sep + 'worktrees' + path.sep
-          const index = gitDir.indexOf(marker)
-          if (index !== -1) {
-            projectPath = gitDir.slice(0, index)
-            worktree = path.basename(cwd)
-          }
-        }
-      }
-    } catch {
-      /* not a Git worktree, or the folder has since moved */
+async function readTail(file, size, bytes) {
+  const length = Math.min(size, bytes)
+  const start = Math.max(0, size - length)
+  const handle = await fsp.open(file, 'r')
+  try {
+    const buffer = Buffer.allocUnsafe(length)
+    const { bytesRead } = await handle.read(buffer, 0, length, start)
+    let text = buffer.subarray(0, bytesRead).toString('utf8')
+    if (start) text = text.slice(text.indexOf('\n') + 1)
+    if (!text.endsWith('\n')) text = text.slice(0, text.lastIndexOf('\n') + 1)
+    return text
+  } finally {
+    await handle.close()
+  }
+}
+
+function readLifecycle(records) {
+  let lifecycle = null
+  for (const record of records) {
+    const payload = record?.payload || {}
+    if (
+      record.type === 'event_msg' &&
+      ['task_started', 'task_complete', 'turn_aborted'].includes(payload.type)
+    ) {
+      lifecycle = { type: payload.type, error: Boolean(payload.error) }
     }
   }
+  return lifecycle
+}
+
+/** Rollout tails supply only ephemeral state not represented in the SQLite index. */
+const lifecycleCache = new Map()
+async function rolloutLifecycle(file) {
+  const safeFile = await safeCodexFile(file)
+  if (!safeFile) return null
+  let stat
+  try {
+    stat = await fsp.stat(safeFile)
+  } catch {
+    return null
+  }
+  const cached = lifecycleCache.get(safeFile)
+  if (cached && cached.mtime === stat.mtimeMs && cached.size === stat.size) return cached.lifecycle
+
+  let lifecycle = readLifecycle(jsonLines(await readTail(safeFile, stat.size, TAIL_BYTES)))
+  if (!lifecycle && !cached?.lifecycle && Date.now() - stat.mtimeMs < ACTIVE_WINDOW_MS) {
+    lifecycle = readLifecycle(jsonLines(await readTail(safeFile, stat.size, MAX_ACTIVE_TAIL_BYTES)))
+  }
+  if (!lifecycle && cached?.lifecycle) lifecycle = cached.lifecycle
+  lifecycleCache.set(safeFile, { mtime: stat.mtimeMs, size: stat.size, lifecycle })
+  return lifecycle
+}
+
+/** Use Codex's project index when available. Older rows safely fall back to their cwd. */
+function projectOf(row, projectRoots) {
+  const indexedRoot = projectRoots.get(row.project_id) || ''
+  const projectPath = indexedRoot || row.cwd || ''
+  const worktree = indexedRoot && indexedRoot !== row.cwd ? path.basename(row.cwd) : ''
   return { projectPath, project: path.basename(projectPath) || projectPath || 'unknown', worktree }
 }
 
-let codexBinaryPromise
-async function codexBinary() {
-  if (codexBinaryPromise) return codexBinaryPromise
-  codexBinaryPromise = (async () => {
-    const candidates = [
-      'codex',
-      '/Applications/ChatGPT.app/Contents/Resources/codex',
-      '/Applications/Codex.app/Contents/Resources/codex',
-    ]
-    for (const candidate of candidates) {
-      try {
-        await execFileAsync(candidate, ['--version'], { timeout: 5000 })
-        return candidate
-      } catch {
-        /* try the next documented or bundled location */
-      }
-    }
-    return ''
-  })()
-  return codexBinaryPromise
-}
-
 async function scanThreads() {
-  const [entries, names, unread, binary] = await Promise.all([
-    transcriptEntries(),
-    threadNames(),
-    unreadThreadIds(),
-    codexBinary(),
-  ])
-  const byId = new Map()
-  const canOpen = DESKTOP_APPS.some((app) => existsSync(app))
-  for (const entry of entries) {
-    const meta = await transcriptMeta(entry)
-    // Codex stores spawned subagents beside user-facing tasks. Its own thread/list defaults to
-    // these two interactive sources, and the colony should make the same distinction.
-    if (!UUID.test(meta.id) || !['cli', 'vscode'].includes(meta.source)) continue
-
-    const tail = await transcriptTail(entry)
-    const lifecycle = tail.lifecycle
-    const { projectPath, project, worktree } = await projectOf(meta.cwd)
-    const firstPrompt = meta.firstPrompt || ''
-    const thread = {
-      id: meta.id,
-      title: names.get(meta.id) || shortTitle(firstPrompt) || 'Untitled thread',
-      preview: firstPrompt.slice(0, 240),
-      project,
-      projectPath,
-      worktree,
-      cwd: meta.cwd,
-      gitBranch: meta.gitBranch,
-      model: tail.model,
-      effort: tail.effort,
-      createdAt: meta.startedAt || entry.mtime,
-      lastActivityAt: entry.mtime,
-      lastFocusedAt: 0,
-      running:
-        lifecycle?.type === 'task_started' && Date.now() - entry.mtime < ACTIVE_WINDOW_MS,
-      unread: unread.has(meta.id),
-      hasError: lifecycle?.type === 'task_complete' && lifecycle.error,
-      starred: false,
-      routine: '',
-      prState: '',
-      archived: false,
-      sizeBytes: entry.size,
-      source: meta.source === 'vscode' ? 'desktop' : 'cli',
-      canOpen,
-      canArchive: Boolean(binary),
-      ref: { sessionId: meta.id },
-    }
-    const existing = byId.get(thread.id)
-    if (!existing || thread.lastActivityAt > existing.lastActivityAt) byId.set(thread.id, thread)
-  }
-  return [...byId.values()]
+  const [{ rows, projectRoots }, unread] = await Promise.all([databaseThreads(), unreadThreadIds()])
+  return await Promise.all(
+    rows.map(async (row) => {
+      const lifecycle = await rolloutLifecycle(row.rollout_path)
+      const firstPrompt = cleanPrompt(row.preview || row.first_user_message)
+      const title = shortTitle(row.name || row.title || firstPrompt) || 'Untitled thread'
+      const { projectPath, project, worktree } = projectOf(row, projectRoots)
+      const lastActivityAt = num(row.updated_at_ms)
+      return {
+        id: row.id,
+        title,
+        preview: firstPrompt.slice(0, 240),
+        project,
+        projectPath,
+        worktree,
+        cwd: row.cwd || '',
+        gitBranch: row.git_branch || '',
+        model: row.model || '',
+        effort: row.reasoning_effort || '',
+        createdAt: num(row.created_at_ms) || lastActivityAt,
+        lastActivityAt,
+        lastFocusedAt: 0,
+        running:
+          lifecycle?.type === 'task_started' && Date.now() - lastActivityAt < ACTIVE_WINDOW_MS,
+        unread: unread.has(row.id),
+        hasError: lifecycle?.type === 'task_complete' && lifecycle.error,
+        starred: Boolean(row.is_pinned),
+        routine: '',
+        prState: '',
+        archived: Boolean(row.archived),
+        sizeBytes: num(row.tokens_used),
+        source: row.source === 'vscode' ? 'desktop' : 'cli',
+        canOpen: true,
+        canArchive: true,
+        ref: { sessionId: row.id },
+      }
+    })
+  )
 }
 
 function openThread(ref) {
@@ -331,11 +311,39 @@ function newSession(dir) {
   return { ok: true, url: 'codex://threads/new?' + new URLSearchParams({ path: dir }) }
 }
 
+/** Resolve only an explicit override or PATH entry, and only after Archive is clicked. */
+async function codexBinary() {
+  const override = process.env[CODEX_BINARY_ENV]
+  const candidates = []
+  if (override) candidates.push(path.isAbsolute(override) ? override : path.resolve(override))
+  for (const dir of (process.env.PATH || '').split(path.delimiter).filter(Boolean)) {
+    candidates.push(path.join(dir, 'codex'))
+  }
+  for (const candidate of candidates) {
+    try {
+      await fsp.access(candidate, fsConstants.X_OK)
+      const real = await fsp.realpath(candidate)
+      // PATH can itself contain an app's Resources directory, and a harmless-looking symlink
+      // can resolve back into one. Never execute either form from another app's bundle.
+      if (APP_BUNDLE_EXECUTABLE.test(real)) continue
+      return real
+    } catch {
+      /* try the next PATH entry */
+    }
+  }
+  return ''
+}
+
 async function setArchived(ref, archived) {
   const id = ref?.sessionId || ''
   if (!UUID.test(id)) return { ok: false, error: 'No archivable Codex session id on that thread' }
   const binary = await codexBinary()
-  if (!binary) return { ok: false, error: 'The Codex CLI is not available on this machine' }
+  if (!binary) {
+    return {
+      ok: false,
+      error: `No standalone Codex CLI found; install it or set ${CODEX_BINARY_ENV}`,
+    }
+  }
   try {
     await execFileAsync(binary, [archived ? 'archive' : 'unarchive', id], {
       timeout: 15000,
@@ -348,13 +356,18 @@ async function setArchived(ref, archived) {
   }
 }
 
+async function detect() {
+  const [databaseFile, sqlite] = await Promise.all([latestStateDatabase(), sqliteApi()])
+  return Boolean(databaseFile && sqlite?.DatabaseSync)
+}
+
 export default {
   id: 'codex',
   name: 'Codex',
-  detect: async () => await exists(SESSIONS),
+  detect,
   scanThreads,
   openThread,
   newSession,
   setArchived,
-  paths: { SESSIONS, SESSION_INDEX, APP_STATE },
+  paths: { CODEX_HOME, APP_STATE },
 }

--- a/server/harnesses/codex.mjs
+++ b/server/harnesses/codex.mjs
@@ -1,0 +1,360 @@
+/**
+ * Harness adapter: Codex (OpenAI) — the desktop app and CLI share one local session store.
+ *
+ * Codex writes append-only JSONL transcripts under ~/.codex/sessions. The first records hold
+ * stable session metadata and the tail holds the current turn state, so neither side requires
+ * reading a whole transcript on every poll. User-facing names and unread state are best-effort
+ * additions from the two small files the desktop app maintains alongside those transcripts.
+ */
+import fsp from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { exists, jsonLines, readHead } from '../lib/fsutil.mjs'
+
+const execFileAsync = promisify(execFile)
+const HOME = os.homedir()
+const CODEX_HOME = process.env.CODEX_HOME || path.join(HOME, '.codex')
+const SESSIONS = path.join(CODEX_HOME, 'sessions')
+const SESSION_INDEX = path.join(CODEX_HOME, 'session_index.jsonl')
+const APP_STATE = path.join(CODEX_HOME, '.codex-global-state.json')
+const DESKTOP_APPS = [
+  '/Applications/ChatGPT.app',
+  '/Applications/Codex.app',
+  path.join(HOME, 'Applications', 'ChatGPT.app'),
+  path.join(HOME, 'Applications', 'Codex.app'),
+]
+
+const HEAD_BYTES = 192 * 1024
+const TAIL_BYTES = 512 * 1024
+const MAX_ACTIVE_TAIL_BYTES = 2 * 1024 * 1024
+const ACTIVE_WINDOW_MS = 30 * 60 * 1000
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+function firstText(content) {
+  if (typeof content === 'string') return content
+  if (Array.isArray(content)) {
+    for (const part of content) {
+      if (typeof part === 'string') return part
+      if (part && typeof part.text === 'string' && ['text', 'input_text'].includes(part.type)) {
+        return part.text
+      }
+    }
+  }
+  return ''
+}
+
+/** Drop UI context injected ahead of the prompt; it is not the title a person gave the task. */
+function cleanPrompt(value) {
+  const text = String(value || '')
+    .replace(/<(in-app-browser-context|environment_context)\b[^>]*>[\s\S]*?<\/\1>/gi, ' ')
+  const request = text.lastIndexOf('## My request:')
+  return (request === -1 ? text : text.slice(request + '## My request:'.length))
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function shortTitle(prompt) {
+  if (prompt.length <= 120) return prompt
+  const cut = prompt.slice(0, 117)
+  const boundary = cut.lastIndexOf(' ')
+  return (boundary > 72 ? cut.slice(0, boundary) : cut).trimEnd() + '…'
+}
+
+function readTranscriptMeta(records) {
+  const out = { id: '', cwd: '', source: '', startedAt: 0, firstPrompt: '', gitBranch: '' }
+  for (const record of records) {
+    const payload = record?.payload || {}
+    if (record.type === 'session_meta' && !out.id) {
+      out.id = typeof payload.id === 'string' ? payload.id : ''
+      out.cwd = typeof payload.cwd === 'string' ? payload.cwd : ''
+      out.source = typeof payload.source === 'string' ? payload.source : ''
+      out.startedAt = Date.parse(payload.timestamp || record.timestamp || '') || 0
+      out.gitBranch = typeof payload.git?.branch === 'string' ? payload.git.branch : ''
+    }
+    if (out.firstPrompt) continue
+    if (record.type === 'event_msg' && payload.type === 'user_message') {
+      out.firstPrompt = cleanPrompt(payload.message)
+    } else if (record.type === 'response_item' && payload.type === 'message' && payload.role === 'user') {
+      out.firstPrompt = cleanPrompt(firstText(payload.content))
+    }
+  }
+  return out
+}
+
+function readTailMeta(records) {
+  const out = { model: '', effort: '', lifecycle: null }
+  for (const record of records) {
+    const payload = record?.payload || {}
+    if (record.type === 'turn_context') {
+      if (typeof payload.model === 'string') out.model = payload.model
+      if (typeof payload.effort === 'string') out.effort = payload.effort
+    }
+    if (
+      record.type === 'event_msg' &&
+      ['task_started', 'task_complete', 'turn_aborted'].includes(payload.type)
+    ) {
+      out.lifecycle = { type: payload.type, error: Boolean(payload.error) }
+    }
+  }
+  return out
+}
+
+async function listTranscripts(root) {
+  const files = []
+  const pending = [root]
+  while (pending.length) {
+    const dir = pending.pop()
+    let entries
+    try {
+      entries = await fsp.readdir(dir, { withFileTypes: true })
+    } catch {
+      continue
+    }
+    for (const entry of entries) {
+      const file = path.join(dir, entry.name)
+      if (entry.isDirectory()) pending.push(file)
+      // session-map tools can project another machine's transcript into this picker. Those
+      // imported-*.jsonl files duplicate the real session and must not become two astronauts.
+      else if (entry.isFile() && entry.name.endsWith('.jsonl') && !entry.name.startsWith('imported-')) {
+        files.push(file)
+      }
+    }
+  }
+  return files
+}
+
+async function transcriptEntries() {
+  const entries = []
+  for (const file of await listTranscripts(SESSIONS)) {
+    try {
+      const stat = await fsp.stat(file)
+      entries.push({ file, size: stat.size, mtime: stat.mtimeMs })
+    } catch {
+      /* archived between readdir and stat — it will be gone on the next pass */
+    }
+  }
+  return entries
+}
+
+async function readTail(file, size, bytes) {
+  const length = Math.min(size, bytes)
+  const start = Math.max(0, size - length)
+  const handle = await fsp.open(file, 'r')
+  try {
+    const buffer = Buffer.allocUnsafe(length)
+    const { bytesRead } = await handle.read(buffer, 0, length, start)
+    let text = buffer.subarray(0, bytesRead).toString('utf8')
+    if (start) text = text.slice(text.indexOf('\n') + 1)
+    // A live task may be halfway through its final JSON record.
+    if (!text.endsWith('\n')) text = text.slice(0, text.lastIndexOf('\n') + 1)
+    return text
+  } finally {
+    await handle.close()
+  }
+}
+
+/** The immutable head is cached forever; Codex only appends to a rollout while it is active. */
+const headCache = new Map()
+async function transcriptMeta(entry) {
+  const cached = headCache.get(entry.file)
+  if (cached) return cached
+  let meta
+  try {
+    meta = readTranscriptMeta(jsonLines(await readHead(entry.file, HEAD_BYTES)))
+  } catch {
+    meta = readTranscriptMeta([])
+  }
+  // A brand-new rollout can be observed before its first record is complete. Do not make that
+  // empty read permanent; the next poll should get another chance.
+  if (meta.id) headCache.set(entry.file, meta)
+  return meta
+}
+
+/** The tail changes during a turn, so cache it only until the file mtime or size moves. */
+const tailCache = new Map()
+async function transcriptTail(entry) {
+  const cached = tailCache.get(entry.file)
+  if (cached && cached.mtime === entry.mtime && cached.size === entry.size) return cached.meta
+
+  let meta = readTailMeta(jsonLines(await readTail(entry.file, entry.size, TAIL_BYTES)))
+  // A very chatty active turn can push task_started out of the first tail window. Widen only
+  // for a recently changing file, and only when an earlier pass cannot supply the lifecycle.
+  if (!meta.lifecycle && !cached?.meta.lifecycle && Date.now() - entry.mtime < ACTIVE_WINDOW_MS) {
+    meta = readTailMeta(jsonLines(await readTail(entry.file, entry.size, MAX_ACTIVE_TAIL_BYTES)))
+  }
+  if (!meta.model && cached?.meta.model) meta.model = cached.meta.model
+  if (!meta.effort && cached?.meta.effort) meta.effort = cached.meta.effort
+  if (!meta.lifecycle && cached?.meta.lifecycle) meta.lifecycle = cached.meta.lifecycle
+  tailCache.set(entry.file, { mtime: entry.mtime, size: entry.size, meta })
+  return meta
+}
+
+async function threadNames() {
+  const names = new Map()
+  let records
+  try {
+    records = jsonLines(await fsp.readFile(SESSION_INDEX, 'utf8'))
+  } catch {
+    return names
+  }
+  for (const record of records) {
+    if (UUID.test(record.id || '') && typeof record.thread_name === 'string' && record.thread_name.trim()) {
+      names.set(record.id, record.thread_name.trim())
+    }
+  }
+  return names
+}
+
+/** The desktop app owns unread state. CLI-only installs simply report no unread sessions. */
+async function unreadThreadIds() {
+  try {
+    const state = JSON.parse(await fsp.readFile(APP_STATE, 'utf8'))
+    const ids = state?.['electron-persisted-atom-state']?.['unread-thread-ids-by-host-v1']?.local
+    return new Set(Array.isArray(ids) ? ids.filter((id) => UUID.test(id)) : [])
+  } catch {
+    return new Set()
+  }
+}
+
+/** Map a Git worktree back to the repo whose zone it belongs on, without spawning git per task. */
+async function projectOf(cwd) {
+  let projectPath = cwd || ''
+  let worktree = ''
+  if (cwd) {
+    try {
+      const dotGit = path.join(cwd, '.git')
+      if ((await fsp.stat(dotGit)).isFile()) {
+        const match = (await fsp.readFile(dotGit, 'utf8')).match(/^gitdir:\s*(.+)$/m)
+        if (match) {
+          const gitDir = path.resolve(cwd, match[1])
+          const marker = path.sep + '.git' + path.sep + 'worktrees' + path.sep
+          const index = gitDir.indexOf(marker)
+          if (index !== -1) {
+            projectPath = gitDir.slice(0, index)
+            worktree = path.basename(cwd)
+          }
+        }
+      }
+    } catch {
+      /* not a Git worktree, or the folder has since moved */
+    }
+  }
+  return { projectPath, project: path.basename(projectPath) || projectPath || 'unknown', worktree }
+}
+
+let codexBinaryPromise
+async function codexBinary() {
+  if (codexBinaryPromise) return codexBinaryPromise
+  codexBinaryPromise = (async () => {
+    const candidates = [
+      'codex',
+      '/Applications/ChatGPT.app/Contents/Resources/codex',
+      '/Applications/Codex.app/Contents/Resources/codex',
+    ]
+    for (const candidate of candidates) {
+      try {
+        await execFileAsync(candidate, ['--version'], { timeout: 5000 })
+        return candidate
+      } catch {
+        /* try the next documented or bundled location */
+      }
+    }
+    return ''
+  })()
+  return codexBinaryPromise
+}
+
+async function scanThreads() {
+  const [entries, names, unread, binary] = await Promise.all([
+    transcriptEntries(),
+    threadNames(),
+    unreadThreadIds(),
+    codexBinary(),
+  ])
+  const byId = new Map()
+  const canOpen = DESKTOP_APPS.some((app) => existsSync(app))
+  for (const entry of entries) {
+    const meta = await transcriptMeta(entry)
+    // Codex stores spawned subagents beside user-facing tasks. Its own thread/list defaults to
+    // these two interactive sources, and the colony should make the same distinction.
+    if (!UUID.test(meta.id) || !['cli', 'vscode'].includes(meta.source)) continue
+
+    const tail = await transcriptTail(entry)
+    const lifecycle = tail.lifecycle
+    const { projectPath, project, worktree } = await projectOf(meta.cwd)
+    const firstPrompt = meta.firstPrompt || ''
+    const thread = {
+      id: meta.id,
+      title: names.get(meta.id) || shortTitle(firstPrompt) || 'Untitled thread',
+      preview: firstPrompt.slice(0, 240),
+      project,
+      projectPath,
+      worktree,
+      cwd: meta.cwd,
+      gitBranch: meta.gitBranch,
+      model: tail.model,
+      effort: tail.effort,
+      createdAt: meta.startedAt || entry.mtime,
+      lastActivityAt: entry.mtime,
+      lastFocusedAt: 0,
+      running:
+        lifecycle?.type === 'task_started' && Date.now() - entry.mtime < ACTIVE_WINDOW_MS,
+      unread: unread.has(meta.id),
+      hasError: lifecycle?.type === 'task_complete' && lifecycle.error,
+      starred: false,
+      routine: '',
+      prState: '',
+      archived: false,
+      sizeBytes: entry.size,
+      source: meta.source === 'vscode' ? 'desktop' : 'cli',
+      canOpen,
+      canArchive: Boolean(binary),
+      ref: { sessionId: meta.id },
+    }
+    const existing = byId.get(thread.id)
+    if (!existing || thread.lastActivityAt > existing.lastActivityAt) byId.set(thread.id, thread)
+  }
+  return [...byId.values()]
+}
+
+function openThread(ref) {
+  const id = ref?.sessionId || ''
+  if (!UUID.test(id)) return { ok: false, error: 'No openable Codex session id on that thread' }
+  return { ok: true, url: 'codex://threads/' + id }
+}
+
+function newSession(dir) {
+  return { ok: true, url: 'codex://threads/new?' + new URLSearchParams({ path: dir }) }
+}
+
+async function setArchived(ref, archived) {
+  const id = ref?.sessionId || ''
+  if (!UUID.test(id)) return { ok: false, error: 'No archivable Codex session id on that thread' }
+  const binary = await codexBinary()
+  if (!binary) return { ok: false, error: 'The Codex CLI is not available on this machine' }
+  try {
+    await execFileAsync(binary, [archived ? 'archive' : 'unarchive', id], {
+      timeout: 15000,
+      maxBuffer: 1024 * 1024,
+    })
+    return { ok: true, archived: Boolean(archived) }
+  } catch (error) {
+    const detail = String(error?.stderr || error?.message || '').trim().split('\n').pop()
+    return { ok: false, error: detail || 'Codex could not update that session' }
+  }
+}
+
+export default {
+  id: 'codex',
+  name: 'Codex',
+  detect: async () => await exists(SESSIONS),
+  scanThreads,
+  openThread,
+  newSession,
+  setArchived,
+  paths: { SESSIONS, SESSION_INDEX, APP_STATE },
+}

--- a/server/harnesses/index.mjs
+++ b/server/harnesses/index.mjs
@@ -7,8 +7,9 @@
  * `server/harnesses/README.md`.
  */
 import claudeCode from './claude-code.mjs'
+import codex from './codex.mjs'
 
-export const HARNESSES = [claudeCode]
+export const HARNESSES = [claudeCode, codex]
 
 export const harnessById = (id) => HARNESSES.find((h) => h.id === id) || null
 


### PR DESCRIPTION
## Summary

- add a Codex harness adapter for the shared desktop/CLI session store
- surface titles, prompts, projects, Git worktrees, model/effort, lifecycle, unread, error, and transcript-size state
- support documented Codex desktop deep links plus CLI archive/unarchive commands
- exclude spawned subagents and imported cross-machine transcript copies from the colony

## Feasibility and limitations

Bot Crossing's harness seam supports Codex without frontend or shared scanner changes. Codex exposes stable local JSONL transcripts, documented desktop deep links, and stable archive/unarchive CLI commands, so there is no hard blocker.

Exact live state from an already-running desktop process is not exposed to another local process. The adapter therefore infers running/error state from transcript lifecycle events and a recent-activity window. Desktop unread state is read best-effort from its local state file, and old transcripts can legitimately lack model or effort metadata.

## Verification

- node --check server/harnesses/codex.mjs
- git diff --check
- npm run build
- verified GET /api/harnesses reports both Claude Code and Codex as detected
- verified GET /api/threads against 53 real user-facing Codex tasks: 0 missing required fields, 12 worktrees, and live running/unread/error states detected
- confirmed generated open/new-session deep links and UUID validation without mutating a real task

The production build retains the repository's existing Vite large-chunk warning.
