### PR TITLE
Stop a second tab pasting over the first one's work

### DIFF
--- a/server/api.mjs
+++ b/server/api.mjs
@@ -57,9 +57,20 @@ async function readState() {
 }
 
 /**
- * One writer: the browser owns this file and PUTs it whole. `/api/archive` deliberately
- * does not touch it — if it did, the next save from a page holding older state would
- * silently drop every archive made since that page loaded.
+ * The browser owns this file and PUTs it whole; `updatedAt` is what makes that safe.
+ *
+ * This used to say "one writer", and that was only ever true of *browser vs server* —
+ * `/api/archive` still deliberately does not touch this file, because a server-side write
+ * would be invisible to a page that had already loaded. It was never true of tab vs tab, and
+ * two tabs are two writers on one whole-file save: the one that saves last pastes its own
+ * boot-time picture over everything the other has done since.
+ *
+ * So the stamp written here is a version, and `PUT /api/state` refuses a body whose
+ * `baseUpdatedAt` disagrees with it — see the endpoint. Every write goes through this
+ * function, so there is exactly one place the version can advance.
+ *
+ * Still written to a temp file and renamed: rename is atomic, so a save interrupted halfway
+ * leaves the previous colony intact rather than a truncated file that reads back as empty.
  */
 async function writeState(next) {
   const state = {
@@ -261,8 +272,31 @@ export async function apiMiddleware(req, res, next) {
       return send(res, 200, await readState())
     }
 
+    /**
+     * Optimistic concurrency, so a second tab cannot paste over the first one's work.
+     *
+     * `baseUpdatedAt` is the `updatedAt` the caller last read or wrote. If the file no longer
+     * carries that version, the caller's whole-file body describes a colony that no longer
+     * exists, and writing it would lose whatever happened in between — so the disk state is
+     * handed back with a 409 and the page merges against it. Merging here was the other option
+     * and it is the wrong place for it: the server has no idea which of two `plots` layouts a
+     * person actually dragged.
+     *
+     * The test is inequality rather than "older than". A colony file also moves *backwards*,
+     * when it is restored from a backup or edited by hand, and a page open across that restore
+     * holds a base newer than the disk — which sails through a greater-than check and pastes
+     * the pre-restore colony straight back, looking exactly like the restore having failed.
+     *
+     * A missing or zero base is a first write and is allowed. That keeps a fresh install
+     * working — there is nothing to lose when the file does not exist yet — and keeps the
+     * endpoint drivable from `curl` without having to read the file first.
+     */
     if (url.pathname === '/api/state' && req.method === 'PUT') {
-      return send(res, 200, await writeState(await readJsonBody(req)))
+      const body = await readJsonBody(req)
+      const base = Number(body.baseUpdatedAt) || 0
+      const current = await readState()
+      if (base && current.updatedAt !== base) return send(res, 409, current)
+      return send(res, 200, await writeState(body))
     }
 
     if (url.pathname === '/api/open' && req.method === 'POST') {

--- a/src/game/api.js
+++ b/src/game/api.js
@@ -1,3 +1,5 @@
+import { mergeState } from './merge-state.js'
+
 async function req(url, options) {
   const res = await fetch(url, options)
   const body = await res.json().catch(() => ({}))
@@ -13,14 +15,70 @@ const post = (url, payload) =>
   })
 
 export const fetchThreads = () => req('/api/threads')
-export const fetchState = () => req('/api/state')
 
-export const saveState = (state) =>
-  req('/api/state', {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(state),
-  })
+/**
+ * The colony file, and the base every later save is measured against.
+ *
+ * `baseUpdatedAt` is the file version this tab last agreed with, and `baseSnapshot` is the
+ * state as it looked at that moment. The snapshot is the expensive-looking half and the one
+ * that matters: without it a conflicted save can only union the two lists, and a union can
+ * never express "I un-archived this" — see `merge-state.js`.
+ */
+let baseUpdatedAt = 0
+let baseSnapshot = null
+
+function adoptBase(state, updatedAt) {
+  baseUpdatedAt = Number(updatedAt ?? state?.updatedAt) || 0
+  // Cloned, because the page mutates the object it holds. Sharing the reference would let
+  // `local` and `base` drift into being the same thing, which reads as "this tab changed
+  // nothing" and quietly turns every save back into last-writer-wins.
+  baseSnapshot = structuredClone(state)
+}
+
+export const fetchState = async () => {
+  const state = await req('/api/state')
+  adoptBase(state)
+  return state
+}
+
+/** Enough attempts to get through a burst of saves from another tab, and no more. */
+const SAVE_TRIES = 3
+
+/**
+ * Save the colony, merging rather than clobbering if another tab got there first.
+ *
+ * The server answers 409 with what is actually on disk when this tab's base is stale. That is
+ * not a failure to report at the user — it is the normal shape of two tabs being open — so it
+ * is merged and re-sent here. `base` for the next attempt is the disk state just merged
+ * against, which is what keeps a retry from re-applying edits it has already folded in.
+ *
+ * @returns the state the caller should hold from now on. That is the *same object* when
+ *   nothing conflicted, so the common path never swaps the page's state out from under a click
+ *   that happened mid-flight; only a real merge hands back something new.
+ */
+export async function saveState(state) {
+  let local = state
+  for (let attempt = 0; attempt < SAVE_TRIES; attempt++) {
+    const res = await fetch('/api/state', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...local, baseUpdatedAt }),
+    })
+    const body = await res.json().catch(() => ({}))
+
+    if (res.status === 409) {
+      local = mergeState(baseSnapshot, local, body)
+      adoptBase(body)
+      continue
+    }
+    if (!res.ok) throw new Error(body.error || `${res.status} ${res.statusText}`)
+    adoptBase(local, body.updatedAt)
+    return local
+  }
+  // Losing to another tab three times running means it is saving faster than we can merge.
+  // The caller swallows this: nothing local is lost, and the next save tries again.
+  throw new Error('Could not save the colony — another tab kept writing first')
+}
 
 /**
  * Hand a thread back to whichever harness owns it — the desktop app comes forward on its own.

--- a/src/game/merge-state.js
+++ b/src/game/merge-state.js
@@ -1,0 +1,126 @@
+/**
+ * Three-way merge of a colony state.
+ *
+ * The colony file is written whole, by a page that read it once at boot. That is fine while
+ * there is only ever one tab: the page holds the truth and the file is its shadow. With two
+ * tabs it is two writers on one file, and the losing write is silent — the tab that saves last
+ * simply pastes over everything the other one did since it loaded. In practice that looks like
+ * a plot you moved snapping back, or a thread you archived reappearing on its own.
+ *
+ * The server refuses a save whose base is stale and hands back what is on disk, so the page can
+ * work out what it actually changed rather than asserting its whole picture. Hence three
+ * inputs: `base` is the state as this tab last saw it agree with disk, `local` is what this tab
+ * holds now, `remote` is what is on disk. The result keeps the other tab's work and replays
+ * this tab's own edits on top of it.
+ *
+ * Pure and browser-free on purpose: this is the one piece worth being able to run under bare
+ * node, since every way of getting it wrong is a way of losing somebody's archive list.
+ */
+
+/**
+ * Structural equality, deep enough for the values that actually live in this file: `plots`
+ * holds arrays of `[q, r]` integer pairs and `seen` holds numbers. Reference equality is no use
+ * here — every one of these values is rebuilt from scratch on each poll, so a cell list that
+ * never moved is still a different array than the one in `base`, and comparing by identity
+ * would call every single zone "changed by this tab" and defeat the merge.
+ */
+function sameValue(a, b) {
+  if (a === b) return true
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return a.length === b.length && a.every((v, i) => sameValue(v, b[i]))
+  }
+  if (a && b && typeof a === 'object' && typeof b === 'object') {
+    const ka = Object.keys(a)
+    const kb = Object.keys(b)
+    return ka.length === kb.length && ka.every((k) => sameValue(a[k], b[k]))
+  }
+  return false
+}
+
+const asArray = (v) => (Array.isArray(v) ? v : [])
+const asObject = (v) => (v && typeof v === 'object' && !Array.isArray(v) ? v : {})
+
+/**
+ * A set-like list — `archived`, `opened` — merged as
+ * `(remote ∪ (local \ base)) \ (base \ local)`.
+ *
+ * Both halves are needed, and it is tempting to write only the first. A plain union of the two
+ * lists keeps every addition and is trivially safe against loss, but it makes un-archiving
+ * *impossible* between two tabs: the id this tab removed is still in the other tab's copy, so
+ * the union puts it straight back and `reconcileArchived` files the thread away again within a
+ * poll. Subtracting what this tab deleted is what makes a removal survive a merge.
+ *
+ * Order follows `remote` and this tab's additions are appended, so the file does not churn.
+ */
+function mergeSet(base, local, remote) {
+  const baseSet = new Set(asArray(base))
+  const localSet = new Set(asArray(local))
+  // Deleted *here* — anything the base had and this tab no longer does.
+  const removed = new Set([...baseSet].filter((id) => !localSet.has(id)))
+
+  const out = []
+  const seen = new Set()
+  for (const id of asArray(remote)) {
+    if (removed.has(id) || seen.has(id)) continue
+    seen.add(id)
+    out.push(id)
+  }
+  for (const id of localSet) {
+    // Added *here* — not in the base, so it cannot be something the other tab deleted.
+    if (baseSet.has(id) || seen.has(id)) continue
+    seen.add(id)
+    out.push(id)
+  }
+  return out
+}
+
+/**
+ * A keyed map — `archivedAt`, `plots`, `seen` — merged key by key.
+ *
+ * `remote` is the starting point, because everything in it is either untouched or the other
+ * tab's work. This tab then replays its own diff against `base` on top: a key it added or
+ * changed wins, a key it deleted goes. A key neither tab touched is left exactly as the other
+ * tab left it, which is what stops a zone the other tab moved from snapping back.
+ */
+function mergeMap(base, local, remote) {
+  const baseMap = asObject(base)
+  const localMap = asObject(local)
+  const out = { ...asObject(remote) }
+
+  for (const [k, v] of Object.entries(localMap)) {
+    if (k in baseMap && sameValue(baseMap[k], v)) continue // untouched here; leave theirs
+    out[k] = v
+  }
+  for (const k of Object.keys(baseMap)) {
+    if (k in localMap) continue
+    delete out[k] // deleted here — the resurrection this whole file exists to prevent
+  }
+  return out
+}
+
+/**
+ * Merge one colony state, field by field.
+ *
+ * `settings` is the deliberate exception: local wins, whole. It is a per-browser preference
+ * blob — render scale, shadow quality, which planet — and the two tabs are usually the same
+ * person on the same machine expressing the same intent. Merging it field-wise would hand
+ * somebody a colony at half quality on Mars at dusk because two tabs each contributed a third
+ * of a preset, which is a worse outcome than the last tab to touch a slider winning.
+ *
+ * `updatedAt` is not merged at all: the server stamps it, and the value here would only ever be
+ * a stale guess.
+ */
+export function mergeState(base, local, remote) {
+  const b = base || {}
+  const l = local || {}
+  const r = remote || {}
+  return {
+    version: r.version ?? l.version ?? 1,
+    archived: mergeSet(b.archived, l.archived, r.archived),
+    archivedAt: mergeMap(b.archivedAt, l.archivedAt, r.archivedAt),
+    opened: mergeSet(b.opened, l.opened, r.opened),
+    plots: mergeMap(b.plots, l.plots, r.plots),
+    seen: mergeMap(b.seen, l.seen, r.seen),
+    settings: l.settings && typeof l.settings === 'object' ? l.settings : r.settings ?? null,
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -593,7 +593,10 @@ function queueSave() {
   clearTimeout(pendingSave)
   pendingSave = setTimeout(async () => {
     try {
-      await saveState(state)
+      // Adopt whatever came back: unchanged when the save was clean, and the merged colony
+      // when another tab had written since this one loaded. Dropping it would leave this page
+      // asserting a picture the file has already moved past, and the next save would fight.
+      state = await saveState(state)
     } catch {
       /* the colony still runs; only the archive list is at risk, and it retries next time */
     }


### PR DESCRIPTION
The page reads colony.json once at boot and writes it whole, so two tabs are two writers and the losing write is silent: the tab that saves last pastes its boot-time picture over everything the other has done since. A zone you dragged snaps back; a thread you archived returns on its own.

The "one writer" note on writeState was only ever true of browser vs server. /api/archive still deliberately leaves this file alone, for exactly the reason given there — but that says nothing about tab vs tab.

PUT /api/state now carries the version it read and gets a 409 with the disk state when they disagree, and the page merges rather than asserting its whole picture. The merge is three-way and lives in game/merge-state.js, pure and browser-free so it runs under bare node.

Set-like fields apply this tab's deletions as well as its additions. A plain union is the obvious shape and it is wrong: the id one tab removed is still in the other's copy, so the union puts it back and reconcileArchived files the thread away again within a poll — un-archiving becomes impossible while two tabs are open.

The conflict test is inequality rather than "older than", because a colony file also moves backwards when it is restored from a backup or edited by hand. A page open across that restore holds a base newer than the disk, sails through a greater-than check, and pastes the pre-restore colony back — which looks exactly like the restore having failed.

Verified against the running server with two simulated tabs on an isolated data directory: 4 of 8 checks fail with the base omitted (the old behaviour), 8 of 8 pass with it, including un-archiving, a deleted plots key staying deleted, and a restore surviving an open tab. Single-tab saves are plain 200s with no 409 loop, a body with no base still writes so a fresh install and curl keep working, and the cross-origin PUT is still refused.