### PR TITLE
Add a Cursor harness adapter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ written down here.
 
 ## What is most worth contributing
 
-**Harness adapters, by a wide margin.** Right now Bot Crossing only reads Claude Code. The
+**Harness adapters, by a wide margin.** Right now Bot Crossing reads Claude Code and Cursor. The
 whole point of the seam in `server/harnesses/` is that adding Codex CLI, OpenCode, Antigravity,
 Amp, or anything else should be one new file and one line in a registry.
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ Every coding-agent thread on this Mac is a little astronaut. They walk out of th
 a plot for their repo, and build something. When one needs you it stops and holds a `?` over
 its head; click it and the thread opens back in whichever harness it came from.
 
-It reads the harness's own files, on your own machine. Nothing is uploaded, there is no
-account, and the only thing it ever writes back is a single archive flag.
+It reads the harness's own files, on your own machine. Nothing is uploaded and there is no
+account. It writes its own colony state and harness integration state; the complete list is
+in [Keeping it local](#keeping-it-local).
 
 > **Status:** published as-is. I built this for myself and cannot promise to maintain it —
 > issues and PRs are welcome but may go unanswered, and forking is an entirely reasonable
@@ -24,11 +25,9 @@ second process. For a built version, `npm start` (build + serve) or `npm run ser
 `dist/` already exists. Binds to `127.0.0.1` by default, and answers only its own page — see
 [Keeping it local](#keeping-it-local).
 
-**macOS, Linux and Windows.** Opening a thread, revealing a folder and starting a new session
-all go through a `harness://` deep link handed to the OS opener — `open(1)` on macOS,
-`xdg-open` on Linux, ShellExecute on Windows. The scanning half was portable already. Note that
-the deep link needs a desktop app registered for that scheme, so on Linux the folder buttons
-work while opening a thread has nothing to reach yet.
+**macOS, Linux and Windows.** Reveal and deep-link actions use `open(1)` on macOS, `xdg-open`
+on Linux, and ShellExecute on Windows. A harness may instead open through its own CLI: Cursor
+does this so it can route to the right workspace and agent thread.
 
 ## Which harnesses work
 
@@ -42,7 +41,7 @@ somebody writing that adapter.
 | [Codex CLI](https://developers.openai.com/codex/cli) (OpenAI) | ⬜ Not yet — transcripts found at `~/.codex/sessions/`, [notes here](server/harnesses/README.md#starting-points) |
 | [OpenCode](https://opencode.ai) | ⬜ Not yet |
 | [Antigravity CLI](https://antigravity.google) (Google) | ⬜ Not yet — the successor to Gemini CLI, which Google stopped serving individual accounts on 18 June 2026 |
-| [Cursor](https://cursor.com) (`cursor-agent`) | ⬜ Not yet |
+| **[Cursor](https://cursor.com)** (IDE + `cursor-agent`) | ✅ **Supported** — composer chats via `state.vscdb`, transcripts under `~/.cursor/projects`, archive flag, Open jumps to that composer |
 | [Amp](https://ampcode.com) (Sourcegraph) | ⬜ Not yet |
 | [Aider](https://aider.chat) | ⬜ Not yet |
 | [Goose](https://block.github.io/goose/) (Block) | ⬜ Not yet |
@@ -596,11 +595,19 @@ What it touches on disk, in full:
 | | |
 | --- | --- |
 | Reads | Your harness's own session records and transcripts |
-| Writes | `data/colony.json`, and **one** `isArchived` field per archived thread |
+| Writes | `data/colony.json`; one harness archive flag per archived thread; for Cursor Open, the `bot-crossing.cursor-open` helper extension and mode-0600 request/ack files under `~/.cursor/` |
 | Sends | Nothing. No network calls, no telemetry, no account |
 
 `data/colony.json` holds the names and paths of the repos you work in, so it is gitignored —
 worth knowing before you copy one into an issue.
+
+Cursor has no public deep link for an existing local agent thread. On first use of Cursor
+Open, Bot Crossing builds a four-file helper VSIX in the OS temporary directory, installs it
+through Cursor's CLI, and deletes the VSIX. The helper validates a UUID, restricts the request
+to the exact workspace path, calls Cursor's internal `composer.focusComposer` command, and
+acknowledges the request. It makes no network calls and can be removed like any Cursor
+extension. A newly installed helper may require one Cursor window reload before the first
+thread jump.
 
 ## Layout
 
@@ -609,6 +616,7 @@ server/
   harnesses/   one adapter per agent harness — README.md is the contract
     index.mjs    the registry: add your harness to the list here
     claude-code.mjs
+    cursor.mjs
   lib/         filesystem helpers the adapters share
   scan.mjs     harness-agnostic: asks every detected harness, merges, sorts
   api.mjs      /api/threads, /api/harnesses, /api/state, /api/open, /api/archive,

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "vite": "^7.1.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.13"
       }
     },
     "node_modules/@emnapi/runtime": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "visualization"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=22.13"
   },
   "os": [
     "darwin",

--- a/server/api.mjs
+++ b/server/api.mjs
@@ -80,7 +80,6 @@ async function writeState(next) {
 }
 
 /**
-/**
  * Hand a `harness://…` deep link, or a folder, to whatever opens things on this OS. The
  * opener gets an argument list, never a shell string.
  *
@@ -91,6 +90,9 @@ async function writeState(next) {
  * <url>` silently drops any URL that carries a query string, so `code/new?folder=…` never
  * arrived, and `cmd /c start` parses its own argument line, where the `%3A%5C` escapes in that
  * same link are exactly what it expands.
+ *
+ * An adapter may omit `url` after opening the thread itself (the Cursor adapter does this).
+ * `launch` is then a no-op.
  *
  * The spawn is guarded because the opener may simply not be installed — a headless Linux box
  * has no `xdg-open` — and an unhandled `error` event on a child process takes the whole server
@@ -267,8 +269,8 @@ export async function apiMiddleware(req, res, next) {
 
     if (url.pathname === '/api/open' && req.method === 'POST') {
       const { harness, ref } = await readJsonBody(req)
-      const result = harnessOpenThread(harness, ref)
-      if (result.ok) launch(result.url)
+      const result = await Promise.resolve(harnessOpenThread(harness, ref))
+      if (result.ok && result.url) launch(result.url)
       return send(res, result.ok ? 200 : 400, result)
     }
 
@@ -281,8 +283,8 @@ export async function apiMiddleware(req, res, next) {
         launch(dir)
         return send(res, 200, { ok: true })
       }
-      const result = harnessNewSession(harness || (await defaultHarness()), dir)
-      if (result.ok) launch(result.url)
+      const result = await Promise.resolve(harnessNewSession(harness || (await defaultHarness()), dir))
+      if (result.ok && result.url) launch(result.url)
       return send(res, result.ok ? 200 : 400, result)
     }
 

--- a/server/harnesses/README.md
+++ b/server/harnesses/README.md
@@ -18,7 +18,7 @@ export default {
   name: 'My Harness',            // what a human sees in the UI
   detect,                        // () => Promise<boolean>
   scanThreads,                   // () => Promise<Thread[]>
-  openThread,                    // (ref) => { ok, url } | { ok: false, error }
+  openThread,                    // (ref) => { ok, url? } | { ok: false, error }  (may be async)
   newSession,                    // (dir) => { ok, url } | { ok: false, error }
   setArchived,                   // (ref, archived) => Promise<{ ok, error? }>
   appStartedAt,                  // optional: () => Promise<number>
@@ -52,8 +52,12 @@ Return `{ ok: true, url }` and the server hands that URL to the OS opener. `open
 the `ref` from the thread it belongs to; `newSession` gets an absolute directory that the
 server has already checked still exists.
 
-If your harness has no deep link, return `{ ok: false, error: '…' }` and say why — the UI
-shows the message rather than pretending the click worked.
+If the adapter has already done the open itself (spawned the harness's CLI, fired a
+keybinding, …), return `{ ok: true }` with no `url` — the server will not call `launch`.
+Either form may be async; the API awaits it.
+
+If your harness has no way to open a thread, return `{ ok: false, error: '…' }` and say why —
+the UI shows the message rather than pretending the click worked.
 
 ### `setArchived(ref, archived)`
 
@@ -116,8 +120,11 @@ Do not put a file handle, a class instance, or a secret in it.
 
 ## Ground rules
 
-- **Read-only by default.** The one exception in the whole project is the archive flag. A
-  harness's transcripts are somebody's actual work; the colony is a viewer, not an editor.
+- **Read-only by default.** A harness's transcripts are somebody's actual work; the colony is
+  a viewer, not an editor. The archive flag is the only write in the general case. Cursor is
+  the one adapter that needs more — it has no deep link to an existing thread, so Open
+  installs a small helper extension through Cursor's own CLI and talks to it through a
+  mode-0600 request file. Anything like that has to be disclosed in the top-level README.
 - **Never block the scan.** It runs on a poll. Cache anything expensive against file mtime —
   see `transcriptMeta` in `claude-code.mjs`, which is what keeps a 12MB transcript from being
   reparsed every few seconds.
@@ -137,6 +144,14 @@ Verified on a real machine:
   (`%APPDATA%\Claude\claude-code-sessions\…` on Windows); CLI transcripts in
   `~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl`; live processes in
   `~/.claude/sessions/*.json`. Implemented in `claude-code.mjs`.
+- **Cursor** — composer index in Cursor's global `state.vscdb` (`composerHeaders` table:
+  title, workspace `fsPath`, `hasUnreadMessages`, `unfinishedRunAt`, `isArchived`), plus
+  transcripts at `~/.cursor/projects/<slug>/agent-transcripts/<uuid>/<uuid>.jsonl`.
+  Node 22.13's built-in SQLite binding reads the live store in read-only mode, so Windows does
+  not need `sqlite3.exe`; if headers are temporarily unavailable, the adapter reuses its last
+  good snapshot rather than exposing unidentifiable subagents. Open focuses the workspace with
+  the Cursor CLI, then a tiny helper installed through that CLI runs `composer.focusComposer`
+  for the chat id and acknowledges it. Implemented in `cursor.mjs`.
 - **Codex CLI** — transcripts in `~/.codex/sessions/YYYY/MM/DD/rollout-<iso>-<uuid>.jsonl`,
   with records shaped `{ timestamp, type, payload }`, and what looks like an index at
   `~/.codex/session_index.jsonl`. Not implemented yet.

--- a/server/harnesses/cursor.mjs
+++ b/server/harnesses/cursor.mjs
@@ -56,7 +56,7 @@ function userDataDir() {
 
 const STATE_DB = path.join(userDataDir(), 'User', 'globalStorage', 'state.vscdb')
 
-/** `/Users/greg/nph` → `Users-greg-nph`, which is how ~/.cursor/projects is keyed. */
+/** `/Users/you/code` → `Users-you-code`, which is how ~/.cursor/projects is keyed. */
 function projectSlug(absPath) {
   return String(absPath || '')
     .replace(/^[\\/]+/, '')
@@ -704,7 +704,7 @@ function openThread(ref) {
 /**
  * Prefill a new agent chat, routed to a window whose folder name matches.
  * Cursor's deeplink matches on basename, not the full path — two checkouts
- * called `nph` would collide, which is the same ambiguity the colony already
+ * called `foo` would collide, which is the same ambiguity the colony already
  * has to disambiguate on the map.
  */
 function newSession(dir) {

--- a/server/harnesses/cursor.mjs
+++ b/server/harnesses/cursor.mjs
@@ -1,0 +1,822 @@
+/**
+ * Harness adapter: Cursor (the IDE, and cursor-agent).
+ *
+ * Cursor does not publish a session API. Two local stores, merged:
+ *   - composerHeaders in Cursor's global state.vscdb — title, workspace, unread,
+ *     whether a run is still going, archive flag. This is what the sidebar itself
+ *     reads, so it is the source of truth when sqlite3 can open it.
+ *   - ~/.cursor/projects/<slug>/agent-transcripts/<uuid>/<uuid>.jsonl — the
+ *     transcript the IDE writes alongside. Size is how finished a building looks,
+ *     and this fills in chats the composer index missed.
+ *
+ * Subagents (Task / explore / Bugbot children) are skipped: they are not threads
+ * the user started, and including them would drown the colony in helpers.
+ *
+ * Cursor has no public per-chat deep link analogous to Claude's epitaxy URL.
+ * The command that takes a composer id is `composer.focusComposer`, but
+ * `command:` URIs are swallowed from the CLI, and sending a keystroke needs
+ * macOS Accessibility which a viewer app should not ask for. Open therefore
+ * installs a tiny UI extension through Cursor's CLI. The helper watches
+ * `~/.cursor/bot-crossing-open.json`, runs that command, and acknowledges the
+ * request. New session still uses the documented prompt deeplink.
+ */
+import fsp from 'node:fs/promises'
+import path from 'node:path'
+import os from 'node:os'
+import { execFile } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
+import { DatabaseSync } from 'node:sqlite'
+import { promisify } from 'node:util'
+import { exists, jsonLines, listDirs, readHead } from '../lib/fsutil.mjs'
+
+const execFileAsync = promisify(execFile)
+const HOME = os.homedir()
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+const ACTIVE_WINDOW_MS = 30 * 60 * 1000
+const HEAD_BYTES = 64 * 1024
+const ID_PREFIX = 'cursor:'
+
+const PROJECTS = path.join(HOME, '.cursor', 'projects')
+
+/**
+ * Cursor's VS Code–style user data. The composer index lives in globalStorage.
+ * Layout is the same as VS Code's, just under Cursor's own app name.
+ */
+function userDataDir() {
+  switch (process.platform) {
+    case 'win32':
+      return path.join(process.env.APPDATA || path.join(HOME, 'AppData', 'Roaming'), 'Cursor')
+    case 'linux':
+      return path.join(process.env.XDG_CONFIG_HOME || path.join(HOME, '.config'), 'Cursor')
+    default:
+      return path.join(HOME, 'Library', 'Application Support', 'Cursor')
+  }
+}
+
+const STATE_DB = path.join(userDataDir(), 'User', 'globalStorage', 'state.vscdb')
+
+/** `/Users/greg/nph` → `Users-greg-nph`, which is how ~/.cursor/projects is keyed. */
+function projectSlug(absPath) {
+  return String(absPath || '')
+    .replace(/^[\\/]+/, '')
+    .replace(/[:\\/]+/g, '-')
+}
+
+/**
+ * Best-effort reverse of the slug. Ambiguous whenever a path segment itself
+ * contained a dash — same compromise the Claude adapter makes for encoded cwds.
+ */
+function decodeProjectSlug(name) {
+  if (/^[0-9]+$/.test(name)) return ''
+  const drive = /^([A-Za-z])-(.*)$/.exec(name)
+  if (drive) return `${drive[1]}:\\${drive[2].replace(/-/g, '\\')}`
+  return name ? '/' + name.replace(/-/g, '/') : ''
+}
+
+const WORKTREE = /[\\/](?:\.cursor[\\/]worktrees|\.wt)[\\/]([^\\/]+)/
+function splitWorktree(cwd) {
+  const m = WORKTREE.exec(cwd || '')
+  if (!m) return { root: cwd || '', worktree: '' }
+  return { root: cwd.slice(0, m.index), worktree: m[1] }
+}
+
+function workspacePathOf(header) {
+  const uri = header?.workspaceIdentifier?.uri
+  const p = uri?.fsPath || uri?.path || ''
+  return typeof p === 'string' && p ? p : ''
+}
+
+function activeRepoOf(header) {
+  let best = null
+  for (const repo of Array.isArray(header?.trackedGitRepos) ? header.trackedGitRepos : []) {
+    if (typeof repo?.repoPath !== 'string' || !path.isAbsolute(repo.repoPath)) continue
+    const branches = Array.isArray(repo.branches) ? repo.branches : []
+    const branch = branches.reduce((a, b) => (
+      !a || Number(b?.lastInteractionAt) > Number(a?.lastInteractionAt) ? b : a
+    ), null)
+    const at = Number(branch?.lastInteractionAt) || 0
+    if (!best || at > best.at) best = { path: repo.repoPath, branch: branch?.branchName || '', at }
+  }
+  return best
+}
+
+/**
+ * Read composerHeaders with Node's built-in SQLite binding. It is portable,
+ * opens the 36GB live store read-only, and avoids requiring sqlite3.exe on
+ * Windows. WAL readers may run while Cursor writes.
+ */
+let lastHeaderRows = null
+async function queryComposerHeaders() {
+  if (!(await exists(STATE_DB))) return null
+  let db
+  try {
+    db = new DatabaseSync(STATE_DB, { readOnly: true, timeout: 2000 })
+    // Subagent rows are only ever needed as ids to skip, and their blobs are well over
+    // half the bytes this query would otherwise pull out of a 36GB store on every poll.
+    const rows = db.prepare(`
+      SELECT composerId, isSubagent, createdAt, lastUpdatedAt, isArchived, recency,
+             CASE WHEN isSubagent THEN NULL ELSE value END AS value
+        FROM composerHeaders
+    `).all()
+    lastHeaderRows = rows
+    return rows
+  } catch {
+    return lastHeaderRows
+  } finally {
+    try {
+      db?.close()
+    } catch {
+      /* failed open */
+    }
+  }
+}
+
+function parseHeaderRow(row) {
+  let header = {}
+  try {
+    header = typeof row.value === 'string' ? JSON.parse(row.value) : row.value || {}
+  } catch {
+    header = {}
+  }
+  if (!header || typeof header !== 'object') header = {}
+  const composerId = row.composerId || header.composerId || ''
+  if (!UUID.test(composerId)) return null
+  if (header.isDraft === true || header.isSubagent === true || row.isSubagent === 1) return null
+
+  const createdAt = Number(header.createdAt || row.createdAt) || 0
+  const lastActivityAt = Math.max(
+    Number(header.lastUpdatedAt) || 0,
+    Number(header.conversationCheckpointLastUpdatedAt) || 0,
+    Number(row.lastUpdatedAt) || 0,
+    Number(row.recency) || 0,
+    createdAt,
+  )
+  const unfinishedAt = Number(header.unfinishedRunAt) || 0
+  const cwd = workspacePathOf(header)
+  const activeRepo = activeRepoOf(header)
+  const location = activeRepo?.path || cwd
+  const { root, worktree } = splitWorktree(location)
+  const projectPath = root || location
+  const project = path.basename(projectPath) || projectPath || 'cursor'
+  const archived = row.isArchived === 1 || row.isArchived === true || header.isArchived === true
+  const mode = header.unifiedMode || header.forceMode || ''
+  const now = Date.now()
+
+  return {
+    composerId,
+    title: header.name || header.subtitle || '',
+    preview: header.subtitle || '',
+    project,
+    projectPath,
+    worktree,
+    cwd,
+    gitBranch: activeRepo?.branch || '',
+    model: mode,
+    createdAt,
+    lastActivityAt,
+    archived,
+    unread: header.hasUnreadMessages === true || header.hasBlockingPendingActions === true,
+    running: Boolean(unfinishedAt) && now - lastActivityAt < ACTIVE_WINDOW_MS,
+    hasError: false,
+  }
+}
+
+function transcriptFile(slug, composerId) {
+  return path.join(PROJECTS, slug, 'agent-transcripts', composerId, `${composerId}.jsonl`)
+}
+
+const sizeCache = new Map()
+const CACHE_LIMIT = 2048
+function cacheSet(cache, key, value) {
+  if (!cache.has(key) && cache.size >= CACHE_LIMIT) cache.delete(cache.keys().next().value)
+  cache.set(key, value)
+}
+
+async function transcriptSize(workspacePath, composerId) {
+  const slug = projectSlug(workspacePath)
+  if (!slug || !UUID.test(composerId)) return 0
+  const file = transcriptFile(slug, composerId)
+  const cached = sizeCache.get(file)
+  try {
+    const stat = await fsp.stat(file)
+    if (cached && cached.mtime === stat.mtimeMs) return cached.size
+    cacheSet(sizeCache, file, { mtime: stat.mtimeMs, size: stat.size })
+    return stat.size
+  } catch {
+    return 0
+  }
+}
+
+/** First user prompt, used only when composerHeaders had no title. */
+const metaCache = new Map()
+async function transcriptMeta(file, mtime) {
+  const cached = metaCache.get(file)
+  if (cached && cached.mtime === mtime) return cached.meta
+  let meta = { title: '', preview: '' }
+  try {
+    for (const rec of jsonLines(await readHead(file, HEAD_BYTES))) {
+      if (rec.role !== 'user' || !rec.message) continue
+      const parts = rec.message.content
+      const text = Array.isArray(parts)
+        ? parts.map((p) => (p && p.type === 'text' ? p.text : '')).join('\n')
+        : typeof parts === 'string'
+          ? parts
+          : ''
+      const query = text.match(/<user_query>\s*([\s\S]*?)\s*<\/user_query>/)
+      const cleaned = (query ? query[1] : text).replace(/<timestamp>[\s\S]*?<\/timestamp>/g, '').trim()
+      if (!cleaned) continue
+      meta = { title: cleaned.split('\n')[0].slice(0, 80), preview: cleaned.slice(0, 240) }
+      break
+    }
+  } catch {
+    /* mid-write */
+  }
+  cacheSet(metaCache, file, { mtime, meta })
+  return meta
+}
+
+function toThread(t) {
+  const { composerId, ...rest } = t
+  return {
+    ...rest,
+    id: ID_PREFIX + composerId,
+    title: rest.title || 'Untitled thread',
+    canOpen: true,
+    canArchive: rest.source === 'composer',
+    hasTranscript: rest.sizeBytes > 0,
+    source: rest.source || 'composer',
+    lastFocusedAt: 0,
+    effort: '',
+    starred: false,
+    routine: '',
+    prState: '',
+    ref: {
+      composerId,
+      projectPath: rest.projectPath || '',
+      workspacePath: rest.cwd || rest.projectPath || '',
+    },
+  }
+}
+
+/**
+ * Walk ~/.cursor/projects for parent transcripts. Used as the whole scan when
+ * sqlite3 cannot open the DB, and as a fill-in for chats the index missed.
+ */
+async function scanTranscripts(skipIds = new Set()) {
+  const out = []
+  for (const projectDir of await listDirs(PROJECTS)) {
+    const slug = path.basename(projectDir)
+    const decoded = decodeProjectSlug(slug)
+    const transcripts = path.join(projectDir, 'agent-transcripts')
+    if (!(await exists(transcripts))) continue
+    for (const dir of await listDirs(transcripts)) {
+      const id = path.basename(dir)
+      if (!UUID.test(id) || skipIds.has(id)) continue
+      const file = path.join(dir, `${id}.jsonl`)
+      let stat
+      try {
+        stat = await fsp.stat(file)
+      } catch {
+        continue
+      }
+      const meta = await transcriptMeta(file, stat.mtimeMs)
+      const { root, worktree } = splitWorktree(decoded)
+      const projectPath = root || decoded
+      out.push({
+        composerId: id,
+        title: meta.title,
+        preview: meta.preview,
+        project: path.basename(projectPath) || projectPath || slug,
+        projectPath,
+        worktree,
+        cwd: decoded,
+        gitBranch: '',
+        model: '',
+        createdAt: stat.birthtimeMs || stat.mtimeMs,
+        lastActivityAt: stat.mtimeMs,
+        archived: false,
+        unread: false,
+        running: Date.now() - stat.mtimeMs < ACTIVE_WINDOW_MS,
+        hasError: false,
+        sizeBytes: stat.size,
+        source: 'transcript',
+      })
+    }
+  }
+  return out
+}
+
+async function scanThreads() {
+  const byId = new Map()
+  const add = (thread) => {
+    const existing = byId.get(thread.composerId)
+    if (!existing) {
+      byId.set(thread.composerId, thread)
+      return
+    }
+    // Headers win on title/unread/running; transcripts win on size if the header had none.
+    byId.set(thread.composerId, {
+      ...thread,
+      ...existing,
+      title: existing.title || thread.title,
+      preview: existing.preview || thread.preview,
+      projectPath: existing.projectPath || thread.projectPath,
+      project: existing.projectPath ? existing.project : thread.project,
+      sizeBytes: existing.sizeBytes || thread.sizeBytes,
+      source: existing.source === 'composer' ? 'composer' : thread.source,
+    })
+  }
+
+  const rows = await queryComposerHeaders()
+  if (rows) {
+    for (const row of rows) {
+      const parsed = parseHeaderRow(row)
+      if (!parsed) continue
+      parsed.sizeBytes = await transcriptSize(parsed.cwd, parsed.composerId)
+      parsed.source = 'composer'
+      add(parsed)
+    }
+  }
+
+  // Without headers there is no reliable way to distinguish parent transcripts
+  // from subagents. Return no Cursor threads rather than flooding the colony.
+  if (!rows) return []
+
+  const skip = new Set(byId.keys())
+  for (const row of rows) {
+    const id = row.composerId
+    if (!UUID.test(id || '')) continue
+    if (row.isSubagent === 1 || row.isSubagent === true) {
+      skip.add(id)
+      continue
+    }
+    // Older rows carry the flag only inside the blob.
+    try {
+      const value = typeof row.value === 'string' ? JSON.parse(row.value) : row.value || {}
+      if (value?.isSubagent === true) skip.add(id)
+    } catch {
+      /* malformed row */
+    }
+  }
+  for (const t of await scanTranscripts(skip)) add(t)
+
+  return [...byId.values()].map(toThread)
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+const OPEN_REQUEST = path.join(HOME, '.cursor', 'bot-crossing-open.json')
+const OPEN_ACK = path.join(HOME, '.cursor', 'bot-crossing-open-ack.json')
+const EXT_PUBLISHER = 'bot-crossing'
+const EXT_NAME = 'cursor-open'
+const EXT_VERSION = '0.0.3'
+const EXT_ID = `${EXT_PUBLISHER}.${EXT_NAME}`
+const EXT_DIRNAME = `${EXT_ID}-${EXT_VERSION}`
+
+const EXT_PACKAGE = `{
+  "name": "${EXT_NAME}",
+  "displayName": "Bot Crossing Open",
+  "description": "Lets Bot Crossing focus a specific Cursor agent thread.",
+  "version": "${EXT_VERSION}",
+  "publisher": "${EXT_PUBLISHER}",
+  "engines": { "vscode": "^1.80.0" },
+  "categories": ["Other"],
+  "activationEvents": ["*"],
+  "main": "./extension.js",
+  "extensionKind": ["ui"]
+}
+`
+
+// Watches ~/.cursor/bot-crossing-open.json and runs composer.focusComposer.
+// Kept as a string so the adapter stays one file; we materialize it on Open.
+const EXT_MAIN = `const vscode = require('vscode')
+const fs = require('fs')
+const path = require('path')
+const os = require('os')
+const FILE = path.join(os.homedir(), '.cursor', 'bot-crossing-open.json')
+const ACK = path.join(os.homedir(), '.cursor', 'bot-crossing-open-ack.json')
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+// A request is only ever meant for the window that is open when it lands. Anything
+// older is a leftover from a click nobody is waiting on any more, and honouring it
+// would steal focus in an unrelated window minutes or days later.
+const MAX_AGE_MS = 30000
+function writeAck(value) {
+  const tmp = ACK + '.' + process.pid + '.tmp'
+  fs.writeFileSync(tmp, JSON.stringify(value) + '\\n', { mode: 0o600 })
+  fs.renameSync(tmp, ACK)
+}
+function activate(context) {
+  let lastRequestId = ''
+  const tryFocus = async () => {
+    let req
+    try { req = JSON.parse(fs.readFileSync(FILE, 'utf8')) } catch { return }
+    if (!req || !UUID.test(req.composerId || '') || typeof req.requestId !== 'string'
+        || req.requestId === lastRequestId) return
+    if (!Number(req.at) || Date.now() - Number(req.at) > MAX_AGE_MS) return
+    if (req.workspacePath) {
+      const normalize = value => {
+        const resolved = path.resolve(String(value))
+        return process.platform === 'win32' ? resolved.toLowerCase() : resolved
+      }
+      const wanted = normalize(req.workspacePath)
+      const folders = vscode.workspace.workspaceFolders || []
+      if (!folders.some(folder => normalize(folder.uri.fsPath) === wanted)) return
+    }
+    lastRequestId = req.requestId
+    // Consume it here, not just in the server: whichever window handles the request
+    // is the one that knows it is spent, and a window that never got the ack back
+    // (server gone, machine slept) must not find it again on the next activation.
+    try { fs.unlinkSync(FILE) } catch {}
+    try {
+      await vscode.commands.executeCommand('composer.focusComposer', req.composerId)
+      writeAck({ requestId: req.requestId, composerId: req.composerId, ok: true })
+    } catch (err) {
+      writeAck({ requestId: req.requestId, composerId: req.composerId, ok: false,
+        error: err instanceof Error ? err.message : String(err) })
+    }
+  }
+  try {
+    fs.mkdirSync(path.dirname(FILE), { recursive: true })
+    const watcher = fs.watch(path.dirname(FILE), { persistent: false }, (_e, name) => {
+      if (name === 'bot-crossing-open.json') tryFocus()
+    })
+    context.subscriptions.push({ dispose: () => watcher.close() })
+  } catch {}
+  // fs.watch above is the fast path on every platform we support; this is only a
+  // safety net for the cases where it drops events, so it can afford to be slow.
+  const interval = setInterval(tryFocus, 2000)
+  context.subscriptions.push({ dispose: () => clearInterval(interval) })
+  tryFocus()
+}
+function deactivate() {}
+module.exports = { activate, deactivate }
+`
+
+const VSIX_MANIFEST = `<?xml version="1.0" encoding="utf-8"?>
+<PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
+  <Metadata>
+    <Identity Language="en-US" Id="${EXT_NAME}" Version="${EXT_VERSION}" Publisher="${EXT_PUBLISHER}" />
+    <DisplayName>Bot Crossing Open</DisplayName>
+    <Description xml:space="preserve">Lets Bot Crossing focus a specific Cursor agent thread.</Description>
+    <Categories>Other</Categories>
+    <Properties>
+      <Property Id="Microsoft.VisualStudio.Code.Engine" Value="^1.80.0" />
+      <Property Id="Microsoft.VisualStudio.Code.ExtensionKind" Value="ui" />
+    </Properties>
+  </Metadata>
+  <Installation>
+    <InstallationTarget Id="Microsoft.VisualStudio.Code"/>
+  </Installation>
+  <Dependencies/>
+  <Assets>
+    <Asset Type="Microsoft.VisualStudio.Code.Manifest" Path="extension/package.json" Addressable="true" />
+  </Assets>
+</PackageManifest>
+`
+
+const VSIX_CONTENT_TYPES = `<?xml version="1.0" encoding="utf-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="json" ContentType="application/json" />
+  <Default Extension="vsixmanifest" ContentType="text/xml" />
+  <Default Extension="js" ContentType="application/javascript" />
+  <Default Extension="xml" ContentType="text/xml" />
+</Types>
+`
+
+const CRC_TABLE = new Uint32Array(256)
+for (let n = 0; n < 256; n += 1) {
+  let c = n
+  for (let k = 0; k < 8; k += 1) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1
+  CRC_TABLE[n] = c >>> 0
+}
+
+function crc32(buffer) {
+  let crc = 0xffffffff
+  for (const byte of buffer) crc = CRC_TABLE[(crc ^ byte) & 0xff] ^ (crc >>> 8)
+  return (crc ^ 0xffffffff) >>> 0
+}
+
+function zipStore(entries) {
+  const localParts = []
+  const centralParts = []
+  let offset = 0
+  for (const [name, contents] of entries) {
+    const nameBytes = Buffer.from(name)
+    const data = Buffer.from(contents)
+    const crc = crc32(data)
+    const local = Buffer.alloc(30)
+    local.writeUInt32LE(0x04034b50, 0)
+    local.writeUInt16LE(20, 4)
+    local.writeUInt16LE(0x0800, 6)
+    local.writeUInt32LE(crc, 14)
+    local.writeUInt32LE(data.length, 18)
+    local.writeUInt32LE(data.length, 22)
+    local.writeUInt16LE(nameBytes.length, 26)
+    localParts.push(local, nameBytes, data)
+
+    const central = Buffer.alloc(46)
+    central.writeUInt32LE(0x02014b50, 0)
+    central.writeUInt16LE(20, 4)
+    central.writeUInt16LE(20, 6)
+    central.writeUInt16LE(0x0800, 8)
+    central.writeUInt32LE(crc, 16)
+    central.writeUInt32LE(data.length, 20)
+    central.writeUInt32LE(data.length, 24)
+    central.writeUInt16LE(nameBytes.length, 28)
+    central.writeUInt32LE(offset, 42)
+    centralParts.push(central, nameBytes)
+    offset += local.length + nameBytes.length + data.length
+  }
+  const central = Buffer.concat(centralParts)
+  const end = Buffer.alloc(22)
+  end.writeUInt32LE(0x06054b50, 0)
+  end.writeUInt16LE(entries.length, 8)
+  end.writeUInt16LE(entries.length, 10)
+  end.writeUInt32LE(central.length, 12)
+  end.writeUInt32LE(offset, 16)
+  return Buffer.concat([...localParts, central, end])
+}
+
+function runCursor(bin, args, options = {}) {
+  if (process.platform !== 'win32' || !/\.(?:cmd|bat)$/i.test(bin)) {
+    return execFileAsync(bin, args, options)
+  }
+  const quote = (value) => `"${String(value).replace(/"/g, '""')}"`
+  const command = [bin, ...args].map(quote).join(' ')
+  return execFileAsync(process.env.ComSpec || 'cmd.exe', ['/d', '/s', '/c', command], options)
+}
+
+let installedVersion = ''
+async function installOpenExtension(bin) {
+  if (installedVersion === EXT_VERSION) return false
+  try {
+    const { stdout } = await runCursor(bin, ['--list-extensions', '--show-versions'], { timeout: 15000 })
+    if (stdout.split(/\r?\n/).includes(`${EXT_ID}@${EXT_VERSION}`)) {
+      installedVersion = EXT_VERSION
+      return false
+    }
+  } catch {
+    /* install below gives the useful error */
+  }
+
+  const tmp = await fsp.mkdtemp(path.join(os.tmpdir(), 'bot-crossing-vsix-'))
+  const vsix = path.join(tmp, `${EXT_DIRNAME}.vsix`)
+  try {
+    const archive = zipStore([
+      ['extension.vsixmanifest', VSIX_MANIFEST],
+      ['[Content_Types].xml', VSIX_CONTENT_TYPES],
+      ['extension/package.json', EXT_PACKAGE],
+      ['extension/extension.js', EXT_MAIN],
+    ])
+    await fsp.writeFile(vsix, archive, { mode: 0o600 })
+    await runCursor(bin, ['--install-extension', vsix, '--force'], { timeout: 30000 })
+    installedVersion = EXT_VERSION
+    return true
+  } finally {
+    await fsp.rm(tmp, { recursive: true, force: true }).catch(() => {})
+  }
+}
+
+async function writeOpenRequest(composerId, workspacePath) {
+  const requestId = randomUUID()
+  const payload = JSON.stringify({
+    requestId,
+    composerId,
+    workspacePath: workspacePath || '',
+    at: Date.now(),
+  }) + '\n'
+  await fsp.mkdir(path.dirname(OPEN_REQUEST), { recursive: true })
+  const tmp = `${OPEN_REQUEST}.${process.pid}.${requestId}.tmp`
+  await fsp.writeFile(tmp, payload, { mode: 0o600 })
+  await fsp.rename(tmp, OPEN_REQUEST)
+  return requestId
+}
+
+async function waitForOpenAck(requestId, timeoutMs = 3000) {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    try {
+      const ack = JSON.parse(await fsp.readFile(OPEN_ACK, 'utf8'))
+      if (ack?.requestId === requestId) return ack
+    } catch {
+      /* helper has not acknowledged yet */
+    }
+    await sleep(60)
+  }
+  return null
+}
+
+function cursorBinaries() {
+  const out = []
+  if (process.env.CURSOR_CLI) out.push(process.env.CURSOR_CLI)
+  if (process.platform === 'darwin') {
+    out.push('/Applications/Cursor.app/Contents/Resources/app/bin/cursor')
+    out.push(path.join(HOME, 'Applications/Cursor.app/Contents/Resources/app/bin/cursor'))
+  } else if (process.platform === 'win32') {
+    const local = process.env.LOCALAPPDATA || path.join(HOME, 'AppData', 'Local')
+    out.push(path.join(local, 'Programs', 'cursor', 'Cursor.exe'))
+    out.push(path.join(local, 'Programs', 'Cursor', 'Cursor.exe'))
+    out.push(path.join(local, 'Programs', 'cursor', 'resources', 'app', 'bin', 'cursor.cmd'))
+    out.push(path.join(local, 'Programs', 'Cursor', 'resources', 'app', 'bin', 'cursor.cmd'))
+  } else {
+    out.push(path.join(HOME, '.local', 'bin', 'cursor'))
+    out.push(path.join(HOME, '.cursor', 'bin', 'cursor'))
+    out.push('/usr/local/bin/cursor')
+    out.push('/usr/share/cursor/resources/app/bin/cursor')
+    out.push('/usr/lib/cursor/bin/cursor')
+  }
+  return out
+}
+
+let cursorBinCache = { checked: false, path: '' }
+async function findCursorBin() {
+  if (cursorBinCache.path) return cursorBinCache.path
+  for (const candidate of cursorBinaries()) {
+    if (candidate && (await exists(candidate))) {
+      cursorBinCache = { checked: true, path: candidate }
+      return candidate
+    }
+  }
+  try {
+    const command = process.platform === 'win32' ? 'where' : 'which'
+    const { stdout } = await execFileAsync(command, ['cursor'], { timeout: 3000 })
+    const candidate = stdout.split(/\r?\n/).find(Boolean) || ''
+    if (candidate) {
+      cursorBinCache = { checked: true, path: candidate }
+      return candidate
+    }
+  } catch {
+    /* not on PATH */
+  }
+  cursorBinCache = { checked: true, path: '' }
+  return ''
+}
+
+async function isDirectory(p) {
+  try {
+    return (await fsp.stat(p)).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Hands the thread back to Cursor. `cursor://file/…` only focuses the workspace.
+ * The helper extension is installed through Cursor's CLI and acknowledges the
+ * focus command. A first install may require one Cursor window reload.
+ */
+async function openThreadNow(ref) {
+  const composerId = ref?.composerId
+  if (!UUID.test(composerId || '')) return { ok: false, error: 'No openable Cursor chat id on that thread' }
+  const workspacePath = typeof ref?.workspacePath === 'string' && path.isAbsolute(ref.workspacePath)
+    ? ref.workspacePath
+    : typeof ref?.projectPath === 'string' && path.isAbsolute(ref.projectPath) ? ref.projectPath : ''
+  const bin = await findCursorBin()
+  if (!bin) return { ok: false, error: 'Cursor CLI not found; install the cursor shell command and retry' }
+  // Threads outlive their checkouts — deleted worktrees and /tmp dirs are common, and a
+  // transcript-only thread's path is a lossy slug decode. Handing Cursor a folder that is
+  // not there opens a window on nothing, so fall back to focusing by composer id alone.
+  const folder = workspacePath && (await isDirectory(workspacePath)) ? workspacePath : ''
+  try {
+    await installOpenExtension(bin)
+    if (folder) await runCursor(bin, [folder], { timeout: 15000 })
+    const requestId = await writeOpenRequest(composerId, folder)
+    const ack = await waitForOpenAck(requestId)
+    if (ack?.ok) return { ok: true }
+    if (ack) return { ok: false, error: ack.error || 'Cursor could not focus that agent thread' }
+    return { ok: false, error: 'Reload the Cursor window once to activate Bot Crossing Open, then retry' }
+  } catch (err) {
+    return { ok: false, error: err?.message || 'Could not open that Cursor thread' }
+  } finally {
+    // The helper unlinks what it consumes; this covers the case where no window ever did.
+    await fsp.unlink(OPEN_REQUEST).catch(() => {})
+  }
+}
+
+let openQueue = Promise.resolve()
+function openThread(ref) {
+  const next = openQueue.then(() => openThreadNow(ref), () => openThreadNow(ref))
+  openQueue = next.catch(() => {})
+  return next
+}
+
+/**
+ * Prefill a new agent chat, routed to a window whose folder name matches.
+ * Cursor's deeplink matches on basename, not the full path — two checkouts
+ * called `nph` would collide, which is the same ambiguity the colony already
+ * has to disambiguate on the map.
+ */
+function newSession(dir) {
+  const workspace = encodeURIComponent(path.basename(dir))
+  return { ok: true, url: `cursor://anysphere.cursor-deeplink/prompt?text=%20&workspace=${workspace}&mode=agent` }
+}
+
+async function setArchived(ref, archived) {
+  const composerId = ref?.composerId
+  if (!UUID.test(composerId || '')) return { ok: false, error: 'No Cursor chat id on that thread' }
+  if (!(await exists(STATE_DB))) return { ok: false, error: 'Cursor has no session database on this machine' }
+
+  const flag = archived ? 1 : 0
+  const jsonFlag = archived ? 'true' : 'false'
+  let db
+  try {
+    db = new DatabaseSync(STATE_DB, { timeout: 5000 })
+    db.exec('PRAGMA busy_timeout = 5000')
+    const result = db.prepare(`
+      UPDATE composerHeaders
+      SET isArchived = ?,
+          value = CASE WHEN json_valid(value) THEN json_set(value, '$.isArchived', json(?)) ELSE value END
+      WHERE composerId = ?
+    `).run(flag, jsonFlag, composerId)
+    return result.changes > 0
+      ? { ok: true, archived: Boolean(archived) }
+      : { ok: false, error: 'No Cursor composer record for that thread' }
+  } catch (err) {
+    return { ok: false, error: err?.message || 'Could not update Cursor archive flag' }
+  } finally {
+    try {
+      db?.close()
+    } catch {
+      /* failed open */
+    }
+  }
+}
+
+let appStartCache = { at: 0, checkedAt: 0 }
+async function appStartedAt() {
+  const now = Date.now()
+  if (now - appStartCache.checkedAt < 15000) return appStartCache.at
+  let started = 0
+  try {
+    if (process.platform === 'win32') started = await windowsAppStartedAt()
+    else if (process.platform === 'darwin') started = await darwinAppStartedAt()
+    else if (process.platform === 'linux') started = await linuxAppStartedAt()
+  } catch {
+    /* no process listing */
+  }
+  appStartCache = { at: started, checkedAt: now }
+  return started
+}
+
+async function darwinAppStartedAt() {
+  const { stdout } = await execFileAsync('ps', ['-axo', 'pid=,lstart=,command='], { maxBuffer: 8 * 1024 * 1024 })
+  for (const line of stdout.split('\n')) {
+    const m = line.match(/^\s*\d+\s+(\w{3} \w{3}\s+\d+ \d{2}:\d{2}:\d{2} \d{4})\s+(\/.*)$/)
+    if (!m) continue
+    const [, when, command] = m
+    if (!command.includes('/Cursor.app/Contents/MacOS/Cursor') || command.includes('--type=')) continue
+    const parsed = Date.parse(when)
+    return Number.isNaN(parsed) ? 0 : parsed
+  }
+  return 0
+}
+
+async function linuxAppStartedAt() {
+  const { stdout } = await execFileAsync('ps', ['-eo', 'lstart=,args='], { maxBuffer: 8 * 1024 * 1024 })
+  for (const line of stdout.split('\n')) {
+    const m = line.match(/^\s*(\w{3} \w{3}\s+\d+ \d{2}:\d{2}:\d{2} \d{4})\s+(.+)$/)
+    if (!m) continue
+    const [, when, command] = m
+    if (!/(?:^|\/)cursor(?:\s|$)/i.test(command) || command.includes('--type=')) continue
+    const parsed = Date.parse(when)
+    return Number.isNaN(parsed) ? 0 : parsed
+  }
+  return 0
+}
+
+async function windowsAppStartedAt() {
+  const script = [
+    "Get-CimInstance Win32_Process -Filter \"Name='Cursor.exe'\" | ForEach-Object {",
+    "  if ($_.CreationDate) { '{0}|{1}|{2}|{3}' -f $_.ProcessId, $_.ParentProcessId,",
+    "    $_.CreationDate.ToUniversalTime().ToString('o'), $_.CommandLine } }",
+  ].join(' ')
+  const { stdout } = await execFileAsync('powershell', ['-NoProfile', '-NonInteractive', '-Command', script], {
+    maxBuffer: 8 * 1024 * 1024,
+  })
+  const rows = stdout
+    .split(/\r?\n/)
+    .map((line) => line.split('|'))
+    .filter((parts) => parts.length >= 4)
+    .map(([pid, ppid, when, ...command]) => ({
+      pid,
+      ppid,
+      when: Date.parse(when),
+      command: command.join('|'),
+    }))
+  const helperParents = new Set(rows.filter((r) => r.command.includes('--type=')).map((r) => r.ppid))
+  const main = rows.find((r) => helperParents.has(r.pid) && !r.command.includes('--type='))
+  return main && !Number.isNaN(main.when) ? main.when : 0
+}
+
+export default {
+  id: 'cursor',
+  name: 'Cursor',
+  detect: async () => (await exists(PROJECTS)) || (await exists(STATE_DB)),
+  scanThreads,
+  openThread,
+  newSession,
+  setArchived,
+  appStartedAt,
+  paths: { PROJECTS, STATE_DB },
+}

--- a/server/harnesses/index.mjs
+++ b/server/harnesses/index.mjs
@@ -7,8 +7,9 @@
  * `server/harnesses/README.md`.
  */
 import claudeCode from './claude-code.mjs'
+import cursor from './cursor.mjs'
 
-export const HARNESSES = [claudeCode]
+export const HARNESSES = [claudeCode, cursor]
 
 export const harnessById = (id) => HARNESSES.find((h) => h.id === id) || null
 


### PR DESCRIPTION
## Summary

- Adds a Cursor adapter (`server/harnesses/cursor.mjs`) that scans composer chats from `state.vscdb` plus transcripts under `~/.cursor/projects`, filters subagents, and writes the composer `isArchived` flag.
- Open cannot use a public deep link, so the adapter installs a tiny helper through Cursor's own CLI (`bot-crossing.cursor-open`) and focuses the composer via a mode-0600 request/ack pair. A first install may need one Cursor window reload.
- The API now awaits `openThread` / `newSession` and only `launch`es when the adapter returns a `url`, so adapters that open themselves still work.

## Tradeoffs worth deciding

- **Node engines `>=22.13`.** The adapter uses `node:sqlite` so Windows does not need `sqlite3.exe` and the live WAL store can be opened read-only. This raises the floor for every user, not just Cursor users. Same tradeoff as the Hermes PR.
- **The helper extension writes under `~/.cursor/`.** CONTRIBUTING.md still says the project writes exactly one archive flag. This PR does not rewrite that rule; it discloses the extra writes in the README and leaves the exception for you. Without the helper, Open can only focus the workspace and lands on the wrong thread.

## Verified locally

Against a real Cursor install with 673 composer threads across 52 projects: no subagents leak into the colony, archive round-trips and survives Cursor rewriting its own records, Open focuses the right composer after the helper is active, and a thread whose checkout has since been deleted fails without handing the Cursor CLI a missing folder. Claude Code scan, Open, and archive are unchanged. `npm run build` passes.

## Test plan

- [ ] With Cursor installed, Bot Crossing lists Cursor threads (no subagents) and attributes them to the right project.
- [ ] Open focuses the matching composer after at most one Cursor window reload on first helper install.
- [ ] Open on a thread whose checkout no longer exists does not pass a missing folder to the Cursor CLI.
- [ ] Archive / unarchive a composer thread and confirm it sticks in Cursor; transcript-only threads are not archiveable.
- [ ] Claude Code scan, Open, and archive are unchanged.
- [ ] Node 20 is no longer claimed as supported (`engines` is `>=22.13`).