### PR TITLE
Add Codex CLI harness support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,19 +31,18 @@ written down here.
 
 ## What is most worth contributing
 
-**Harness adapters, by a wide margin.** Right now Bot Crossing only reads Claude Code. The
-whole point of the seam in `server/harnesses/` is that adding Codex CLI, OpenCode, Antigravity,
-Amp, or anything else should be one new file and one line in a registry.
+**Harness adapters, by a wide margin.** Bot Crossing currently reads Claude Code and Codex CLI.
+The whole point of the seam in `server/harnesses/` is that adding OpenCode, Antigravity, Amp,
+or anything else should be one new file and one line in a registry.
 
 Everything you need is in **[`server/harnesses/README.md`](server/harnesses/README.md)** — the
 interface, the thread shape, the ground rules, and how to find where a given harness keeps its
 sessions on disk.
 
-One caveat worth knowing before you start: **the interface has only ever been implemented once**,
-by the Claude Code adapter it was extracted from. It is very likely the first genuinely different
-harness will not fit perfectly. If yours does not, that is a bug in the seam and not in your
-work — say so in the PR and change what you need to. I would much rather widen the interface
-than have you contort an adapter around it.
+One caveat worth knowing before you start: **the interface began with Claude Code and still has
+only two implementations**. A genuinely different harness may not fit perfectly. If yours does
+not, that is a bug in the seam and not in your work — say so in the PR and change what you need
+to. I would much rather widen the interface than have you contort an adapter around it.
 
 Also useful:
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ somebody writing that adapter.
 | Harness | Status |
 | --- | --- |
 | **[Claude Code](https://claude.com/claude-code)** (Anthropic) | ✅ **Supported** — desktop app and CLI, including worktrees, live-process detection and archiving |
-| [Codex CLI](https://developers.openai.com/codex/cli) (OpenAI) | ⬜ Not yet — transcripts found at `~/.codex/sessions/`, [notes here](server/harnesses/README.md#starting-points) |
+| **[Codex CLI](https://developers.openai.com/codex/cli)** (OpenAI) | ✅ **Supported** — local discovery and opening in the Codex VS Code extension; new sessions, native archiving, and exact process state are not yet available ([details](docs/adapter-investigation.md)) |
 | [OpenCode](https://opencode.ai) | ⬜ Not yet |
 | [Antigravity CLI](https://antigravity.google) (Google) | ⬜ Not yet — the successor to Gemini CLI, which Google stopped serving individual accounts on 18 June 2026 |
 | [Cursor](https://cursor.com) (`cursor-agent`) | ⬜ Not yet |

--- a/docs/adapter-investigation.md
+++ b/docs/adapter-investigation.md
@@ -40,12 +40,12 @@ Read-only inspection of an installed Codex extension found:
 
 ## Known limitations
 
-- Sessions with UUID thread IDs can open in the installed OpenAI VS Code extension through its verified `vscode://openai.chatgpt/local/<thread-id>` route. The server hands this route to Windows through PowerShell when running under WSL, to `open(1)` on macOS, or to `xdg-open` on native Linux.
+- Sessions with UUID thread IDs open through the installed extension's verified `openai-codex://route/local/<thread-id>` custom-editor URI. The server invokes the VS Code CLI with that URI; `BOT_CROSSING_CODE_CLI` may specify the CLI path when `code` is not on `PATH` (as with a desktop-launched WSL server).
 - Creating sessions is disabled for the same reason.
 - Native archiving is disabled (`canArchive: false`) because no Codex archive field or supported mutation was found. Bot Crossing's own colony archive state remains separate.
 - Running and error states are conservative transcript-based inferences, not direct process state.
 - Worktree identity and focus/unread state are unavailable from the verified records.
-- Session scanning works with the verified Linux/WSL storage path. Codex thread opening is supported in Windows VS Code from WSL; other cross-platform harness handoffs remain dependent on their registered URI handlers.
+- Session scanning works with the verified Linux/WSL storage path. Codex thread opening is supported in the connected WSL VS Code window when its CLI and IPC environment are available; other cross-platform harness handoffs remain dependent on their registered URI handlers.
 
 The selected-thread card displays the adapter's generic `harnessName`, so Codex and Claude sessions are distinguishable without adding harness-specific frontend branches.
 

--- a/docs/adapter-investigation.md
+++ b/docs/adapter-investigation.md
@@ -1,0 +1,54 @@
+# Codex CLI adapter investigation
+
+This document records the evidence used for the Codex CLI harness adapter. No private transcript content, credentials, or personal conversation data is included.
+
+## Repository architecture
+
+- `server/harnesses/index.mjs` is the registry. A registered adapter supplies `id`, `name`, `detect`, `scanThreads`, `openThread`, `newSession`, and `setArchived`; `appStartedAt` is optional.
+- `server/scan.mjs` asks each detected harness for normalized threads, isolates adapter failures, adds harness identity, and sorts the merged result. The browser requests `/api/threads` at boot, every 15 seconds, on window focus, and when a hidden tab becomes visible.
+- `server/api.mjs` exposes the merged data and delegates open/archive requests to the originating adapter. The existing opener uses macOS `open(1)` with a URL returned by an adapter.
+- The browser consumes the normalized shape rather than harness-specific records. Colony layout/archive state is separate from a harness's own archive state.
+- `server/lib/fsutil.mjs` provides bounded head reads, tolerant JSONL parsing, directory listing, and existence checks.
+
+The normalized fields are documented in `server/harnesses/README.md`. Important behavioral fields include globally unique `id`, timestamps in epoch milliseconds, exact `sizeBytes`, capability flags, and an opaque `ref` returned to the adapter.
+
+## Codex storage findings
+
+Read-only inspection of an installed Codex extension found:
+
+- Sessions under `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`.
+- An optional `~/.codex/session_index.jsonl`, with records containing `id`, `thread_name`, and `updated_at`.
+- Transcript envelopes shaped as `{ timestamp, type, payload }`.
+- `session_meta` provides a session identifier, creation timestamp, working directory, and sometimes Git metadata.
+- `turn_context` provides current working directory, model, and effort.
+- User messages are `response_item` records whose payload is a `message` with role `user`.
+- Lifecycle records are `event_msg` payloads including `task_started`, `task_complete`, and `turn_aborted`.
+- Installed CLI help verifies `codex resume [SESSION_ID]`. Inspection of the installed OpenAI VS Code extension also verifies its registered URI handler and `/local/:conversationId` route.
+
+## Implemented mapping
+
+`server/harnesses/codex-cli.mjs` discovers every dated rollout file and returns one thread per valid session:
+
+- Title prefers the session index, then the first user message, then `Untitled thread`.
+- Preview is a whitespace-normalized, length-limited first user message.
+- Project path is the nearest ancestor containing `.git`, falling back to the recorded working directory.
+- Model, effort, branch, and creation time come from transcript metadata when present.
+- Transcript size is the file's exact stat size. Activity is the newer of transcript mtime and index update time.
+- A thread is running only when the latest lifecycle record is `task_started` and activity is less than five minutes old. This is deliberately an inference: Codex exposes no verified process-to-session mapping.
+- A latest `turn_aborted` marks `hasError`; unread is always false because Codex focus/read state is unavailable.
+- Parsing reads bounded head and tail chunks, caches unchanged files, skips malformed records, and never writes Codex data.
+
+## Known limitations
+
+- Sessions with UUID thread IDs can open in the installed OpenAI VS Code extension through its verified `vscode://openai.chatgpt/local/<thread-id>` route. The server hands this route to Windows through PowerShell when running under WSL, to `open(1)` on macOS, or to `xdg-open` on native Linux.
+- Creating sessions is disabled for the same reason.
+- Native archiving is disabled (`canArchive: false`) because no Codex archive field or supported mutation was found. Bot Crossing's own colony archive state remains separate.
+- Running and error states are conservative transcript-based inferences, not direct process state.
+- Worktree identity and focus/unread state are unavailable from the verified records.
+- Session scanning works with the verified Linux/WSL storage path. Codex thread opening is supported in Windows VS Code from WSL; other cross-platform harness handoffs remain dependent on their registered URI handlers.
+
+The selected-thread card displays the adapter's generic `harnessName`, so Codex and Claude sessions are distinguishable without adding harness-specific frontend branches.
+
+## Validation
+
+The adapter has fixture-based tests for normalized metadata, project-root discovery, exact sizing, recent/old lifecycle state, aborted state, malformed JSONL, missing storage, and unsupported actions. Run them with `npm test` or directly with `node --test server/harnesses/codex-cli.test.mjs`.

--- a/docs/adapter-investigation.md
+++ b/docs/adapter-investigation.md
@@ -41,7 +41,7 @@ Read-only inspection of an installed Codex extension found:
 
 ## Known limitations
 
-- Sessions whose metadata identifies a `codex_vscode` origin and a UUID thread ID open through the installed extension's verified `openai-codex://route/local/<thread-id>` custom-editor URI. The server invokes the VS Code CLI with that URI and supplies the session working directory as `BOT_CROSSING_THREAD_CWD`; `BOT_CROSSING_CODE_CLI` may point to a host-specific bridge when `code` is not on `PATH` or VS Code must first be launched (as with a desktop-launched WSL server).
+- Sessions whose metadata identifies a `codex_vscode` origin and a UUID thread ID open through the installed extension's verified `openai-codex://route/local/<thread-id>` custom-editor URI. The server invokes the VS Code CLI's `--file-uri` path with that URI and supplies the session working directory as `BOT_CROSSING_THREAD_CWD`; `BOT_CROSSING_CODE_CLI` may point to a host-specific bridge when `code` is not on `PATH` or VS Code must first be launched (as with a desktop-launched WSL server).
 - Other origins are not forced into VS Code. Their Open action remains disabled until that originating client exposes a verified resume mechanism; this prevents a CLI or standalone-app session from being sent to the wrong interface.
 - Creating sessions is disabled for the same reason.
 - Native archiving is disabled (`canArchive: false`) because no Codex archive field or supported mutation was found. Bot Crossing's own colony archive state remains separate.

--- a/docs/adapter-investigation.md
+++ b/docs/adapter-investigation.md
@@ -20,6 +20,7 @@ Read-only inspection of an installed Codex extension found:
 - An optional `~/.codex/session_index.jsonl`, with records containing `id`, `thread_name`, and `updated_at`.
 - Transcript envelopes shaped as `{ timestamp, type, payload }`.
 - `session_meta` provides a session identifier, creation timestamp, working directory, and sometimes Git metadata.
+- `session_meta.originator` identifies the creating client and is used for opener selection; `source` alone is not sufficient.
 - `turn_context` provides current working directory, model, and effort.
 - User messages are `response_item` records whose payload is a `message` with role `user`.
 - Lifecycle records are `event_msg` payloads including `task_started`, `task_complete`, and `turn_aborted`.
@@ -40,7 +41,8 @@ Read-only inspection of an installed Codex extension found:
 
 ## Known limitations
 
-- Sessions with UUID thread IDs open through the installed extension's verified `openai-codex://route/local/<thread-id>` custom-editor URI. The server invokes the VS Code CLI with that URI; `BOT_CROSSING_CODE_CLI` may specify the CLI path when `code` is not on `PATH` (as with a desktop-launched WSL server).
+- Sessions whose metadata identifies a `codex_vscode` origin and a UUID thread ID open through the installed extension's verified `openai-codex://route/local/<thread-id>` custom-editor URI. The server invokes the VS Code CLI with that URI and supplies the session working directory as `BOT_CROSSING_THREAD_CWD`; `BOT_CROSSING_CODE_CLI` may point to a host-specific bridge when `code` is not on `PATH` or VS Code must first be launched (as with a desktop-launched WSL server).
+- Other origins are not forced into VS Code. Their Open action remains disabled until that originating client exposes a verified resume mechanism; this prevents a CLI or standalone-app session from being sent to the wrong interface.
 - Creating sessions is disabled for the same reason.
 - Native archiving is disabled (`canArchive: false`) because no Codex archive field or supported mutation was found. Bot Crossing's own colony archive state remains separate.
 - Running and error states are conservative transcript-based inferences, not direct process state.

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "build": "npm run assets --silent && vite build",
     "start": "vite build && node server/serve.mjs",
     "serve": "node server/serve.mjs",
-    "assets": "node tools/build-assets.mjs"
+    "assets": "node tools/build-assets.mjs",
+    "test": "node --test server/harnesses/*.test.mjs"
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",

--- a/server/api.mjs
+++ b/server/api.mjs
@@ -80,7 +80,6 @@ async function writeState(next) {
 }
 
 /**
-/**
  * Hand a `harness://…` deep link, or a folder, to whatever opens things on this OS. The
  * opener gets an argument list, never a shell string.
  *
@@ -104,10 +103,24 @@ const OPENERS = {
 }
 
 function launch(target) {
-  const opener = OPENERS[process.platform]
-  if (!opener) return
-  const [cmd, ...args] = opener
-  const child = spawn(cmd, [...args, target], { stdio: 'ignore', detached: true })
+  let [command, ...args] = OPENERS[process.platform] || []
+  let options = { stdio: 'ignore', detached: true }
+
+  if (process.platform === 'linux' && process.env.WSL_DISTRO_NAME) {
+    if (String(target).startsWith('vscode://')) {
+      command = 'powershell.exe'
+      args = ['-NoProfile', '-Command', 'Start-Process -FilePath $env:BOT_CROSSING_LAUNCH_TARGET']
+      options = { ...options, env: { ...process.env, BOT_CROSSING_LAUNCH_TARGET: target } }
+    } else {
+      command = 'explorer.exe'
+      args = [target]
+    }
+  } else {
+    args.push(target)
+  }
+
+  if (!command) return
+  const child = spawn(command, args, options)
   child.on('error', () => {})
   child.unref()
 }

--- a/server/api.mjs
+++ b/server/api.mjs
@@ -108,7 +108,7 @@ function launch(target, context = {}) {
 
   if (String(target).startsWith('openai-codex://')) {
     command = process.env.BOT_CROSSING_CODE_CLI || 'code'
-    args = ['--reuse-window', target]
+    args = ['--file-uri', target]
     options = {
       ...options,
       env: { ...process.env, BOT_CROSSING_THREAD_CWD: context.cwd || '' },

--- a/server/api.mjs
+++ b/server/api.mjs
@@ -106,15 +106,12 @@ function launch(target) {
   let [command, ...args] = OPENERS[process.platform] || []
   let options = { stdio: 'ignore', detached: true }
 
-  if (process.platform === 'linux' && process.env.WSL_DISTRO_NAME) {
-    if (String(target).startsWith('vscode://')) {
-      command = 'powershell.exe'
-      args = ['-NoProfile', '-Command', 'Start-Process -FilePath $env:BOT_CROSSING_LAUNCH_TARGET']
-      options = { ...options, env: { ...process.env, BOT_CROSSING_LAUNCH_TARGET: target } }
-    } else {
-      command = 'explorer.exe'
-      args = [target]
-    }
+  if (String(target).startsWith('openai-codex://')) {
+    command = process.env.BOT_CROSSING_CODE_CLI || 'code'
+    args = ['--reuse-window', target]
+  } else if (process.platform === 'linux' && process.env.WSL_DISTRO_NAME) {
+    command = 'explorer.exe'
+    args = [target]
   } else {
     args.push(target)
   }

--- a/server/api.mjs
+++ b/server/api.mjs
@@ -102,13 +102,17 @@ const OPENERS = {
   linux: ['xdg-open'],
 }
 
-function launch(target) {
+function launch(target, context = {}) {
   let [command, ...args] = OPENERS[process.platform] || []
   let options = { stdio: 'ignore', detached: true }
 
   if (String(target).startsWith('openai-codex://')) {
     command = process.env.BOT_CROSSING_CODE_CLI || 'code'
     args = ['--reuse-window', target]
+    options = {
+      ...options,
+      env: { ...process.env, BOT_CROSSING_THREAD_CWD: context.cwd || '' },
+    }
   } else if (process.platform === 'linux' && process.env.WSL_DISTRO_NAME) {
     command = 'explorer.exe'
     args = [target]
@@ -278,7 +282,7 @@ export async function apiMiddleware(req, res, next) {
     if (url.pathname === '/api/open' && req.method === 'POST') {
       const { harness, ref } = await readJsonBody(req)
       const result = harnessOpenThread(harness, ref)
-      if (result.ok) launch(result.url)
+      if (result.ok) launch(result.url, result)
       return send(res, result.ok ? 200 : 400, result)
     }
 

--- a/server/harnesses/README.md
+++ b/server/harnesses/README.md
@@ -138,8 +138,10 @@ Verified on a real machine:
   `~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl`; live processes in
   `~/.claude/sessions/*.json`. Implemented in `claude-code.mjs`.
 - **Codex CLI** — transcripts in `~/.codex/sessions/YYYY/MM/DD/rollout-<iso>-<uuid>.jsonl`,
-  with records shaped `{ timestamp, type, payload }`, and what looks like an index at
-  `~/.codex/session_index.jsonl`. Not implemented yet.
+  with records shaped `{ timestamp, type, payload }`, plus an optional index at
+  `~/.codex/session_index.jsonl`. Implemented read-only in `codex-cli.mjs`; see
+  [`docs/adapter-investigation.md`](../../docs/adapter-investigation.md) for verified fields
+  and capability limitations.
 
 For anything else, the fastest way in is usually to start a throwaway session in that harness
 and watch which files change:
@@ -150,8 +152,7 @@ find ~ -maxdepth 4 -newermt '-2 minutes' -type f 2>/dev/null | grep -iv Library/
 
 ## Checking your work
 
-There is no test suite to run yet. What the Claude Code adapter was verified against, and what
-a new one should clear too:
+The Codex adapter has fixture-based tests (`npm test`). A new adapter should also clear:
 
 1. `node --check server/harnesses/my-harness.mjs`
 2. With the app running, `GET /api/harnesses` lists every registered harness and whether

--- a/server/harnesses/codex-cli.mjs
+++ b/server/harnesses/codex-cli.mjs
@@ -177,7 +177,7 @@ export function createCodexHarness({ codexHome = path.join(os.homedir(), '.codex
       if (!SESSION_ID_RE.test(ref?.sessionId || '')) {
         return { ok: false, error: 'This Codex session does not have a valid thread ID.' }
       }
-      return { ok: true, url: `vscode://openai.chatgpt/local/${ref.sessionId}` }
+      return { ok: true, url: `openai-codex://route/local/${ref.sessionId}` }
     },
     newSession: () => ({ ok: false, error: 'Codex has no verified desktop deep link. Start it in a terminal from the project folder.' }),
     setArchived: async () => ({ ok: false, error: 'Codex does not expose a native session archive operation.' }),

--- a/server/harnesses/codex-cli.mjs
+++ b/server/harnesses/codex-cli.mjs
@@ -64,7 +64,7 @@ async function readIndex(file) {
 }
 
 function inspect(records) {
-  const result = { sessionId: '', cwd: '', gitBranch: '', model: '', effort: '', createdAt: 0, prompt: '', lifecycle: '' }
+  const result = { sessionId: '', cwd: '', gitBranch: '', model: '', effort: '', originator: '', sessionSource: '', createdAt: 0, prompt: '', lifecycle: '' }
   for (const record of records) {
     const payload = record?.payload
     if (!payload || typeof payload !== 'object') continue
@@ -72,6 +72,8 @@ function inspect(records) {
       result.sessionId ||= payload.id || payload.session_id || ''
       result.cwd ||= payload.cwd || ''
       result.gitBranch ||= payload.git?.branch || ''
+      result.originator ||= payload.originator || ''
+      result.sessionSource ||= payload.source || ''
       result.createdAt ||= timestamp(payload.timestamp || record.timestamp)
       result.model ||= payload.model || payload.model_provider || ''
     } else if (record.type === 'turn_context') {
@@ -156,10 +158,10 @@ export function createCodexHarness({ codexHome = path.join(os.homedir(), '.codex
           prState: '',
           archived: false,
           sizeBytes: stat.size,
-          source: 'cli',
-          canOpen: SESSION_ID_RE.test(session.sessionId),
+          source: session.originator.startsWith('codex_vscode') ? 'vscode' : session.sessionSource || 'cli',
+          canOpen: SESSION_ID_RE.test(session.sessionId) && session.originator.startsWith('codex_vscode'),
           canArchive: false,
-          ref: { sessionId: session.sessionId, cwd },
+          ref: { sessionId: session.sessionId, cwd, originator: session.originator },
         })
       } catch {
         // Partially written or malformed transcripts must not break a scan.
@@ -170,14 +172,21 @@ export function createCodexHarness({ codexHome = path.join(os.homedir(), '.codex
 
   return {
     id: 'codex-cli',
-    name: 'Codex CLI',
+    name: 'Codex',
     detect: async () => await exists(sessionsDir),
     scanThreads,
     openThread: (ref) => {
       if (!SESSION_ID_RE.test(ref?.sessionId || '')) {
         return { ok: false, error: 'This Codex session does not have a valid thread ID.' }
       }
-      return { ok: true, url: `openai-codex://route/local/${ref.sessionId}` }
+      if (!String(ref?.originator || '').startsWith('codex_vscode')) {
+        return { ok: false, error: 'No verified opener is available for this Codex session origin.' }
+      }
+      return {
+        ok: true,
+        url: `openai-codex://route/local/${ref.sessionId}`,
+        cwd: ref.cwd && path.isAbsolute(ref.cwd) ? ref.cwd : '',
+      }
     },
     newSession: () => ({ ok: false, error: 'Codex has no verified desktop deep link. Start it in a terminal from the project folder.' }),
     setArchived: async () => ({ ok: false, error: 'Codex does not expose a native session archive operation.' }),

--- a/server/harnesses/codex-cli.mjs
+++ b/server/harnesses/codex-cli.mjs
@@ -1,0 +1,187 @@
+/** Read-only adapter for Codex CLI's local JSONL session transcripts. */
+import fsp from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
+import { exists, jsonLines, listDirs, listFiles, readHead } from '../lib/fsutil.mjs'
+
+const HEAD_BYTES = 256 * 1024
+const TAIL_BYTES = 256 * 1024
+const ACTIVE_WINDOW_MS = 5 * 60 * 1000
+const SESSION_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+function timestamp(value, fallback = 0) {
+  const parsed = new Date(value).getTime()
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
+function contentText(content) {
+  if (typeof content === 'string') return content
+  if (!Array.isArray(content)) return ''
+  return content.map((part) => typeof part === 'string' ? part : part?.text || part?.input_text || '').filter(Boolean).join('\n')
+}
+
+const clean = (value) => String(value || '').replace(/\s+/g, ' ').trim().slice(0, 240)
+
+async function readTail(file, size) {
+  if (size <= TAIL_BYTES) return await fsp.readFile(file, 'utf8')
+  const handle = await fsp.open(file, 'r')
+  try {
+    const buffer = Buffer.alloc(TAIL_BYTES)
+    await handle.read(buffer, 0, TAIL_BYTES, size - TAIL_BYTES)
+    const text = buffer.toString('utf8')
+    const newline = text.indexOf('\n')
+    return newline < 0 ? '' : text.slice(newline + 1)
+  } finally {
+    await handle.close()
+  }
+}
+
+async function findTranscripts(root) {
+  const found = []
+  for (const year of await listDirs(root)) {
+    for (const month of await listDirs(year)) {
+      for (const day of await listDirs(month)) {
+        found.push(...await listFiles(day, (name) => /^rollout-.*\.jsonl$/.test(name)))
+      }
+    }
+  }
+  return found
+}
+
+async function readIndex(file) {
+  const result = new Map()
+  try {
+    for (const row of jsonLines(await fsp.readFile(file, 'utf8'))) {
+      if (!row?.id) continue
+      const old = result.get(row.id)
+      if (!old || timestamp(row.updated_at) >= timestamp(old.updated_at)) result.set(row.id, row)
+    }
+  } catch {
+    // The index is optional; transcripts are authoritative.
+  }
+  return result
+}
+
+function inspect(records) {
+  const result = { sessionId: '', cwd: '', gitBranch: '', model: '', effort: '', createdAt: 0, prompt: '', lifecycle: '' }
+  for (const record of records) {
+    const payload = record?.payload
+    if (!payload || typeof payload !== 'object') continue
+    if (record.type === 'session_meta') {
+      result.sessionId ||= payload.id || payload.session_id || ''
+      result.cwd ||= payload.cwd || ''
+      result.gitBranch ||= payload.git?.branch || ''
+      result.createdAt ||= timestamp(payload.timestamp || record.timestamp)
+      result.model ||= payload.model || payload.model_provider || ''
+    } else if (record.type === 'turn_context') {
+      result.cwd = payload.cwd || result.cwd
+      result.model = payload.model || result.model
+      result.effort = payload.effort || result.effort
+    } else if (record.type === 'response_item' && payload.type === 'message' && payload.role === 'user') {
+      result.prompt ||= clean(contentText(payload.content))
+    } else if (record.type === 'event_msg') {
+      if (payload.type === 'task_started') result.lifecycle = 'running'
+      if (payload.type === 'task_complete') result.lifecycle = 'complete'
+      if (payload.type === 'turn_aborted') result.lifecycle = 'aborted'
+    }
+  }
+  return result
+}
+
+async function findGitRoot(cwd, cache) {
+  if (!cwd || !path.isAbsolute(cwd)) return ''
+  if (cache.has(cwd)) return cache.get(cwd)
+  let current = cwd
+  while (true) {
+    if (await exists(path.join(current, '.git'))) {
+      cache.set(cwd, current)
+      return current
+    }
+    const parent = path.dirname(current)
+    if (parent === current) break
+    current = parent
+  }
+  cache.set(cwd, '')
+  return ''
+}
+
+export function createCodexHarness({ codexHome = path.join(os.homedir(), '.codex'), now = () => Date.now(), activeWindowMs = ACTIVE_WINDOW_MS } = {}) {
+  const sessionsDir = path.join(codexHome, 'sessions')
+  const indexFile = path.join(codexHome, 'session_index.jsonl')
+  const parseCache = new Map()
+  const rootCache = new Map()
+
+  async function parse(file, stat) {
+    const cached = parseCache.get(file)
+    if (cached?.mtimeMs === stat.mtimeMs && cached?.size === stat.size) return cached.value
+    const head = await readHead(file, HEAD_BYTES)
+    const tail = stat.size > HEAD_BYTES ? await readTail(file, stat.size) : ''
+    const value = inspect([...jsonLines(head), ...jsonLines(tail)])
+    parseCache.set(file, { mtimeMs: stat.mtimeMs, size: stat.size, value })
+    return value
+  }
+
+  async function scanThreads() {
+    const index = await readIndex(indexFile)
+    const threads = []
+    for (const file of await findTranscripts(sessionsDir)) {
+      try {
+        const stat = await fsp.stat(file)
+        const session = await parse(file, stat)
+        if (!session.sessionId) continue
+        const indexed = index.get(session.sessionId)
+        const cwd = session.cwd && path.isAbsolute(session.cwd) ? session.cwd : ''
+        const projectPath = (await findGitRoot(cwd, rootCache)) || cwd
+        const lastActivityAt = Math.max(stat.mtimeMs, timestamp(indexed?.updated_at))
+        threads.push({
+          id: `codex-cli:${session.sessionId}`,
+          title: clean(indexed?.thread_name) || session.prompt || 'Untitled thread',
+          preview: session.prompt,
+          project: projectPath ? path.basename(projectPath) : '',
+          projectPath,
+          worktree: '',
+          cwd,
+          gitBranch: session.gitBranch,
+          model: session.model,
+          effort: session.effort,
+          createdAt: session.createdAt || stat.birthtimeMs || stat.ctimeMs,
+          lastActivityAt,
+          lastFocusedAt: 0,
+          running: session.lifecycle === 'running' && now() - lastActivityAt <= activeWindowMs,
+          unread: false,
+          hasError: session.lifecycle === 'aborted',
+          starred: false,
+          routine: '',
+          prState: '',
+          archived: false,
+          sizeBytes: stat.size,
+          source: 'cli',
+          canOpen: SESSION_ID_RE.test(session.sessionId),
+          canArchive: false,
+          ref: { sessionId: session.sessionId, cwd },
+        })
+      } catch {
+        // Partially written or malformed transcripts must not break a scan.
+      }
+    }
+    return threads
+  }
+
+  return {
+    id: 'codex-cli',
+    name: 'Codex CLI',
+    detect: async () => await exists(sessionsDir),
+    scanThreads,
+    openThread: (ref) => {
+      if (!SESSION_ID_RE.test(ref?.sessionId || '')) {
+        return { ok: false, error: 'This Codex session does not have a valid thread ID.' }
+      }
+      return { ok: true, url: `vscode://openai.chatgpt/local/${ref.sessionId}` }
+    },
+    newSession: () => ({ ok: false, error: 'Codex has no verified desktop deep link. Start it in a terminal from the project folder.' }),
+    setArchived: async () => ({ ok: false, error: 'Codex does not expose a native session archive operation.' }),
+  }
+}
+
+export default createCodexHarness()

--- a/server/harnesses/codex-cli.test.mjs
+++ b/server/harnesses/codex-cli.test.mjs
@@ -108,7 +108,7 @@ test('builds the verified VS Code route for a valid Codex thread ID', () => {
   const sessionId = '12345678-1234-4abc-8def-123456789abc'
   assert.deepEqual(harness.openThread({ sessionId }), {
     ok: true,
-    url: `vscode://openai.chatgpt/local/${sessionId}`,
+    url: `openai-codex://route/local/${sessionId}`,
   })
   assert.equal(harness.openThread({ sessionId: 'not-a-session' }).ok, false)
 })

--- a/server/harnesses/codex-cli.test.mjs
+++ b/server/harnesses/codex-cli.test.mjs
@@ -26,7 +26,7 @@ async function fixture(records, { indexed = true } = {}) {
 
 test('normalizes a recent running Codex transcript', async (t) => {
   const data = await fixture([
-    line('session_meta', { id: 'session-1', cwd: '/placeholder', timestamp: '2026-09-04T11:00:00.000Z', git: { branch: 'feature/codex' } }),
+    line('session_meta', { id: 'session-1', cwd: '/placeholder', originator: 'codex_vscode', source: 'exec', timestamp: '2026-09-04T11:00:00.000Z', git: { branch: 'feature/codex' } }),
     line('response_item', { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'Build a small adapter.' }] }),
     line('turn_context', { cwd: '/placeholder', model: 'gpt-test', effort: 'high' }),
     line('event_msg', { type: 'task_started' }),
@@ -52,7 +52,8 @@ test('normalizes a recent running Codex transcript', async (t) => {
   assert.equal(thread.canOpen, false)
   assert.equal(thread.canArchive, false)
   assert.equal(thread.sizeBytes, stat.size)
-  assert.deepEqual(thread.ref, { sessionId: 'session-1', cwd: data.project })
+  assert.equal(thread.source, 'vscode')
+  assert.deepEqual(thread.ref, { sessionId: 'session-1', cwd: data.project, originator: 'codex_vscode' })
 })
 
 test('skips malformed records and does not call an old unfinished task running', async (t) => {
@@ -106,9 +107,12 @@ test('handles an absent Codex installation and unsupported actions', async (t) =
 test('builds the verified VS Code route for a valid Codex thread ID', () => {
   const harness = createCodexHarness()
   const sessionId = '12345678-1234-4abc-8def-123456789abc'
-  assert.deepEqual(harness.openThread({ sessionId }), {
+  assert.deepEqual(harness.openThread({ sessionId, originator: 'codex_vscode' }), {
     ok: true,
     url: `openai-codex://route/local/${sessionId}`,
+    cwd: '',
   })
+  assert.equal(harness.openThread({ sessionId, cwd: '/tmp/project', originator: 'codex_vscode' }).cwd, '/tmp/project')
   assert.equal(harness.openThread({ sessionId: 'not-a-session' }).ok, false)
+  assert.equal(harness.openThread({ sessionId, originator: 'codex_cli' }).ok, false)
 })

--- a/server/harnesses/codex-cli.test.mjs
+++ b/server/harnesses/codex-cli.test.mjs
@@ -1,0 +1,114 @@
+import assert from 'node:assert/strict'
+import fsp from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+
+import { createCodexHarness } from './codex-cli.mjs'
+
+const line = (type, payload, timestamp = '2026-09-04T12:00:00.000Z') => JSON.stringify({ timestamp, type, payload })
+
+async function fixture(records, { indexed = true } = {}) {
+  const root = await fsp.mkdtemp(path.join(os.tmpdir(), 'bot-crossing-codex-'))
+  const codexHome = path.join(root, '.codex')
+  const day = path.join(codexHome, 'sessions', '2026', '09', '04')
+  const project = path.join(root, 'project', 'nested')
+  await fsp.mkdir(day, { recursive: true })
+  await fsp.mkdir(project, { recursive: true })
+  await fsp.writeFile(path.join(root, 'project', '.git'), 'gitdir: elsewhere\n')
+  const file = path.join(day, 'rollout-example.jsonl')
+  await fsp.writeFile(file, `${records.join('\n')}\n`)
+  if (indexed) {
+    await fsp.writeFile(path.join(codexHome, 'session_index.jsonl'), `${JSON.stringify({ id: 'session-1', thread_name: 'Indexed title', updated_at: '2026-09-04T12:01:00.000Z' })}\n`)
+  }
+  return { root, codexHome, project, file }
+}
+
+test('normalizes a recent running Codex transcript', async (t) => {
+  const data = await fixture([
+    line('session_meta', { id: 'session-1', cwd: '/placeholder', timestamp: '2026-09-04T11:00:00.000Z', git: { branch: 'feature/codex' } }),
+    line('response_item', { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'Build a small adapter.' }] }),
+    line('turn_context', { cwd: '/placeholder', model: 'gpt-test', effort: 'high' }),
+    line('event_msg', { type: 'task_started' }),
+  ])
+  t.after(() => fsp.rm(data.root, { recursive: true, force: true }))
+  const raw = await fsp.readFile(data.file, 'utf8')
+  await fsp.writeFile(data.file, raw.replaceAll('/placeholder', data.project))
+  const stat = await fsp.stat(data.file)
+
+  const harness = createCodexHarness({ codexHome: data.codexHome, now: () => stat.mtimeMs + 1000 })
+  assert.equal(await harness.detect(), true)
+  const [thread] = await harness.scanThreads()
+  assert.equal(thread.id, 'codex-cli:session-1')
+  assert.equal(thread.title, 'Indexed title')
+  assert.equal(thread.preview, 'Build a small adapter.')
+  assert.equal(thread.projectPath, path.join(data.root, 'project'))
+  assert.equal(thread.cwd, data.project)
+  assert.equal(thread.gitBranch, 'feature/codex')
+  assert.equal(thread.model, 'gpt-test')
+  assert.equal(thread.effort, 'high')
+  assert.equal(thread.running, true)
+  assert.equal(thread.unread, false)
+  assert.equal(thread.canOpen, false)
+  assert.equal(thread.canArchive, false)
+  assert.equal(thread.sizeBytes, stat.size)
+  assert.deepEqual(thread.ref, { sessionId: 'session-1', cwd: data.project })
+})
+
+test('skips malformed records and does not call an old unfinished task running', async (t) => {
+  const data = await fixture([
+    '{not-json',
+    line('session_meta', { id: 'session-1', cwd: '/tmp/project' }),
+    line('event_msg', { type: 'task_started' }),
+  ], { indexed: false })
+  t.after(() => fsp.rm(data.root, { recursive: true, force: true }))
+  const harness = createCodexHarness({ codexHome: data.codexHome, now: () => Date.now() + 10 * 60 * 1000 })
+  const [thread] = await harness.scanThreads()
+  assert.equal(thread.running, false)
+  assert.equal(thread.title, 'Untitled thread')
+})
+
+test('reports the latest aborted lifecycle as an error', async (t) => {
+  const data = await fixture([
+    line('session_meta', { id: 'session-1', cwd: '/tmp/project' }),
+    line('event_msg', { type: 'task_started' }),
+    line('event_msg', { type: 'turn_aborted' }),
+  ])
+  t.after(() => fsp.rm(data.root, { recursive: true, force: true }))
+  const [thread] = await createCodexHarness({ codexHome: data.codexHome }).scanThreads()
+  assert.equal(thread.running, false)
+  assert.equal(thread.hasError, true)
+})
+
+test('reads lifecycle state from the tail of a large transcript', async (t) => {
+  const data = await fixture([
+    line('session_meta', { id: 'session-1', cwd: '/tmp/project' }),
+    line('event_msg', { type: 'task_started' }),
+    line('response_item', { type: 'reasoning', content: 'x'.repeat(300 * 1024) }),
+    line('event_msg', { type: 'task_complete' }),
+  ])
+  t.after(() => fsp.rm(data.root, { recursive: true, force: true }))
+  const [thread] = await createCodexHarness({ codexHome: data.codexHome }).scanThreads()
+  assert.equal(thread.running, false)
+})
+
+test('handles an absent Codex installation and unsupported actions', async (t) => {
+  const root = await fsp.mkdtemp(path.join(os.tmpdir(), 'bot-crossing-codex-missing-'))
+  t.after(() => fsp.rm(root, { recursive: true, force: true }))
+  const harness = createCodexHarness({ codexHome: path.join(root, '.codex') })
+  assert.equal(await harness.detect(), false)
+  assert.deepEqual(await harness.scanThreads(), [])
+  assert.equal(harness.openThread({}).ok, false)
+  assert.equal(harness.newSession('/tmp').ok, false)
+  assert.equal((await harness.setArchived({}, true)).ok, false)
+})
+
+test('builds the verified VS Code route for a valid Codex thread ID', () => {
+  const harness = createCodexHarness()
+  const sessionId = '12345678-1234-4abc-8def-123456789abc'
+  assert.deepEqual(harness.openThread({ sessionId }), {
+    ok: true,
+    url: `vscode://openai.chatgpt/local/${sessionId}`,
+  })
+  assert.equal(harness.openThread({ sessionId: 'not-a-session' }).ok, false)
+})

--- a/server/harnesses/index.mjs
+++ b/server/harnesses/index.mjs
@@ -7,8 +7,9 @@
  * `server/harnesses/README.md`.
  */
 import claudeCode from './claude-code.mjs'
+import codexCli from './codex-cli.mjs'
 
-export const HARNESSES = [claudeCode]
+export const HARNESSES = [claudeCode, codexCli]
 
 export const harnessById = (id) => HARNESSES.find((h) => h.id === id) || null
 

--- a/src/ui/hud.js
+++ b/src/ui/hud.js
@@ -503,6 +503,7 @@ export class Hud {
       `<span class="tag"><i class="swatch" style="background:${hex(agent.trim.getHex())}"></i>${escapeHtml(status)}</span>`,
     ]
     // The repo is the panel's own heading now, so the card says what the *thread* is.
+    if (thread.harnessName) bits.push(`<span class="tag">${escapeHtml(thread.harnessName)}</span>`)
     if (thread.worktree) bits.push(`<span class="tag">⑂ ${escapeHtml(thread.worktree)}</span>`)
     if (thread.gitBranch) bits.push(`<span class="tag">${escapeHtml(thread.gitBranch)}</span>`)
     if (thread.model) bits.push(`<span class="tag">${escapeHtml(shortModel(thread.model))}</span>`)


### PR DESCRIPTION
## Summary

- add a read-only Codex CLI harness for local JSONL sessions
- normalize Codex metadata, activity, transcript size, project roots, and conservative status inference
- open UUID-backed Codex sessions in the installed OpenAI VS Code extension, including WSL-to-Windows handoff
- display the originating harness in the selected-thread card
- document verified storage details and unsupported capabilities

## Safety and limitations

- session data is never modified
- malformed and partially written JSONL records are skipped
- native Codex archiving and new-session launching remain disabled
- running/error status is a conservative transcript-based inference
- no private session content or machine-specific launcher paths are included

## Validation

- `npm test` — 6 passing
- `npm run build` — passing (existing Vite chunk-size warning only)
- live scan against 4 local Codex sessions — all normalized with unique IDs
- `git diff --check` — passing