### PR TITLE
Hide repos from the colony without archiving their threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ than have you work around it.
 | How finished a building looks | How large its transcript is, on a log scale |
 | Scaffolding | Somebody is at that site right now |
 | Walking out of the ship | A thread that just appeared |
-| Walking back into the ship | You archived it |
+| Walking back into the ship | You archived that thread |
+| A repo vanishing from the map | You hid it from the colony. Its threads are untouched; show it again from the Hidden list |
 
 ### A zone stays where it is
 
@@ -628,9 +629,10 @@ Everything that knows what a *particular* harness's files look like lives in
 `server/harnesses/`. Everything else — the scanner, the API, the whole of `src/` — is written
 against the thread shape and never against a harness.
 
-Colony state lives in `data/colony.json` — where each zone sits and what you archived.
-Deleting it only loses the archive list and the map's arrangement; the threads themselves are
-untouched, and the colony lays itself out again from scratch.
+Colony state lives in `data/colony.json` — where each zone sits, what you archived, and which
+repos you hid from the map. Deleting it only loses the archive list, the hide list and the
+map's arrangement; the threads themselves are untouched, and the colony lays itself out again
+from scratch.
 
 ## Building your own
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "build": "npm run assets --silent && vite build",
     "start": "vite build && node server/serve.mjs",
     "serve": "node server/serve.mjs",
-    "assets": "node tools/build-assets.mjs"
+    "assets": "node tools/build-assets.mjs",
+    "test": "node --test src/**/*.test.js"
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",

--- a/server/api.mjs
+++ b/server/api.mjs
@@ -21,8 +21,9 @@ const STATE_VERSION = 1
 
 /**
  * Colony state is only ever the things the *game* invents — which plot a project got,
- * what a thread's building looks like, what you archived. The threads themselves stay
- * read-only: nothing here ever writes to a harness's data except the one archive flag.
+ * what a thread's building looks like, what you archived, which repos you hid from the
+ * map. The threads themselves stay read-only: nothing here ever writes to a harness's
+ * data except the one archive flag.
  */
 const emptyState = () => ({
   version: STATE_VERSION,
@@ -31,6 +32,7 @@ const emptyState = () => ({
   opened: [],
   plots: {},
   seen: {},
+  hiddenProjects: [],
   settings: null,
   updatedAt: 0,
 })
@@ -48,6 +50,7 @@ async function readState() {
       opened: asArray(raw.opened),
       plots: asObject(raw.plots),
       seen: asObject(raw.seen),
+      hiddenProjects: asArray(raw.hiddenProjects).map(String).filter(Boolean),
       settings: raw.settings && typeof raw.settings === 'object' ? raw.settings : null,
       updatedAt: Number(raw.updatedAt) || 0,
     }
@@ -69,6 +72,7 @@ async function writeState(next) {
     opened: asArray(next.opened),
     plots: asObject(next.plots),
     seen: asObject(next.seen),
+    hiddenProjects: asArray(next.hiddenProjects).map(String).filter(Boolean),
     settings: next.settings && typeof next.settings === 'object' ? next.settings : null,
     updatedAt: Date.now(),
   }

--- a/src/game/colony.js
+++ b/src/game/colony.js
@@ -18,6 +18,7 @@ import { Astronauts } from '../agents/astronauts.js'
 import { Indicators, BADGE } from '../agents/indicators.js'
 import { Particles } from '../agents/particles.js'
 import { Navigation } from '../agents/navigation.js'
+import { liveThreadsForColony } from './hidden-projects.js'
 
 /**
  * The colony: everything that turns a list of agent threads into a place.
@@ -257,9 +258,9 @@ export class Colony {
    * ids — repo name for plots, session id for buildings — so a poll that changes nothing
    * moves nothing on screen.
    */
-  setThreads(threads, archivedIds = new Set()) {
+  setThreads(threads, archivedIds = new Set(), hiddenProjects = new Set()) {
     const now = Date.now()
-    const live = threads.filter((t) => !t.archived && !archivedIds.has(t.id))
+    const live = liveThreadsForColony(threads, archivedIds, hiddenProjects)
 
     // Group by repo, biggest project first so the busiest work lands nearest the middle.
     const byProject = new Map()
@@ -274,6 +275,16 @@ export class Colony {
     })
 
     this._syncPlots(projects)
+
+    // Hidden repos keep their last footprint in layout memory so showing them again can
+    // reclaim the same ground if it is still free. Touching the map entry also keeps
+    // LAYOUT_MEMORY from dropping a name you only hid.
+    for (const name of hiddenProjects) {
+      const cells = this.plotCells.get(name)
+      if (!cells) continue
+      this.plotCells.delete(name)
+      this.plotCells.set(name, cells)
+    }
 
     const roster = []
     const seenBuildings = new Set()

--- a/src/game/hidden-projects.js
+++ b/src/game/hidden-projects.js
@@ -1,0 +1,30 @@
+/**
+ * Colony-only project hiding. Threads stay in the harness; the map just stops drawing
+ * that repo until you unhide it. Names are folder basenames, the same key plots use.
+ */
+
+export function hideProject(hidden, name) {
+  const id = String(name || '')
+  if (!id) return [...hidden]
+  if (hidden.includes(id)) return [...hidden]
+  return [...hidden, id]
+}
+
+export function unhideProject(hidden, name) {
+  const id = String(name || '')
+  return hidden.filter((n) => n !== id)
+}
+
+export function liveThreadsForColony(threads, archivedIds, hiddenProjects) {
+  const archived = archivedIds instanceof Set ? archivedIds : new Set(archivedIds)
+  const hidden = hiddenProjects instanceof Set ? hiddenProjects : new Set(hiddenProjects)
+  return threads.filter((t) => !t.archived && !archived.has(t.id) && !hidden.has(t.project || 'unknown'))
+}
+
+export function hiddenCatalog(hidden, threads) {
+  const names = [...new Set(hidden.map(String).filter(Boolean))].sort((a, b) => a.localeCompare(b))
+  return names.map((name) => ({
+    name,
+    count: threads.filter((t) => !t.archived && (t.project || 'unknown') === name).length,
+  }))
+}

--- a/src/game/hidden-projects.test.js
+++ b/src/game/hidden-projects.test.js
@@ -1,0 +1,50 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  hideProject,
+  unhideProject,
+  liveThreadsForColony,
+  hiddenCatalog,
+} from './hidden-projects.js'
+
+test('hideProject adds a name once', () => {
+  const next = hideProject(['alpha'], 'beta')
+  assert.deepEqual(next, ['alpha', 'beta'])
+  assert.deepEqual(hideProject(next, 'beta'), ['alpha', 'beta'])
+})
+
+test('unhideProject removes a name', () => {
+  assert.deepEqual(unhideProject(['alpha', 'beta'], 'alpha'), ['beta'])
+  assert.deepEqual(unhideProject(['beta'], 'missing'), ['beta'])
+})
+
+test('liveThreadsForColony drops archived threads and hidden repos', () => {
+  const threads = [
+    { id: '1', project: 'keep', archived: false },
+    { id: '2', project: 'keep', archived: true },
+    { id: '3', project: 'gone', archived: false },
+    { id: '4', project: 'also', archived: false },
+  ]
+  const live = liveThreadsForColony(threads, ['2'], ['gone'])
+  assert.deepEqual(
+    live.map((t) => t.id),
+    ['1', '4']
+  )
+})
+
+test('hiddenCatalog lists hidden names with live thread counts', () => {
+  const catalog = hiddenCatalog(
+    ['gone', 'empty'],
+    [
+      { project: 'gone', archived: false },
+      { project: 'gone', archived: false },
+      { project: 'gone', archived: true },
+      { project: 'keep', archived: false },
+    ]
+  )
+  assert.equal(catalog.length, 2)
+  assert.equal(catalog[0].name, 'empty')
+  assert.equal(catalog[0].count, 0)
+  assert.equal(catalog[1].name, 'gone')
+  assert.equal(catalog[1].count, 2)
+})

--- a/src/main.js
+++ b/src/main.js
@@ -18,6 +18,7 @@ import {
   newSession,
   revealFolder,
 } from './game/api.js'
+import { hideProject, hiddenCatalog, unhideProject } from './game/hidden-projects.js'
 
 /**
  * Boot and the outer game loop.
@@ -47,7 +48,7 @@ const engine = new Engine(settings).mount(app)
 const rig = new CameraRig(engine.camera, engine.canvas, settings)
 const colony = new Colony(engine.scene, settings, engine.camera, engine.renderer)
 
-let state = { archived: [], archivedAt: {}, opened: [], plots: {}, seen: {} }
+let state = { archived: [], archivedAt: {}, opened: [], plots: {}, seen: {}, hiddenProjects: [] }
 let threads = []
 /** Last legend built for the bottom bar, kept so the open zone's chip can light up between polls. */
 let legendProjects = []
@@ -164,6 +165,28 @@ const actions = {
     } catch (err) {
       hud.toast(err.message || 'Could not open that folder', 'err')
     }
+  },
+
+  hideProject: () => {
+    const name = selectedProject
+    if (!name) return
+    state.hiddenProjects = hideProject(state.hiddenProjects || [], name)
+    queueSave()
+    if (selectedId) {
+      const thread = threads.find((t) => t.id === selectedId)
+      if (thread?.project === name) select(null, {})
+    }
+    selectedProject = null
+    applyThreads(threads)
+    hud.toast(`Hidden ${name} — still in your harness, gone from the colony`)
+  },
+
+  unhideProject: (name) => {
+    if (!name) return
+    state.hiddenProjects = unhideProject(state.hiddenProjects || [], name)
+    queueSave()
+    applyThreads(threads)
+    hud.toast(`Showing ${name} again`)
   },
 
   copyProjectPath: async () => {
@@ -318,11 +341,12 @@ function pathForProject(name) {
 
 /** Push the open zone's current contents at the sidebar. Closes it if the zone is gone. */
 function syncProject() {
+  const hidden = hiddenCatalog(state.hiddenProjects || [], threads)
   const plot = selectedProject ? colony.plots.get(selectedProject) : null
   if (!plot) {
     selectedProject = null
     hud.setProject(null)
-    hud.setLegend(legendProjects, null)
+    hud.setLegend(legendProjects, null, hidden)
     return
   }
   const now = Date.now()
@@ -351,7 +375,7 @@ function syncProject() {
   })
   // The legend is the same selection seen from the bottom of the screen: keep it in step
   // here rather than only on the next poll.
-  hud.setLegend(legendProjects, selectedProject)
+  hud.setLegend(legendProjects, selectedProject, hidden)
 }
 
 // ── pointer ───────────────────────────────────────────────────────────────────────────
@@ -541,7 +565,8 @@ window.addEventListener('keydown', (e) => {
 function applyThreads(list) {
   threads = list
   const archivedSet = new Set(state.archived)
-  const stats = colony.setThreads(list, archivedSet)
+  const hiddenSet = new Set(state.hiddenProjects || [])
+  const stats = colony.setThreads(list, archivedSet, hiddenSet)
   hud.setStats(stats)
 
   legendProjects = colony.plotOrder

--- a/src/ui/hud.js
+++ b/src/ui/hud.js
@@ -3,6 +3,7 @@ import { PLANETS } from '../world/planet.js'
 import { TIMES } from '../world/sky.js'
 import { STATUS_LABEL } from '../game/colony.js'
 import { FACE, FRAME_COLS, FRAME_ROWS } from '../agents/faces.js'
+import { PLOT_PALETTE, hashString } from '../world/plots.js'
 
 /**
  * The whole HUD, in plain DOM.
@@ -59,6 +60,7 @@ export class Hud {
     this.actions = actions
     this.visible = true
     this._last = {}
+    this.hiddenOpen = false
 
     this.el = document.createElement('div')
     this.el.className = 'hud'
@@ -341,6 +343,8 @@ export class Hud {
     on('#btn-new-session', 'click', () => this.actions.newConversation?.())
     on('#btn-reveal', 'click', () => this.actions.revealProject?.())
     on('#btn-copy-path', 'click', () => this.actions.copyProjectPath?.())
+    on('#btn-hide-project', 'click', () => this.actions.hideProject?.())
+    on('#btn-hidden-toggle', 'click', () => this.toggleHiddenList())
     on('#btn-locate', 'click', () => this.actions.focusProject?.(this.project?.name))
     on('#btn-close-project', 'click', () => this.actions.closeProject?.())
     on('.help', 'click', (e) => {
@@ -375,8 +379,11 @@ export class Hud {
    * it is a list now because the sidebar is where all the chrome lives, and because a list
    * can carry a count and an alarm without running out of room at eleven repos.
    */
-  setLegend(projects, activeName = null) {
-    const signature = projects.map((p) => `${p.name}:${p.count}:${p.accent}:${p.urgent ? 1 : 0}`).join('|') + `~${activeName}`
+  setLegend(projects, activeName = null, hidden = []) {
+    const signature =
+      projects.map((p) => `${p.name}:${p.count}:${p.accent}:${p.urgent ? 1 : 0}`).join('|') +
+      `~${activeName}~` +
+      hidden.map((p) => `${p.name}:${p.count}`).join('|')
     if (this._last.legend === signature) return
     this._last.legend = signature
 
@@ -397,6 +404,42 @@ export class Hud {
       wrap.appendChild(b)
     }
     this.$('.sec-head span').textContent = `${projects.length} repo${projects.length === 1 ? '' : 's'}`
+
+    const block = this.$('.hidden-block')
+    block.hidden = hidden.length === 0
+    this.$('#btn-hidden-toggle .label').textContent = `${hidden.length} hidden`
+    const hiddenWrap = this.$('.hidden-projects')
+    hiddenWrap.innerHTML = ''
+    for (const p of hidden) {
+      const accent = PLOT_PALETTE[hashString(p.name) % PLOT_PALETTE.length]
+      const row = document.createElement('div')
+      row.className = 'repo hidden-repo'
+      row.innerHTML =
+        `<i class="swatch" style="background:${hex(accent)};color:${hex(accent)}"></i>` +
+        `<span class="n">${escapeHtml(p.name)}</span>` +
+        `<span class="count">${p.count}</span>`
+      const show = document.createElement('button')
+      show.type = 'button'
+      show.className = 'btn ghost show-repo'
+      show.title = `Show ${p.name} on the map again`
+      show.textContent = 'Show'
+      show.addEventListener('click', () => this.actions.unhideProject?.(p.name))
+      row.appendChild(show)
+      hiddenWrap.appendChild(row)
+    }
+    this._syncHiddenList()
+  }
+
+  toggleHiddenList() {
+    this.hiddenOpen = !this.hiddenOpen
+    this._syncHiddenList()
+  }
+
+  _syncHiddenList() {
+    const toggle = this.$('#btn-hidden-toggle')
+    const list = this.$('.hidden-projects')
+    toggle.setAttribute('aria-expanded', String(this.hiddenOpen))
+    list.hidden = !this.hiddenOpen
   }
 
   /**
@@ -826,6 +869,12 @@ const TEMPLATE = `
     <div class="projects-pane">
       <div class="sec-head"><span>Repos</span></div>
       <div class="projects"></div>
+      <div class="hidden-block" hidden>
+        <button type="button" class="hidden-toggle" id="btn-hidden-toggle" aria-expanded="false">
+          <span class="label">0 hidden</span>
+        </button>
+        <div class="hidden-projects" hidden></div>
+      </div>
     </div>
 
     <div class="project-detail">
@@ -844,6 +893,7 @@ const TEMPLATE = `
           <button class="btn" id="btn-reveal" title="Show this folder in ${FILE_MANAGER}">${ICON.folder} ${FILE_MANAGER}</button>
           <button class="btn" id="btn-copy-path" title="Copy the folder path">${ICON.copy} Copy path</button>
         </div>
+        <button class="btn" id="btn-hide-project" title="Hide this repo from the colony — does not archive its threads">${ICON.eyeOff} Hide from colony</button>
       </div>
       <div class="threads-head"></div>
       <div class="threads"></div>
@@ -889,7 +939,7 @@ const TEMPLATE = `
 <div class="help">
   <div class="sheet panel">
     <h2>Bot Crossing</h2>
-    <p class="sub">Every coding-agent thread on this Mac is an astronaut. They walk out of the ship, claim a plot for their repo, and build. Click one to open its thread; click a zone — its deck or its name — for the repo itself, and start a new conversation there. Navigation works like Google Earth — drag the ground itself, right-drag to tilt, scroll to zoom in on whatever is under the cursor.</p>
+    <p class="sub">Every coding-agent thread on this Mac is an astronaut. They walk out of the ship, claim a plot for their repo, and build. Click one to open its thread; click a zone — its deck or its name — for the repo itself, and start a new conversation there. Hide a repo from that panel if you do not want it on the map — its threads stay in your harness, and you can show it again from the list. Navigation works like Google Earth — drag the ground itself, right-drag to tilt, scroll to zoom in on whatever is under the cursor.</p>
     <div class="cols">
       <div>
         <div class="k"><span>Drag the ground</span><kbd>drag</kbd></div>
@@ -905,7 +955,7 @@ const TEMPLATE = `
       <div>
         <div class="k"><span>Next needing you</span><kbd>N</kbd></div>
         <div class="k"><span>Open thread</span><kbd>Enter</kbd></div>
-        <div class="k"><span>Archive</span><kbd>A</kbd></div>
+        <div class="k"><span>Archive thread</span><kbd>A</kbd></div>
         <div class="k"><span>New conversation</span><kbd>C</kbd></div>
         <div class="k"><span>Orbit mode</span><kbd>O</kbd></div>
         <div class="k"><span>Change planet</span><kbd>Tab</kbd></div>

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -820,6 +820,82 @@ body {
   scrollbar-color: rgba(255, 255, 255, 0.16) transparent;
 }
 
+.side .hidden-block {
+  flex: none;
+  border-top: 1px solid var(--line);
+}
+
+.side .hidden-block[hidden] {
+  display: none;
+}
+
+.side .hidden-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  margin: 0;
+  padding: 11px 15px 12px;
+  border: 0;
+  background: transparent;
+  color: var(--dim);
+  font: inherit;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  text-align: left;
+  cursor: pointer;
+}
+
+.side .hidden-toggle:hover {
+  color: var(--text);
+}
+
+.side .hidden-toggle::after {
+  content: '';
+  width: 0;
+  height: 0;
+  border-left: 4px solid currentColor;
+  border-top: 3px solid transparent;
+  border-bottom: 3px solid transparent;
+  opacity: 0.7;
+  transition: transform 140ms ease;
+}
+
+.side .hidden-toggle[aria-expanded='true']::after {
+  transform: rotate(90deg);
+}
+
+.side .hidden-projects {
+  padding: 0 9px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.side .hidden-projects[hidden] {
+  display: none;
+}
+
+.side .hidden-repo {
+  cursor: default;
+}
+
+.side .hidden-repo:hover {
+  background: transparent;
+}
+
+.side .hidden-repo .n {
+  opacity: 0.72;
+}
+
+.side .show-repo {
+  height: 28px;
+  padding: 0 10px;
+  font-size: 12px;
+  flex: none;
+}
+
 .side .repo {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- Lets you hide a whole repo from the map and sidebar without archiving its harness threads. **Hide from colony** on the project panel drops the plot and crew; a collapsed **N hidden** row at the bottom of the repo list expands so you can **Show** it again.
- The hide list is stored in `data/colony.json` (`hiddenProjects`) only. Nothing extra is written to Claude Code / other harness records.
- Hidden plots keep their last layout in memory so unhiding can reclaim the same ground if it is still free.

## Test plan
- [ ] Open a repo in the sidebar and click **Hide from colony** — the zone leaves the map, the repo leaves the main list, toast confirms it is still in the harness
- [ ] Confirm the sidebar footer shows **N hidden** collapsed (names not listed until you click it)
- [ ] Expand Hidden, click **Show** — the repo returns to the map
- [ ] Reload the page — hidden repos stay hidden
- [ ] Archive a single thread as before (**A**) and confirm hide did not archive sibling threads in the harness
- [ ] `npm test` (node:test filter for hidden project names)


Made with [Cursor](https://cursor.com)