### PR TITLE
Fill the astronaut roster by urgency, not plot order

### DIFF
--- a/src/game/colony.js
+++ b/src/game/colony.js
@@ -325,6 +325,19 @@ export class Colony {
     this.activePlots = active
     this._rebuildNavigation()
     this.stats = { ...stats, done: stats.celebrating }
+    // The roster is capped by `maxAgents` (40-200 by preset), and it was filled in plot
+    // order — biggest repo first. A repo holding thousands of automated SDK runs therefore
+    // consumed every slot before a thread that wants you was ever reached: the panel counts
+    // "23 need you" off the full list while `N` walks the roster, finds none of them, and
+    // says nobody is waiting. Rank by the same status order the thread list already uses,
+    // so whatever the cap keeps is whatever matters most. Buildings are untouched — they
+    // are placed by the createdAt index above, and only roster *membership* is at stake.
+    roster.sort((a, b) => {
+      const rank = STATUS_ORDER.indexOf(a.status) - STATUS_ORDER.indexOf(b.status)
+      if (rank !== 0) return rank
+      return b.thread.lastActivityAt - a.thread.lastActivityAt
+    })
+
     this.astronauts.setRoster(roster, this._world())
     return this.stats
   }


### PR DESCRIPTION
## The symptom

`N` reports **"Nobody is waiting on you right now"** while the panel, three inches away, says **23 need you**. Selecting one of those threads from the sidebar also does nothing visible: no fly-to, no card. The thread is real and the count is right — there is simply no astronaut for it.

## The cause

`setRoster` caps the crew at `maxAgents` (40–200 by preset) with `entries.slice(0, cap)`, and the roster is built by walking plots biggest-repo-first with `createdAt` ascending inside each. So which threads get a body is decided by iteration order.

That is fine until one repo is much larger than the rest. A repo used as a batch farm — headless SDK runs, one transcript each — consumes the entire budget before any thread that wants attention is reached. The panel counts the full thread list, the roster is a capped and arbitrary sample of it, and the two disagree.

## Reproduction

Needs a colony where one repo's thread count exceeds `maxAgents` by a wide margin. Mine: 4927 live threads across 8 repos, one holding 4802 automated runs, `balanced` preset (`maxAgents: 90`).

Before:

```
astronauts: 90
by repo:    { <the batch repo>: 90 }
by status:  { sleeping: 89, idle: 1 }
```

**0 of 36** threads wanting attention had an astronaut.

## The fix

Rank the roster by the same `STATUS_ORDER` the sidebar's thread list already uses at `main.js:341`, then by recency, so whatever survives the cap is whatever matters most.

After, same colony and same cap:

```
astronauts: 90
by repo:    6 repos represented
by status:  { waiting: 24, celebrating: 11, working: 1, idle: 54 }
```

**36 of 36.**

Buildings are untouched — they are placed by the `createdAt` index in the loop above, so only roster membership changes and nothing on the map moves.

## One behavioural consequence

Roster membership now shifts as status changes, so an astronaut whose thread stops being urgent can fall out of the cap and walk back to the ship. Previously that only happened on archive or when a transcript vanished. It reads well — a thread you have finished with heads home — but it is a change in when `_sendHome` fires, and you may have a view on it.

---

Entirely understood if this sits; the README is clear about what to expect, and the diagnosis above should stand on its own even if the patch itself does not suit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)