### PR TITLE
Open threads on Linux without the desktop app

### DIFF
--- a/.claude/skills/agent-session-world/references/harness-adapters.md
+++ b/.claude/skills/agent-session-world/references/harness-adapters.md
@@ -21,10 +21,14 @@ export default {
   /** → Thread[] in the common shape below. */
   async scanThreads(),
 
-  /** Hand a thread back to its harness. → { ok, url } | { ok: false, error } */
+  /**
+   * Hand a thread back to its harness. → { ok, url, command? } | { ok: false, error }
+   * `command` is the same action as a terminal argv, for a machine where nothing answers
+   * the URL's scheme (a Linux box with only the CLI). May return a Promise.
+   */
   openThread(ref),
 
-  /** Start a fresh thread rooted at a folder. → { ok, url } */
+  /** Start a fresh thread rooted at a folder. → { ok, url, command? }, likewise. */
   newSession(dir),
 
   /** Flip archive state on the harness's own records. → { ok } */

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,9 +47,10 @@ than have you contort an adapter around it.
 
 Also useful:
 
-- **Linux and Windows support.** The scanning half is portable; the opening half is not. Every
-  "open this thread", "reveal this folder" and "start a session here" path goes through macOS's
-  `open(1)` in `server/api.mjs`. That is the whole blocker.
+- **Platform edges.** macOS, Linux and Windows all run now, but each was verified on one
+  machine. On Linux in particular, the terminal that opens a CLI-only thread is chosen from a
+  table in `server/lib/xdg.mjs` — a terminal that is not in it, or a desktop that names its
+  terminal some other way, is a small and welcome PR.
 - **Bug fixes**, especially anything where the colony misrepresents what a thread is actually
   doing. That is the one thing the project has to get right.
 - **Performance**, if you can measure it. See the Performance section of the README for the kind

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **[botcrossing.com](https://botcrossing.com)**
 
-Every coding-agent thread on this Mac is a little astronaut. They walk out of the ship, claim
+Every coding-agent thread on this machine is a little astronaut. They walk out of the ship, claim
 a plot for their repo, and build something. When one needs you it stops and holds a `?` over
 its head; click it and the thread opens back in whichever harness it came from.
 
@@ -26,9 +26,16 @@ second process. For a built version, `npm start` (build + serve) or `npm run ser
 
 **macOS, Linux and Windows.** Opening a thread, revealing a folder and starting a new session
 all go through a `harness://` deep link handed to the OS opener — `open(1)` on macOS,
-`xdg-open` on Linux, ShellExecute on Windows. The scanning half was portable already. Note that
-the deep link needs a desktop app registered for that scheme, so on Linux the folder buttons
-work while opening a thread has nothing to reach yet.
+`xdg-open` on Linux, ShellExecute on Windows. The scanning half was portable already.
+
+On Linux the desktop app is optional. If nothing is registered for `claude://` — the server
+asks `xdg-mime` — opening a thread instead runs the CLI in a new terminal window, in the
+folder the session ran in: `claude --resume <id>`, or a bare `claude` for a new conversation.
+The terminal is `$TERMINAL` if you set one (and it is one the table in `server/lib/xdg.mjs`
+knows), otherwise one that ships with your desktop, otherwise whatever is installed, with
+Debian's `x-terminal-emulator` as the last resort; `--` and the working directory are passed
+the way each one expects. A launch the terminal refuses outright — no display, say — comes
+back as an error rather than a toast that says it opened.
 
 ## Which harnesses work
 
@@ -176,10 +183,11 @@ into the same repo. Picking somebody is also picking the zone they are standing 
 **The repo**, at the top, whether or not anybody is selected:
 
 - **New conversation** (`C`) starts a fresh thread in that folder. It is the same
-  `claude://code/new?folder=…` deep link Finder's "New Claude Code Session Here" quick
-  action uses, so the desktop app opens an empty session with the repo as its workspace —
-  nothing is resumed and nothing is written.
-- **Finder** (Explorer on Windows) opens the folder, **Copy path** copies it.
+  `claude://code/new?folder=…` deep link the desktop app's "New Claude Code Session Here"
+  action uses (a Finder quick action on macOS), so the app opens an empty session with the
+  repo as its workspace — nothing is resumed and nothing is written. Without the app, it is
+  the bare CLI in a terminal, in that folder.
+- **Finder** (Explorer on Windows, Files on Linux) opens the folder, **Copy path** copies it.
 - Underneath, everything running in that repo, whoever wants something first. Clicking one
   flies to its astronaut and selects it.
 
@@ -191,7 +199,8 @@ flipping to its left rather than sliding under the sidebar, and never leaving th
 It is moved with a transform rather than with `left`/`top`, the one geometric change a
 browser makes without touching layout, so following a walking astronaut costs nothing.
 
-- **Open** hands the thread back to Claude Code and the desktop app comes forward.
+- **Open** hands the thread back to Claude Code and the desktop app comes forward — or, on a
+  Linux box without the app, a terminal opens with the CLI resuming it.
 - **Archive** sets `isArchived` on Claude Code's own session record — the thread lands in
   Claude Code's Archived list, not just here — and the astronaut walks back up the ramp and
   boards the ship.
@@ -212,7 +221,7 @@ stomp the flag, so the colony re-asserts it on every scan — an archive that ge
 back within one poll.
 
 Nothing is ever written to your Claude Code data except that one `isArchived` field. The
-folder buttons only ever hand a path to `open`.
+folder buttons only ever hand a path to the OS opener.
 
 The deep links above are the **Claude Code adapter's** business, not the colony's — another
 harness plugs its own in, and a harness with no deep link simply greys the button out. See
@@ -257,7 +266,7 @@ under **View → Return to isometric**.
 
 | Key | Does |
 | --- | --- |
-| `H` / `⌘\` | **Hide every panel.** The colony still reads: status lives above the astronauts' heads |
+| `H` / `⌘\` or `Ctrl+\` | **Hide every panel.** The colony still reads: status lives above the astronauts' heads |
 | `S` | Settings |
 | `N` | Fly to the next astronaut waiting on you |
 | `Enter` / `A` | Open / archive the selected thread |
@@ -565,7 +574,7 @@ more interesting target than a localhost toy usually is. Three things hold it in
   `Host: their-domain`, and are refused.
 - **It checks `Origin`.** A cross-site `fetch` with a `text/plain` body is not preflighted, so
   without this any page you happened to have open could POST here — spawning sessions, opening
-  Finder windows, or overwriting the colony layout — even while unable to read the response.
+  file-manager windows, or overwriting the colony layout — even while unable to read the response.
   Requests from anywhere but this server's own page are refused.
 
 The practical cost: a bare `curl` POST is refused too, since browsers always send `Origin` on

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "type": "module",
-  "description": "A 3D colony sim where every coding-agent thread on your Mac is a little astronaut building something.",
+  "description": "A 3D colony sim where every coding-agent thread on your machine is a little astronaut building something.",
   "license": "MIT",
   "author": "Jarren Rocks",
   "homepage": "https://botcrossing.com",

--- a/server/api.mjs
+++ b/server/api.mjs
@@ -3,6 +3,7 @@ import os from 'node:os'
 import path from 'node:path'
 import { spawn } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
+import { openInTerminal, schemeHasHandler, schemeOf } from './lib/xdg.mjs'
 import {
   defaultHarness,
   harnessAppStartedAt,
@@ -113,6 +114,58 @@ function launch(target) {
 }
 
 /**
+ * Show a harness's answer to "open this" — `{ ok, url, command }` — to the user, and say
+ * truthfully whether anything happened.
+ *
+ * macOS and Windows hand the URL to the opener exactly as before: a scheme the harness's app
+ * registers is always answered there, so nothing is probed. Linux is the platform where the
+ * URL may have nowhere to go — the desktop app is optional and often absent, and `xdg-open`
+ * on a scheme nobody claims exits quietly, which used to reach the page as "Opened". So here
+ * the scheme is checked first; failing that, the harness's own CLI is run in a terminal, from
+ * the `command` the adapter offered alongside the URL; failing *that*, the page is told so.
+ *
+ * `command.cwd` came from the page — inside `ref`, or as the folder itself — so it gets the
+ * same check as any other folder the page names, even where the handler above already ran it.
+ * There is no fallback directory on purpose: `claude --resume` looks a session up under the
+ * folder it ran in, and a terminal that opens on "No conversation found" and closes is worse
+ * than an error toast. A harness that offers only a command gets an error on the platforms
+ * that have no terminal path yet, for the same reason.
+ */
+async function present(result) {
+  // Only the reason goes to the page: an adapter's failure may still carry its command.
+  if (!result || !result.ok) return { ok: false, error: result?.error || 'Nothing to open' }
+
+  if (process.platform !== 'linux') {
+    if (!result.url) return { ok: false, error: 'That harness has no deep link to open on this platform' }
+    launch(result.url)
+    return { ok: true, url: result.url }
+  }
+
+  if (result.url && (await schemeHasHandler(result.url))) {
+    launch(result.url)
+    return { ok: true, url: result.url }
+  }
+  if (result.command) {
+    // Usually a page that predates this server, still holding refs without a cwd.
+    if (!result.command.cwd) return { ok: false, error: 'That thread has no folder on record to resume in' }
+    const cwd = await resolveFolder(result.command.cwd)
+    if (!cwd) return { ok: false, error: 'The folder that thread ran in is not on this machine any more' }
+    // A folder that exists but cannot be entered fails inside every terminal alike, and the
+    // terminal would get the blame; say what is actually wrong instead.
+    const enterable = await fsp.access(cwd, fsp.constants.X_OK).then(() => true, () => false)
+    if (!enterable) return { ok: false, error: 'The folder that thread ran in cannot be entered' }
+    return openInTerminal(result.command.argv, cwd)
+  }
+  const scheme = schemeOf(result.url)
+  return {
+    ok: false,
+    error: scheme
+      ? `Nothing on this machine opens ${scheme}:// links, and there is no CLI command to run instead`
+      : 'Nothing on this machine can open that',
+  }
+}
+
+/**
  * A folder is openable only if it is still on this machine and still a directory. Paths
  * arrive from the page, which got them from a scan that may be minutes old — a repo that
  * has since been moved or deleted must fail here rather than hand the opener a dead path.
@@ -199,7 +252,7 @@ function hostnameOf(value) {
  *     can then read every response. The rebound request still carries `Host: evil.com`.
  *   - **Origin** stops CSRF. A cross-site `fetch` with a `text/plain` body is not
  *     preflighted, so without this check any page you happened to be visiting could POST
- *     here — spawning sessions, opening Finder windows, or wiping the colony layout —
+ *     here — spawning sessions, opening file-manager windows, or wiping the colony layout —
  *     even though it could never read the reply.
  *
  * A state-changing request with no `Origin` at all is refused: browsers always send one on
@@ -267,9 +320,8 @@ export async function apiMiddleware(req, res, next) {
 
     if (url.pathname === '/api/open' && req.method === 'POST') {
       const { harness, ref } = await readJsonBody(req)
-      const result = harnessOpenThread(harness, ref)
-      if (result.ok) launch(result.url)
-      return send(res, result.ok ? 200 : 400, result)
+      const shown = await present(await harnessOpenThread(harness, ref))
+      return send(res, shown.ok ? 200 : 400, shown)
     }
 
     if ((url.pathname === '/api/new-session' || url.pathname === '/api/reveal') && req.method === 'POST') {
@@ -281,9 +333,8 @@ export async function apiMiddleware(req, res, next) {
         launch(dir)
         return send(res, 200, { ok: true })
       }
-      const result = harnessNewSession(harness || (await defaultHarness()), dir)
-      if (result.ok) launch(result.url)
-      return send(res, result.ok ? 200 : 400, result)
+      const shown = await present(await harnessNewSession(harness || (await defaultHarness()), dir))
+      return send(res, shown.ok ? 200 : 400, shown)
     }
 
     if (url.pathname === '/api/archive' && req.method === 'POST') {

--- a/server/harnesses/README.md
+++ b/server/harnesses/README.md
@@ -18,8 +18,8 @@ export default {
   name: 'My Harness',            // what a human sees in the UI
   detect,                        // () => Promise<boolean>
   scanThreads,                   // () => Promise<Thread[]>
-  openThread,                    // (ref) => { ok, url } | { ok: false, error }
-  newSession,                    // (dir) => { ok, url } | { ok: false, error }
+  openThread,                    // (ref) => { ok, url, command? } | { ok: false, error }   (may be async)
+  newSession,                    // (dir) => { ok, url, command? } | { ok: false, error }   (may be async)
   setArchived,                   // (ref, archived) => Promise<{ ok, error? }>
   appStartedAt,                  // optional: () => Promise<number>
 }
@@ -50,10 +50,29 @@ broken adapter costs you its own threads and nothing else. Prefer that over retu
 
 Return `{ ok: true, url }` and the server hands that URL to the OS opener. `openThread` gets
 the `ref` from the thread it belongs to; `newSession` gets an absolute directory that the
-server has already checked still exists.
+server has already checked still exists. Either may return a Promise.
 
-If your harness has no deep link, return `{ ok: false, error: '…' }` and say why — the UI
-shows the message rather than pretending the click worked.
+You can also offer the same action as a terminal command, alongside or instead of the URL:
+
+```js
+{
+  ok: true,
+  url: 'my-harness://resume/1234',
+  command: { argv: ['/usr/bin/my-harness', 'resume', '1234'], cwd: '/repo' },
+}
+```
+
+`command` is used when nothing on the machine answers the URL's scheme — today that means a
+Linux box where the harness's desktop app is not installed; macOS and Windows always hand the
+URL to the opener, so there a command-only harness gets an error back rather than a window.
+The server runs `argv` in a new terminal window with `cwd` as the working directory, after
+checking `cwd` the same way it checks any folder the page names. Build `argv` only from
+literals, ids that passed a strict pattern check, and a binary path you resolved yourself —
+never copy a `ref` field in verbatim, since a value that starts with `-` becomes a flag to
+your CLI.
+
+If your harness has neither, return `{ ok: false, error: '…' }` and say why — the UI shows the
+message rather than pretending the click worked.
 
 ### `setArchived(ref, archived)`
 
@@ -134,7 +153,8 @@ Verified on a real machine:
 
 - **Claude Code** — desktop records in
   `~/Library/Application Support/Claude/claude-code-sessions/<account>/<org>/local_*.json`
-  (`%APPDATA%\Claude\claude-code-sessions\…` on Windows); CLI transcripts in
+  (`%APPDATA%\Claude\claude-code-sessions\…` on Windows, `~/.config/Claude/claude-code-sessions/…`
+  on Linux); CLI transcripts in
   `~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl`; live processes in
   `~/.claude/sessions/*.json`. Implemented in `claude-code.mjs`.
 - **Codex CLI** — transcripts in `~/.codex/sessions/YYYY/MM/DD/rollout-<iso>-<uuid>.jsonl`,

--- a/server/harnesses/claude-code.mjs
+++ b/server/harnesses/claude-code.mjs
@@ -15,7 +15,7 @@ import path from 'node:path'
 import os from 'node:os'
 import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
-import { exists, jsonLines, listDirs, listFiles, num, readHead } from '../lib/fsutil.mjs'
+import { exists, findExecutable, jsonLines, listDirs, listFiles, num, readHead } from '../lib/fsutil.mjs'
 
 const execFileAsync = promisify(execFile)
 const HOME = os.homedir()
@@ -54,6 +54,10 @@ const ACTIVE_WINDOW_MS = 30 * 60 * 1000
 
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 const DESKTOP_ID = /^local_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+// The type check matters wherever an id came back from the page: `RegExp.test` stringifies, so
+// a one-element array holding a valid id would pass the pattern and then travel on as an array.
+const isCliId = (v) => typeof v === 'string' && UUID.test(v)
+const isDesktopId = (v) => typeof v === 'string' && DESKTOP_ID.test(v)
 
 function firstText(content) {
   if (typeof content === 'string') return content
@@ -238,15 +242,19 @@ function mergeThread(existing, next) {
  * Fold the adapter's private bookkeeping into the shape the rest of the app sees.
  * The session ids stay, but behind `ref` — an opaque blob the browser hands straight
  * back on open/archive, so nothing outside this file has to know what a Claude session
- * id looks like.
+ * id looks like. The cwd rides along because resuming from a terminal has to happen in
+ * the folder the session ran in — the worktree, not the repo root.
  */
 function toThread(t) {
-  const { desktopSessionId, desktopSessionIds, cliSessionId, bridgeSessionId, titled, hasLiveProcess, ...rest } = t
+  const {
+    desktopSessionId, desktopSessionIds, cliSessionId, cwdGuessed,
+    bridgeSessionId, titled, hasLiveProcess, ...rest
+  } = t
   return {
     ...rest,
-    canOpen: Boolean((desktopSessionId && DESKTOP_ID.test(desktopSessionId)) || (cliSessionId && UUID.test(cliSessionId))),
+    canOpen: isDesktopId(desktopSessionId) || isCliId(cliSessionId),
     canArchive: desktopSessionIds.length > 0,
-    ref: { desktopSessionId, desktopSessionIds, cliSessionId },
+    ref: { desktopSessionId, desktopSessionIds, cliSessionId, cwd: cwdGuessed ? '' : t.cwd || '' },
   }
 }
 
@@ -307,6 +315,9 @@ async function scanThreads() {
   for (const [id, entry] of transcripts) {
     if (claimed.has(id)) continue
     const meta = await transcriptMeta(entry)
+    // The decoded folder name is a guess (every dash became a slash), good enough to place the
+    // thread on the map but not to resume from: `claude --resume` in the wrong folder finds
+    // nothing. Only a cwd the transcript itself recorded goes into the ref.
     const cwd = meta.cwd || decodeProjectDir(path.basename(entry.projectDir))
     const { projectPath, project, worktree } = projectOf(cwd, '')
     add({
@@ -322,6 +333,7 @@ async function scanThreads() {
       projectPath,
       worktree,
       cwd,
+      cwdGuessed: !meta.cwd,
       gitBranch: meta.gitBranch,
       model: '',
       effort: '',
@@ -353,7 +365,7 @@ async function scanThreads() {
 
 /** Locate the desktop app's record for a session. Id is pattern-checked, never joined raw. */
 async function findSessionFile(sessionId) {
-  if (!DESKTOP_ID.test(sessionId)) return null
+  if (!isDesktopId(sessionId)) return null
   for (const account of await listDirs(DESKTOP_SESSIONS)) {
     for (const org of await listDirs(account)) {
       const file = path.join(org, `${sessionId}.json`)
@@ -403,29 +415,62 @@ async function setArchived(ref, archived) {
 }
 
 /**
+ * Where the `claude` CLI is, for a machine that has it but no desktop app to answer the deep
+ * link: PATH, then the places its installers put it. Only Linux asks; on macOS and Windows the
+ * deep link is always answered, so the walk would be wasted.
+ */
+const CLI_DIRS = [
+  path.join(HOME, '.local', 'bin'),
+  path.join(HOME, '.claude', 'local'),
+  '/usr/local/bin',
+  '/usr/bin',
+]
+const cliBinary = () => findExecutable('claude', CLI_DIRS)
+
+/** The terminal form of an action, for the server to fall back on. Only Linux has that path. */
+async function cliCommand(args, cwd) {
+  if (process.platform !== 'linux') return undefined
+  const bin = await cliBinary()
+  return bin ? { argv: [bin, ...args], cwd } : undefined
+}
+
+/**
  * Hands the thread back to Claude Code. `epitaxy/<local_…>` *navigates* the desktop app
  * to a thread it already has; `resume` *imports* the transcript, which spawns a second
  * untitled session and rewrites the .jsonl — so it is only ever the fallback for threads
  * the app has never seen. Ids are pattern-checked before they reach the opener.
+ *
+ * Alongside the URL, a CLI thread also offers `command`: the same resume done by running the
+ * CLI itself in a terminal, in the folder the session ran in. The server uses it only when
+ * nothing on the machine answers `claude://` — a Linux box with the CLI and no desktop app.
+ * The argv is built from the resolved binary and a pattern-checked id, never from `ref` raw.
  */
-function openThread(ref) {
-  const { desktopSessionId, cliSessionId } = ref || {}
-  if (desktopSessionId && DESKTOP_ID.test(desktopSessionId)) {
-    return { ok: true, url: `claude://claude.ai/epitaxy/${desktopSessionId}` }
+async function openThread(ref) {
+  const { desktopSessionId, cliSessionId, cwd } = ref || {}
+  let url = ''
+  if (isDesktopId(desktopSessionId)) {
+    url = `claude://claude.ai/epitaxy/${desktopSessionId}`
+  } else if (isCliId(cliSessionId)) {
+    url = `claude://resume?session=${cliSessionId}`
   }
-  if (cliSessionId && UUID.test(cliSessionId)) {
-    return { ok: true, url: `claude://resume?session=${cliSessionId}` }
-  }
-  return { ok: false, error: 'No openable session id on that thread' }
+
+  const command = isCliId(cliSessionId)
+    ? await cliCommand(['--resume', cliSessionId], typeof cwd === 'string' ? cwd : '')
+    : undefined
+
+  if (!url && !command) return { ok: false, error: 'No openable session id on that thread' }
+  return { ok: true, url, command }
 }
 
 /**
- * A brand new thread rooted in a repo — the same `code/new?folder=` deep link Finder's
- * "New Claude Code Session Here" quick action uses. Nothing is resumed and nothing is
- * written: the desktop app just opens an empty session with that folder as its workspace.
+ * A brand new thread rooted in a repo — the same `code/new?folder=` deep link the desktop
+ * app's "New Claude Code Session Here" action uses (a Finder quick action on macOS). Nothing
+ * is resumed and nothing is written: the desktop app just opens an empty session with that
+ * folder as its workspace. Without the app, the equivalent is the bare CLI in that folder.
  */
-function newSession(dir) {
-  return { ok: true, url: `claude://code/new?${new URLSearchParams({ folder: dir })}` }
+async function newSession(dir) {
+  const url = `claude://code/new?${new URLSearchParams({ folder: dir })}`
+  return { ok: true, url, command: await cliCommand([], dir) }
 }
 
 /**
@@ -440,7 +485,12 @@ async function appStartedAt() {
 
   let started = 0
   try {
-    started = process.platform === 'win32' ? await windowsAppStartedAt() : await darwinAppStartedAt()
+    // Linux stays at 0: the desktop app is optional there and its process shape has not
+    // been verified, and the one thing this feeds — `archivePending` — is not surfaced by the
+    // page. It used to fall into the macOS branch, a `ps` sweep every scan for a path that
+    // only exists inside a .app bundle.
+    if (process.platform === 'win32') started = await windowsAppStartedAt()
+    else if (process.platform !== 'linux') started = await darwinAppStartedAt()
   } catch {
     /* no process listing — treat the app as never having restarted */
   }

--- a/server/lib/fsutil.mjs
+++ b/server/lib/fsutil.mjs
@@ -1,5 +1,5 @@
 /**
- * Filesystem helpers shared by every harness adapter.
+ * Filesystem helpers shared by the harness adapters and the server.
  *
  * Nothing in here knows about a particular harness — an adapter is free to ignore the lot
  * and read its data however it likes. See `server/harnesses/README.md` for the contract.
@@ -63,6 +63,29 @@ export async function exists(p) {
   } catch {
     return false
   }
+}
+
+/**
+ * Where an executable is, as an absolute path, or null. PATH first, then `extraDirs` — the
+ * places an installer puts a binary that a server started with a thin PATH (an IDE launcher, a
+ * service unit) would not see. Candidates are resolved rather than joined: the caller may spawn
+ * from a different working directory than this check ran in, and a relative PATH entry would
+ * then name two different files. X_OK alone passes for a directory, hence the stat.
+ */
+export async function findExecutable(name, extraDirs = []) {
+  if (typeof name !== 'string' || !name) return null
+  const explicit = name.includes('/') || name.includes(path.sep)
+  const onPath = (process.env.PATH || '').split(path.delimiter).filter(Boolean)
+  for (const dir of explicit ? ['.'] : [...onPath, ...extraDirs]) {
+    const candidate = path.resolve(dir, name)
+    try {
+      await fsp.access(candidate, fsp.constants.X_OK)
+      if ((await fsp.stat(candidate)).isFile()) return candidate
+    } catch {
+      /* not here */
+    }
+  }
+  return null
 }
 
 export const num = (v) => {

--- a/server/lib/xdg.mjs
+++ b/server/lib/xdg.mjs
@@ -1,0 +1,212 @@
+/**
+ * Linux desktop plumbing: does anything on this machine answer a URL scheme, and how do you
+ * put a command in a terminal window here.
+ *
+ * Only `server/api.mjs` uses this, and only on Linux. It is split out because it is a page of
+ * desktop-environment trivia that has nothing to do with HTTP, and nothing in here knows about
+ * a particular harness — an adapter never imports it; it hands the server an argv and the
+ * server decides whether a terminal is the right place for it.
+ */
+import { execFile, spawn } from 'node:child_process'
+import fsp from 'node:fs/promises'
+import path from 'node:path'
+import { promisify } from 'node:util'
+import { findExecutable } from './fsutil.mjs'
+
+const execFileAsync = promisify(execFile)
+
+/** The scheme of a URL, or '' if it does not parse. */
+export function schemeOf(url) {
+  try {
+    return new URL(url).protocol.replace(/:$/, '')
+  } catch {
+    return ''
+  }
+}
+
+/**
+ * Is a desktop app registered for this URL's scheme?
+ *
+ * `xdg-mime query default x-scheme-handler/<scheme>` is what `xdg-open` itself consults. It
+ * checks that a `mimeapps.list` entry still points at an installed .desktop file, which is the
+ * common stale case — an uninstalled app leaves its line behind — though its `mimeinfo.cache`
+ * fallback takes an entry on trust, exactly as xdg-open would. Anything that stops the query
+ * (no xdg-mime at all, a non-zero exit) counts as "no handler": the alternative is handing
+ * xdg-open a URL nothing answers, which fails silently.
+ */
+export async function schemeHasHandler(url) {
+  const scheme = schemeOf(url)
+  if (!/^[a-z][a-z0-9+.-]*$/.test(scheme)) return false
+  try {
+    // Bounded: on KDE the query goes through the trader, which can sit on a D-Bus timeout.
+    const args = ['query', 'default', `x-scheme-handler/${scheme}`]
+    const { stdout } = await execFileAsync('xdg-mime', args, { timeout: 5000 })
+    return stdout.trim().length > 0
+  } catch {
+    return false
+  }
+}
+
+/**
+ * How each terminal wants "run this command in this directory". The command comes after the
+ * terminal's own end-of-options marker where it has one, so nothing in it is ever read as a
+ * flag; the working directory is also set on the spawn itself, which is all the xterm family
+ * needs and what the D-Bus terminals forward to their server anyway.
+ *
+ * Only terminals whose flags are documented are listed. `tilix` is deliberately absent: its
+ * `-e` takes one string that it re-splits itself, which would mean building a shell string.
+ */
+const TERMINALS = {
+  'gnome-terminal': (dir, cmd) => [`--working-directory=${dir}`, '--', ...cmd],
+  kgx: (dir, cmd) => [`--working-directory=${dir}`, '--', ...cmd],
+  ptyxis: (dir, cmd) => [`--working-directory=${dir}`, '--', ...cmd],
+  konsole: (dir, cmd) => ['--workdir', dir, '-e', ...cmd],
+  'xfce4-terminal': (dir, cmd) => [`--working-directory=${dir}`, '-x', ...cmd],
+  'mate-terminal': (dir, cmd) => [`--working-directory=${dir}`, '-x', ...cmd],
+  kitty: (dir, cmd) => [`--directory=${dir}`, ...cmd],
+  alacritty: (dir, cmd) => ['--working-directory', dir, '-e', ...cmd],
+  ghostty: (dir, cmd) => [`--working-directory=${dir}`, '-e', ...cmd],
+  wezterm: (dir, cmd) => ['start', '--cwd', dir, '--', ...cmd],
+  foot: (dir, cmd) => [`--working-directory=${dir}`, ...cmd],
+  terminator: (dir, cmd) => [`--working-directory=${dir}`, '-x', ...cmd],
+  xterm: (_dir, cmd) => ['-e', ...cmd],
+  uxterm: (_dir, cmd) => ['-e', ...cmd],
+  urxvt: (_dir, cmd) => ['-e', ...cmd],
+  rxvt: (_dir, cmd) => ['-e', ...cmd],
+  st: (_dir, cmd) => ['-e', ...cmd],
+}
+
+const GENERAL_ORDER = [
+  'gnome-terminal', 'konsole', 'xfce4-terminal', 'mate-terminal', 'kitty', 'alacritty', 'ghostty',
+  'wezterm', 'foot', 'terminator', 'ptyxis', 'kgx', 'xterm', 'uxterm', 'urxvt', 'rxvt', 'st',
+]
+
+/**
+ * A terminal that ships with the desktop first. `XDG_CURRENT_DESKTOP` is a colon list, such as
+ * `ubuntu:GNOME`, and GNOME gets the three it has shipped over the years in the order they are
+ * most likely to be the one actually configured.
+ */
+function desktopOrder() {
+  const parts = (process.env.XDG_CURRENT_DESKTOP || '').toLowerCase().split(':')
+  if (parts.includes('kde')) return ['konsole']
+  if (parts.includes('xfce')) return ['xfce4-terminal']
+  if (parts.includes('mate')) return ['mate-terminal']
+  if (parts.some((p) => ['gnome', 'ubuntu', 'unity', 'cinnamon', 'x-cinnamon'].includes(p))) {
+    return ['gnome-terminal', 'kgx', 'ptyxis']
+  }
+  return []
+}
+
+/**
+ * Is there anywhere for a window to appear? Deliberately loose: only the plainly headless case
+ * is refused here, so that it gets a message that says so; anything less clear-cut is left to
+ * the launch itself, whose exit code is the real answer. Wayland clients find their socket
+ * without the variable being set, so the runtime dir is checked too.
+ */
+async function hasDisplay() {
+  if (process.env.DISPLAY || process.env.WAYLAND_DISPLAY) return true
+  const run = process.env.XDG_RUNTIME_DIR
+  if (!run) return false
+  try {
+    return (await fsp.readdir(run)).some((name) => name.startsWith('wayland-'))
+  } catch {
+    return false
+  }
+}
+
+/**
+ * A terminal that refuses does so at once — well under 50 ms on a GNOME desktop — while a
+ * window takes longer than this to come up. A refusal slower than this is knowingly reported
+ * as a success: the alternative, treating every late non-zero exit as a failure, would open a
+ * second terminal whenever the command inside the first one ended quickly.
+ */
+const REFUSAL_MS = 300
+/** After this a foreground terminal (xterm, Debian's `--wait` wrapper) is plainly up: let it run. */
+const GRACE_MS = 1500
+
+/**
+ * Spawn a terminal and say whether it actually came up. The D-Bus terminals hand the window
+ * to a service and exit 0 at once; when they cannot — no display, a flag they reject — they
+ * exit non-zero just as fast, and that is the failure worth reporting instead of a toast that
+ * says "opened". A non-zero exit that arrives *later* is different: the window came up and the
+ * command inside it has ended, which is the user's to see and no reason to open a second
+ * terminal on top of it.
+ */
+function trySpawn(cmd, args, cwd) {
+  return new Promise((resolve) => {
+    let child
+    try {
+      child = spawn(cmd, args, { cwd, stdio: 'ignore', detached: true })
+    } catch (err) {
+      resolve({ ok: false, error: err?.message || String(err) })
+      return
+    }
+    const startedAt = Date.now()
+    let timer = null
+    let settled = false
+    const done = (result) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      resolve(result)
+    }
+    child.on('error', (err) => done({ ok: false, error: err?.message || String(err) }))
+    child.on('exit', (code, signal) => {
+      if (code === 0 || Date.now() - startedAt >= REFUSAL_MS) return done({ ok: true })
+      const how = signal ? `signal ${signal}` : `code ${code}`
+      done({ ok: false, error: `${path.basename(cmd)} exited with ${how}` })
+    })
+    timer = setTimeout(() => {
+      child.unref()
+      done({ ok: true })
+    }, GRACE_MS)
+  })
+}
+
+/**
+ * Run `argv` in a new terminal window with `cwd` as its working directory.
+ *
+ * The caller has already resolved both: `argv[0]` is an absolute executable and `cwd` an
+ * existing directory. Which terminal is up to the machine — `$TERMINAL` if set, then the
+ * desktop's own, then whatever is installed, then Debian's `x-terminal-emulator` alternative.
+ * That last one is tried by name and given `-e`, the one form Debian policy guarantees, because
+ * on Ubuntu it is a wrapper script that knows no other flags — pass it `--working-directory`
+ * and it opens an empty window. It is also why a real `gnome-terminal` is looked for first.
+ *
+ * A `$TERMINAL` the table does not know is skipped rather than guessed at: `-e` means "the rest
+ * of the line" to xterm and "one string, which I will split" to tilix, and guessing wrong opens
+ * a window on the wrong command, which is worse than moving on to a terminal we do know.
+ */
+export async function openInTerminal(argv, cwd) {
+  const wellFormed = Array.isArray(argv) && argv.length > 0 && argv.every((a) => typeof a === 'string' && a)
+  if (!wellFormed || !path.isAbsolute(argv[0]) || typeof cwd !== 'string' || !path.isAbsolute(cwd)) {
+    return { ok: false, error: 'Invalid launch command' }
+  }
+  if (!(await hasDisplay())) return { ok: false, error: 'No graphical display to open a terminal on' }
+
+  const preferred = [process.env.TERMINAL || '', ...desktopOrder(), ...GENERAL_ORDER, 'x-terminal-emulator']
+  const names = [...new Set(preferred.filter(Boolean))]
+  const tried = new Set()
+  let lastError = ''
+  for (const name of names) {
+    const resolved = await findExecutable(name)
+    if (!resolved || tried.has(resolved)) continue
+    tried.add(resolved)
+
+    const base = path.basename(name)
+    let args
+    if (base === 'x-terminal-emulator') args = ['-e', ...argv]
+    else if (TERMINALS[base]) args = TERMINALS[base](cwd, argv)
+    else continue
+
+    const result = await trySpawn(resolved, args, cwd)
+    if (result.ok) return { ok: true }
+    lastError = result.error
+  }
+  return {
+    ok: false,
+    error: lastError
+      ? `Could not open a terminal (${lastError})`
+      : 'No terminal emulator found — set $TERMINAL or install one (gnome-terminal, konsole, kitty, xterm)',
+  }
+}

--- a/src/ui/hud.js
+++ b/src/ui/hud.js
@@ -764,7 +764,8 @@ function statusClass(status) {
  * leading `~`, so the trim is done here and the whole path lives in the title attribute.
  */
 function shortPath(dir, max = 30) {
-  const home = dir.replace(/^\/Users\/[^/]+/, '~')
+  // Home is /Users/you on macOS and /home/you (or /root) on Linux; either becomes `~`.
+  const home = dir.replace(/^(?:\/Users|\/home)\/[^/]+(?=\/|$)|^\/root(?=\/|$)/, '~')
   if (home.length <= max) return home
   const parts = home.split('/')
   let out = parts.pop() || ''
@@ -889,7 +890,7 @@ const TEMPLATE = `
 <div class="help">
   <div class="sheet panel">
     <h2>Bot Crossing</h2>
-    <p class="sub">Every coding-agent thread on this Mac is an astronaut. They walk out of the ship, claim a plot for their repo, and build. Click one to open its thread; click a zone — its deck or its name — for the repo itself, and start a new conversation there. Navigation works like Google Earth — drag the ground itself, right-drag to tilt, scroll to zoom in on whatever is under the cursor.</p>
+    <p class="sub">Every coding-agent thread on this machine is an astronaut. They walk out of the ship, claim a plot for their repo, and build. Click one to open its thread; click a zone — its deck or its name — for the repo itself, and start a new conversation there. Navigation works like Google Earth — drag the ground itself, right-drag to tilt, scroll to zoom in on whatever is under the cursor.</p>
     <div class="cols">
       <div>
         <div class="k"><span>Drag the ground</span><kbd>drag</kbd></div>


### PR DESCRIPTION
## Open threads on Linux without the desktop app

**What this does: adds Linux support for the half that was missing.** Bot Crossing already
scanned threads and opened folders on Linux; after this, **Open** and **New conversation** work
there too, with or without the Claude desktop app installed. Built and verified on Ubuntu 24.04
(GNOME) with only the Claude Code CLI. **macOS and Windows are unchanged**, and were checked
against `main` to be — see "Nothing else changed" below.

Linux already scanned and could reveal folders, but **Open** and **New conversation** handed a
`claude://` link to `xdg-open`, and on a box with only the CLI nothing answers that scheme:
`xdg-open` exits 4, the spawn error is swallowed, and the page toasts "Opened in Claude Code". The README
admitted it — "opening a thread has nothing to reach yet".

Now the server asks `xdg-mime` whether anything handles the URL's scheme. If so, the link goes to
the app exactly as before. If not, the harness's own CLI runs in a new terminal window, in the
folder the session ran in: `claude --resume <id>` for a thread, a bare `claude` for a new
conversation. If neither is possible the page gets a 400 with a reason, never a false "opened".
macOS and Windows keep the opener argv they had: nothing is probed there and the adapter never
builds a command.

One commit on top of current `main` (through "Run on Windows too"); the tree is clean and
`npm run build` passes on it.

Against the ground rules in CONTRIBUTING: one thing (opening on Linux, and the copy that said
it could not); no new dependencies; nothing new is written to disk — the only writes remain
`data/colony.json` and the one archive flag, and the new code only spawns. Under `src/` the
change is three lines in `src/ui/hud.js` (a home-directory regex with its comment, and a word of
help text), named below, because a Linux user reading "…/Desktop/dev/foo" and "this Mac" seemed
worse than touching the client.

### What changed

- **Opener** (`server/api.mjs`): `present()` sits between an adapter's `{ ok, url, command }` and
  the page. Off Linux it hands `url` to `launch()` as before. On Linux it first asks
  `schemeHasHandler(url)`; failing that it runs `command.argv` in a terminal, after
  `resolveFolder(command.cwd)` — the same check every folder the page names gets, with no
  fallback directory on purpose: `claude --resume` looks a session up under the folder it ran
  in, and a terminal that opens on "No conversation found" and closes is worse than an error
  toast. Failing both, a 400 that names the scheme. `/api/open` and `/api/new-session` now
  `await` the adapter.
- **Linux plumbing** (`server/lib/xdg.mjs`, new): `schemeHasHandler` runs
  `xdg-mime query default x-scheme-handler/<scheme>`, bounded at 5 s; anything that stops the
  query counts as "no handler", since the alternative is handing `xdg-open` a URL nobody
  answers. `openInTerminal` picks a terminal — `$TERMINAL` if it is in the table, then the
  desktop's own (from `XDG_CURRENT_DESKTOP`), then whatever is installed, then Debian's
  `x-terminal-emulator` with `-e`, the one form its wrapper understands — and gives each one
  `--` where it has one, and the working directory the way it documents it. Nothing is ever a
  shell string; a `$TERMINAL` the table does not know is skipped rather than guessed at. A
  non-zero exit within 300 ms is a refusal and is reported; later than that the window came up
  and the command inside it ended, so no second terminal is tried. A plainly headless box (no
  `DISPLAY`, no `WAYLAND_DISPLAY`, no wayland socket in `XDG_RUNTIME_DIR`) is refused with a
  message before anything is spawned.
- **Shared helper** (`server/lib/fsutil.mjs`): `findExecutable(name, extraDirs)` — PATH walk
  with absolute results and an `isFile` check — used by both the terminal picker and the
  Claude adapter.
- **Adapter contract** (`server/harnesses/README.md`, the skill's `harness-adapters.md`):
  `openThread` / `newSession` may return `command: { argv, cwd }` alongside `url`, and may be
  async. Both are optional; a URL-only adapter needs no change.
- **Claude Code adapter** (`server/harnesses/claude-code.mjs`): resolves the CLI binary (PATH,
  then `~/.local/bin`, `~/.claude/local`, `/usr/local/bin`, `/usr/bin`) and, on Linux only,
  offers `[claude, --resume, <id>]` for a CLI thread and `[claude]` for a new session. `ref` now
  carries the thread's `cwd`, because `--resume` looks a session up under the folder it ran in
  — the worktree, not the repo root. A cwd that had to be guessed from the encoded folder name
  (a transcript with no cwd record; every dash becomes a slash) is not offered for resume at
  all, since the wrong folder finds nothing. Ids are type-checked as well as pattern-checked
  (`RegExp.test` stringifies, so a one-element array holding a valid id used to pass).
  `appStartedAt()` no longer runs the macOS `ps` sweep on Linux — it grepped for a `.app` path
  and always returned 0.
- **Copy** (`README.md`, `CONTRIBUTING.md`, `package.json`, `src/ui/hud.js`): "this Mac" becomes
  "this machine"; the project card abbreviates `/home/you` and `/root` to `~` the way it already
  did `/Users/you`; the README now says the folder button reads Files on Linux (the label itself
  already did); CONTRIBUTING's "Linux and Windows support" wanted-item becomes "Platform edges",
  pointing at the terminal table.

### What I verified, and how

Ubuntu 24.04 (GNOME, X11), Claude Code CLI 2.1.260 at `~/.local/bin/claude`, no desktop app,
Node 20:

- 38 threads scan. `GET /api/threads`, `/api/harnesses` and `/api/state` compared structurally
  against a `main` worktree on the same data: the only difference is `ref.cwd` on each thread.
  Latency of `/api/threads` is unchanged (about 3 ms on both).
- `xdg-mime query default x-scheme-handler/…` answers: `claude` → nothing (this box has a stale
  `claude=com.anthropic.Claude.desktop` line in `mimeapps.list` whose .desktop file is gone, and
  `xdg-mime` correctly ignores it), `claude-cli` → `claude-code-url-handler.desktop`, `http` →
  `google-chrome.desktop`.
- Through the running server with `Origin` set: `POST /api/open` on an idle CLI thread opened
  `gnome-terminal` in that thread's own folder with `claude --resume <id>` running;
  `POST /api/new-session` opened a bare `claude` in the target folder.
- Error paths, each a 400 with a message rather than a 200: a desktop-only ref (no CLI id, so
  nothing to run), a folder that no longer exists, an array-typed id, a ref with no `cwd`, and a
  headless environment (`DISPLAY` and `WAYLAND_DISPLAY` unset). Same requests against `main`
  return 200 and hand `xdg-open` a URL nothing answers.
- The Linux-with-desktop-app path, simulated with an `xdg-mime` shim that reports a handler and
  an `xdg-open` shim that logs: the URL is launched and no terminal is attempted.
- macOS and Windows: `process.platform` overridden to `darwin` and `win32` with `open` and
  `rundll32` shims on PATH, driving `/api/open`, `/api/new-session` and `/api/reveal` on `main`
  and on this branch. Opener argv and response bodies are byte-identical, except that an
  array-typed id is now refused (see below). `command` never appears in a response.
- The built page in headless Chrome, branch against `main`: zero console errors or warnings on
  either; the project card shows `~/Desktop/…` where `main` showed `…/Desktop/…`; the Open
  button is enabled on a selected thread; the folder button reads Files.
- A bare `curl` POST without `Origin` is still refused; so are a rebound `Host` and a foreign
  `Origin`.
- `npm run build` passes; `node --check` on the changed server files passes;
  `git diff --check` is clean; no semicolons, single quotes, 2-space indent.

**Not verified:** macOS and Windows on real hardware (no machine here) — they were simulated,
see below. Of the terminal table only `gnome-terminal` was actually opened; the other entries
follow each terminal's documented flags (kgx, ptyxis and foot were checked against their
sources). KDE, XFCE, Wayland-only desktops and the `x-terminal-emulator` fallback were not
exercised.

### Nothing else changed

Everything below was run against a worktree of `main` on the same data, side by side with this
branch, so it does not rest on reading the diff:

- **macOS and Windows**: `process.platform` forced to `darwin` and then `win32`, with `open` and
  `rundll32` shims on PATH that record what they are handed, driving `/api/open`,
  `/api/new-session` and `/api/reveal` on both servers. Opener argv and response bodies are
  byte-identical to `main`. The adapter never builds a `command` off Linux and no response ever
  carries one. The single divergence is the array-typed id now being refused (listed under
  "Behaviour changes").
- **Scanning**: `GET /api/threads`, `/api/harnesses` and `/api/state` from both servers,
  structurally diffed: the only difference is the new `ref.cwd` key on each thread. Same 38
  threads, same ids, same fields otherwise; latency unchanged at about 3 ms.
- **The page**: built from both branches and loaded in headless Chrome. Zero console errors or
  warnings on either. Repo list, project panel, thread card, Open and Archive buttons behave the
  same; the only visible differences are the `~/…` path and the help-sheet wording.
- **Security**: a POST without `Origin`, a rebound `Host`, and a foreign `Origin` are all refused
  with 403 exactly as on `main`; `PUT /api/state` round-trips; nothing new is written to disk.
- **Linux with the desktop app** (simulated with an `xdg-mime` shim that reports a handler and an
  `xdg-open` shim that logs): the `claude://` URL is launched exactly as before, and no terminal
  is attempted.
- **Archive round trip and reconcile** (synthetic desktop records, since this box has none):
  archive, unarchive and the re-assert-on-scan path return the same responses as `main`.

### Behaviour changes

- On Linux, a thread only the desktop app could open (desktop record, no CLI transcript) now
  gets a **400** — "Nothing on this machine opens claude:// links, and there is no CLI command
  to run instead" — when no handler is registered, instead of a 200 and a toast for a window
  that never opened. Likewise a folder that has vanished or cannot be entered, a headless
  session, and a ref with no `cwd` (a page loaded before this server, or a transcript whose
  folder could only be guessed).
- On every platform, an id that is not a string (an array holding one) is now refused with a
  400 rather than stringified into a URL.
- On every platform, each thread's `ref` in `/api/threads` gains a `cwd` field. `ref` is opaque
  to the page and handed back as-is; nothing under `src/` reads it.
- Other adapters on Linux: one that returns only a URL (Codex's `codex://…` in #5) gets the same
  400 when nothing handles its scheme — before, the click silently "succeeded". Hermes (#7)
  already returns `ok: false` from both and is unaffected.

### QA checklist

Run on the final commit by a nine-lens regression — API, unit edges, macOS/Windows simulation,
production server, browser, real launches, docs, style, and a completeness pass over the other
eight — each against a `main` worktree on the same data. About 260 individual checks; the
high-level view:

**Nothing else broke**
- [x] `/api/threads`, `/api/harnesses`, `/api/state` identical to `main` except `ref.cwd`
  (38 threads); `PUT /api/state` round-trips; `/api/archive`, `/api/reveal`, 404s, wrong
  methods, malformed JSON and oversized bodies all answer exactly as on `main`
- [x] Origin and Host checks refuse exactly as on `main` — no Origin, `Origin: null`, foreign
  Origin, rebound Host — on the dev and production servers, including `BOT_CROSSING_HOST` bound
  to a LAN address
- [x] macOS and Windows: opener argv and response bodies byte-identical to `main` (`open` and
  `rundll32` shims, platform overridden); `xdg-mime` never consulted there; no response carries
  `command`
- [x] Production server: static files, cache headers, SPA fallback, path traversal, HEAD, `PORT`
  — identical headers and bodies to `main`
- [x] Page in headless Chrome, both builds: zero console errors, warnings or failed requests;
  repo list, project panel, thread card, Open and Archive buttons, help sheet, keys (H, S, Esc)
  and resize behave as on `main`; the built bundle differs only in the `~` regex and one word
- [x] `GET /api/threads` latency unchanged (about 3 ms); ten concurrent opens, no cross-talk
- [x] Archive and reconcile paths (synthetic desktop records) answer as on `main`
- [x] No test wrote to the real `data/colony.json` or to the Claude data directory

**The new Linux path**
- [x] Real launch on this desktop: `POST /api/open` resumed an idle thread in gnome-terminal in
  its own folder; `POST /api/new-session` opened a bare `claude` in the target folder; both
  processes had the right cwd; no residue under `~/.claude/projects`
- [x] Linux with a `claude://` handler registered (shimmed `xdg-mime`): the URL is launched and
  no terminal is attempted
- [x] Honest 400s where `main` returned 200 and launched nothing: desktop-only thread, vanished
  folder, folder that is a file or cannot be entered, array-typed id, ref without cwd, headless
  session, no terminal installed
- [x] Terminal picking: desktop order from `XDG_CURRENT_DESKTOP`, `$TERMINAL` honoured when known
  and skipped when not (tilix), `x-terminal-emulator` given `-e` and Debian's wrapper shown to
  translate it; every argv element reaches the terminal verbatim (spaces, dashes, umlauts)
- [x] Refusal versus late exit: a fast non-zero exit moves to the next terminal, a late one counts
  as opened, no leaked timers; `xdg-mime` bounded at 5 s and a failing `xdg-mime` counts as no
  handler
- [x] Every new or changed function edge-cased directly: `schemeOf`, `schemeHasHandler`,
  `findExecutable` (relative PATH entries, a directory named like the binary, non-executables,
  non-strings), `openInTerminal` guards, `present` on all three platforms, `openThread` and
  `newSession` for every ref shape, the id type checks, `shortPath` (every `/Users` input
  unchanged)
- [x] Table entries for terminals not installed here checked against their sources or manuals
  (kgx, ptyxis, foot, ghostty, kitty, alacritty, wezterm, konsole, xfce4-terminal,
  mate-terminal, terminator)

**Hygiene**
- [x] Diff is exactly ten files; no new dependencies; lockfile untouched; nothing new written to
  disk
- [x] Style: no semicolons, single quotes, 2-space indent, added lines within ~110 columns,
  `git diff --check` clean, `node --check` on every changed file, no unused imports, no sync fs
  calls, `npm run build` and `npm run dev` start clean
- [x] Every claim in the commit message, this description, README, CONTRIBUTING and the harness
  README checked against the code; README anchors resolve; no "this Mac" left anywhere
- [x] Overlap with open PRs #5, #7, #8, #9, #10 re-checked by `merge-tree`: all clean except the
  one `hud.js` line in #8

**Not covered**
- [ ] macOS and Windows on real hardware (simulated only)
- [ ] Terminals other than gnome-terminal actually opened; KDE, XFCE and Wayland-only desktops;
  the `x-terminal-emulator` fallback end to end
- [ ] `claude --resume` from a non-matching folder (would launch the CLI); the KDE trader path
  of `xdg-mime`

**Found on the way — pre-existing, identical on `main`, deliberately not touched here**
- `GET /%` (a malformed percent-escape) throws inside the request handler in `server/serve.mjs`
  and takes the production server down; a try/catch around `decodeURIComponent` would fix it.
  Worth its own small PR.
- An unknown or missing `harness` on `/api/open` answers 500 rather than 400, and a body over
  4 MB drops the connection instead of returning the 500 the code intends.

### Overlaps with

Checked by merging each open PR's head onto this branch (`git merge-tree --write-tree`) and by
`git apply --3way` in both orders:

- **#8 Hide repos from the colony** — `README.md`, `package.json`, `server/api.mjs` merge
  clean; **one conflict** in `src/ui/hud.js`, the help sheet's `<p class="sub">` line, where
  this branch changes "this Mac" to "this machine" and #8 inserts a sentence about hiding repos.
  Whoever lands second keeps both. Same single conflict in the other order.
- **#10** — `server/api.mjs`, different functions (state read / `PUT /api/state` vs. the
  opener); merges clean.
- **#9** — `server/harnesses/claude-code.mjs`, different functions (`desktopDataDir` vs.
  `openThread` / `newSession`); merges clean.
- **#5 Add Codex harness support** — `README.md`, `server/harnesses/README.md`, different
  sections; merges clean.
- **#7 Add Hermes Agent harness adapter** — `package.json`, a different key; merges clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Hu4ye8G9LaHCJkHqLnMoY
