### PR TITLE
Add Codex support with read-only scanning and native archive actions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,14 +68,14 @@ You need a real harness installed with real threads for anything interesting to 
 because the built files are checked in and the raw packs are not. You only need it if you are
 changing the art pipeline, and the README explains where to re-download the packs.
 
-There is no test suite and no linter. That is not a standard I am asking you to meet — it is
-just the state of things, and I would rather tell you than have you guess.
+`npm test` runs the focused Codex adapter and archive reconciliation tests using Node's
+built-in runner (Node 22.13+). There is no linter or full-colony test suite.
 
 ## What makes a PR easy to say yes to
 
 - **One thing at a time.** A harness adapter, or a bug fix, or a refactor — not all three.
-- **Say what you verified and how.** There are no tests to lean on, so your description is the
-  evidence. "Ran it against 40 real Codex sessions, screenshots attached" is worth more than a
+- **Say what you verified and how.** Include both relevant tests and live verification.
+  "Ran it against 40 real Codex sessions, screenshots attached" is worth more than a
   clean diff.
 - **Match the surrounding code.** No semicolons, single quotes, 2-space indent, 110ish columns.
   Comments in this codebase explain *why* — particularly why an obvious approach was rejected.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ a plot for their repo, and build something. When one needs you it stops and hold
 its head; click it and the thread opens back in whichever harness it came from.
 
 It reads the harness's own files, on your own machine. Nothing is uploaded, there is no
-account, and the only thing it ever writes back is a single archive flag.
+account, and the only action that changes harness data is archive/unarchive.
 
 > **Status:** published as-is. I built this for myself and cannot promise to maintain it —
 > issues and PRs are welcome but may go unanswered, and forking is an entirely reasonable
@@ -39,7 +39,7 @@ somebody writing that adapter.
 | Harness | Status |
 | --- | --- |
 | **[Claude Code](https://claude.com/claude-code)** (Anthropic) | ✅ **Supported** — desktop app and CLI, including worktrees, live-process detection and archiving |
-| [Codex CLI](https://developers.openai.com/codex/cli) (OpenAI) | ⬜ Not yet — transcripts found at `~/.codex/sessions/`, [notes here](server/harnesses/README.md#starting-points) |
+| **[Codex](https://developers.openai.com/codex/cli)** (OpenAI) | ✅ **Supported** — local desktop and CLI tasks, worktrees, unread state, activity inference and archiving |
 | [OpenCode](https://opencode.ai) | ⬜ Not yet |
 | [Antigravity CLI](https://antigravity.google) (Google) | ⬜ Not yet — the successor to Gemini CLI, which Google stopped serving individual accounts on 18 June 2026 |
 | [Cursor](https://cursor.com) (`cursor-agent`) | ⬜ Not yet |
@@ -51,6 +51,33 @@ somebody writing that adapter.
 
 Every harness that is installed shows up at once — the colony is the union of all of them, and
 an astronaut carries the name of the harness it belongs to.
+
+### Codex setup
+
+Use **Node 22.13+** (Node 24 recommended) for its built-in SQLite reader. The adapter opens
+the newest numbered `state_*.sqlite` in `CODEX_HOME` (default `~/.codex`) read-only, and reads
+desktop unread/project hints separately. Internal reviewers and spawned child sessions are
+excluded. Scanning never runs the Codex CLI and does not change Codex's files.
+
+Open and New conversation require the Codex desktop app. They use `codex://threads/<id>`
+and `codex://threads/new?path=<encoded-folder>` respectively. In a mixed-provider project,
+select a Codex astronaut before choosing New conversation to use Codex's composer.
+
+Archiving requires a standalone Codex CLI with `archive` and `unarchive` commands. Install
+it on `PATH`, or set `BOT_CROSSING_CODEX_BIN` to its executable path before starting the
+server. Executables inside application bundles are rejected. CLI errors appear in the UI;
+a failed archive does not hide the task locally. A successful archive stops being pending
+when the next database scan confirms it; no desktop restart is needed.
+
+Codex's working animation is an **inference**, based on bounded transcript tails and a
+30-minute activity ceiling. Completion and cancellation stop it; missing or stale evidence
+does not count as running. Building growth uses actual transcript bytes and represents
+accumulated activity, **not percentage complete**. Transcripts are cached and their state is
+discarded when a file is truncated or replaced. Older schemas can leave some metadata blank.
+
+The adapter builds on [PR #5](https://github.com/jarrenrocks/bot-crossing/pull/5), pinned at
+`c6ccb1fe55d9e6e835efa1ef2fa04ffbb2a2fcf7`. Run `npm test` for its focused fixture suite and
+`npm run build` for the production build.
 
 ### Adding one
 
@@ -71,7 +98,7 @@ than have you work around it.
 | --- | --- |
 | One hex zone | One repo. Bigger repos claim more tiles — one per seven threads, grown as a contiguous blob from the middle outward. A zone stays where it is: see below |
 | One astronaut + one building | One session |
-| How finished a building looks | How large its transcript is, on a log scale |
+| How finished a building looks | Transcript bytes on a log scale: accumulated activity, not percentage complete |
 | Scaffolding | Somebody is at that site right now |
 | Walking out of the ship | A thread that just appeared |
 | Walking back into the ship | You archived it |
@@ -191,10 +218,9 @@ flipping to its left rather than sliding under the sidebar, and never leaving th
 It is moved with a transform rather than with `left`/`top`, the one geometric change a
 browser makes without touching layout, so following a walking astronaut costs nothing.
 
-- **Open** hands the thread back to Claude Code and the desktop app comes forward.
-- **Archive** sets `isArchived` on Claude Code's own session record — the thread lands in
-  Claude Code's Archived list, not just here — and the astronaut walks back up the ramp and
-  boards the ship.
+- **Open** hands the thread back to its harness and the desktop app comes forward.
+- **Archive** updates the harness's own archive state — Claude's `isArchived` field or
+  Codex's standalone CLI command — and the astronaut walks back up the ramp and boards the ship.
 
 Only one button in the panel is ever the accent colour: whichever action is the immediate
 one. `Esc` steps outward a notch at a time — the thread first, then its zone.
@@ -205,7 +231,7 @@ transcript: it *imports* the transcript, which creates a second untitled session
 the `.jsonl`, so it is only ever used when there is nothing to navigate to.
 
 Archiving carries a deliberate one-writer discipline: the browser owns
-`data/colony.json` and PUTs it whole, `/api/archive` only touches Claude Code's records. If
+`data/colony.json` and PUTs it whole, `/api/archive` only updates the harness's records. If
 both wrote it, a save from a page holding older state would silently drop every archive made
 since that page loaded. Claude Code also rewrites its session records from memory and can
 stomp the flag, so the colony re-asserts it on every scan — an archive that gets stomped comes
@@ -596,7 +622,7 @@ What it touches on disk, in full:
 | | |
 | --- | --- |
 | Reads | Your harness's own session records and transcripts |
-| Writes | `data/colony.json`, and **one** `isArchived` field per archived thread |
+| Writes | `data/colony.json`, Claude's `isArchived` field, or Codex archive/unarchive through its standalone CLI |
 | Sends | Nothing. No network calls, no telemetry, no account |
 
 `data/colony.json` holds the names and paths of the repos you work in, so it is gitignored —
@@ -609,6 +635,7 @@ server/
   harnesses/   one adapter per agent harness — README.md is the contract
     index.mjs    the registry: add your harness to the list here
     claude-code.mjs
+    codex.mjs
   lib/         filesystem helpers the adapters share
   scan.mjs     harness-agnostic: asks every detected harness, merges, sorts
   api.mjs      /api/threads, /api/harnesses, /api/state, /api/open, /api/archive,

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "linux"
   ],
   "scripts": {
+    "test": "node --test test/codex.test.mjs",
     "dev": "npm run assets --silent && vite",
     "build": "npm run assets --silent && vite build",
     "start": "vite build && node server/serve.mjs",

--- a/server/api.mjs
+++ b/server/api.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url'
 import {
   defaultHarness,
   harnessAppStartedAt,
+  harnessArchiveSync,
   harnessStatus,
   newSession as harnessNewSession,
   openThread as harnessOpenThread,
@@ -146,6 +147,10 @@ async function reconcileArchived(threads) {
   return Promise.all(
     threads.map(async (thread) => {
       if (!wanted.has(thread.id)) return thread
+      if (harnessArchiveSync(thread.harness) === 'database') {
+        // Only a user action invokes this harness's CLI. Polling merely confirms its result.
+        return { ...thread, archived: true, archivePending: !thread.archived }
+      }
       if (!thread.archived && thread.canArchive) {
         await setThreadArchived(thread.harness, thread.ref, true).catch(() => {})
       }
@@ -250,7 +255,8 @@ export async function apiMiddleware(req, res, next) {
   try {
     if (url.pathname === '/api/threads' && req.method === 'GET') {
       const threads = await reconcileArchived(await scanThreads())
-      return send(res, 200, { threads, scannedAt: Date.now() })
+      const warnings = (await harnessStatus()).filter((h) => h.error).map((h) => h.error)
+      return send(res, 200, { threads, scannedAt: Date.now(), warnings })
     }
 
     if (url.pathname === '/api/harnesses' && req.method === 'GET') {
@@ -300,6 +306,7 @@ export async function apiMiddleware(req, res, next) {
         })
       }
       const result = await setThreadArchived(harness, ref, archived)
+      if (!result.ok && harnessArchiveSync(harness) === 'database') return send(res, 400, result)
       return send(res, 200, { ...result, ok: true, archived: Boolean(archived), harnessRecord: result.ok })
     }
 

--- a/server/harnesses/README.md
+++ b/server/harnesses/README.md
@@ -22,6 +22,8 @@ export default {
   newSession,                    // (dir) => { ok, url } | { ok: false, error }
   setArchived,                   // (ref, archived) => Promise<{ ok, error? }>
   appStartedAt,                  // optional: () => Promise<number>
+  archiveSync: 'database',        // optional: default 'restart' preserves Claude's behaviour
+  diagnostic,                    // optional: () => Promise<string>, empty string means healthy
 }
 ```
 
@@ -66,6 +68,17 @@ Be conservative about what you write. The Claude Code adapter touches exactly on
 through a temp file and renames over the original, and re-reads the record first to check it
 is the session it thinks it is. Someone's real work is in these files.
 
+### `archiveSync` / `diagnostic()` — optional
+
+Use `archiveSync: 'database'` when `scanThreads()` reports authoritative archive state.
+The next scan confirms completion without waiting for an app restart or re-running an
+archive command. For this mode, action failures return an error rather than locally hiding
+the thread. Omit it to preserve the existing restart-based reconciliation.
+
+`diagnostic()` returns a user-facing setup error or `''`. `/api/harnesses` exposes it and
+`/api/threads` includes it in `warnings`, which the HUD displays. Detection can remain true
+when a data store exists but its runtime is unsupported; other harnesses keep scanning.
+
 ### `appStartedAt()` — optional
 
 Epoch milliseconds of when the harness's long-lived app last launched, or `0`.
@@ -96,11 +109,12 @@ what earns a repo its own zone, and `lastActivityAt` is what sorts the whole map
 | `lastActivityAt` | number | Epoch ms. Sorts the colony and drives the "asleep for 3 days" behaviour |
 | `lastFocusedAt` | number | Epoch ms, `0` if unknowable |
 | `running` | boolean | Working **right now** — the astronaut hammers away |
+| `activityNote` | string | Optional explanation of inferred activity, shown on the card tooltip |
 | `unread` | boolean | Moved on since you last looked — the astronaut stops and holds a `?` |
 | `hasError` | boolean | Errored — the astronaut slumps, red eyes |
 | `starred` / `routine` / `prState` | | Optional extras; `prState: 'merged'` triggers the confetti |
 | `archived` | boolean | Archived in the harness's own records |
-| `sizeBytes` | number | Transcript size. **This is how finished a building looks**, on a log scale |
+| `sizeBytes` | number | Actual transcript bytes, not token counts. Building growth is activity volume, not task completion |
 | `source` | string | Free-form, for your own bookkeeping (the Claude adapter uses `desktop` / `cli`) |
 | `canOpen` / `canArchive` | boolean | Whether this thread supports those actions. The UI greys the buttons out |
 | `ref` | object | **Opaque.** Whatever *you* need to find this thread again |
@@ -137,9 +151,10 @@ Verified on a real machine:
   (`%APPDATA%\Claude\claude-code-sessions\…` on Windows); CLI transcripts in
   `~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl`; live processes in
   `~/.claude/sessions/*.json`. Implemented in `claude-code.mjs`.
-- **Codex CLI** — transcripts in `~/.codex/sessions/YYYY/MM/DD/rollout-<iso>-<uuid>.jsonl`,
-  with records shaped `{ timestamp, type, payload }`, and what looks like an index at
-  `~/.codex/session_index.jsonl`. Not implemented yet.
+- **Codex** — newest numbered `state_*.sqlite` under `CODEX_HOME` (default `~/.codex`),
+  `.codex-global-state.json` for desktop hints/unread state, and bounded tails of the indexed
+  rollout files. Implemented in `codex.mjs`; requires Node 22.13+. Archive actions use a
+  standalone CLI from `PATH` or `BOT_CROSSING_CODEX_BIN`, never an app-bundle executable.
 
 For anything else, the fastest way in is usually to start a throwaway session in that harness
 and watch which files change:
@@ -150,8 +165,8 @@ find ~ -maxdepth 4 -newermt '-2 minutes' -type f 2>/dev/null | grep -iv Library/
 
 ## Checking your work
 
-There is no test suite to run yet. What the Claude Code adapter was verified against, and what
-a new one should clear too:
+Run `npm test` on Node 22.13+ for Codex fixtures and archive reconciliation coverage.
+What the Claude Code adapter was verified against, and what a new one should clear too:
 
 1. `node --check server/harnesses/my-harness.mjs`
 2. With the app running, `GET /api/harnesses` lists every registered harness and whether

--- a/server/harnesses/codex.mjs
+++ b/server/harnesses/codex.mjs
@@ -1,0 +1,427 @@
+/**
+ * Harness adapter: Codex (OpenAI) — the desktop app and CLI share one local state database.
+ *
+ * Codex publishes its thread index in the newest ~/.codex/state_*.sqlite database. Metadata
+ * comes from that database through Node's read-only SQLite mode; only the tail of a rollout is
+ * read for live/error state, which the index does not currently expose. No scan runs a process
+ * or reaches into an application bundle.
+ */
+import fsp from 'node:fs/promises'
+import { constants as fsConstants } from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { jsonLines, num } from '../lib/fsutil.mjs'
+
+const execFileAsync = promisify(execFile)
+const HOME = os.homedir()
+const CODEX_HOME = process.env.CODEX_HOME || path.join(HOME, '.codex')
+const APP_STATE = path.join(CODEX_HOME, '.codex-global-state.json')
+const CODEX_BINARY_ENV = 'BOT_CROSSING_CODEX_BIN'
+
+const TAIL_BYTES = 512 * 1024
+const MAX_ACTIVE_TAIL_BYTES = 2 * 1024 * 1024
+const ACTIVE_WINDOW_MS = 30 * 60 * 1000
+const STATE_DATABASE = /^state_(\d+)\.sqlite$/
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+const APP_BUNDLE_EXECUTABLE = /\.app[/\\]Contents[/\\]/i
+
+let sqlitePromise
+async function sqliteApi() {
+  if (!sqlitePromise) sqlitePromise = import('node:sqlite').catch(() => null)
+  return sqlitePromise
+}
+
+async function diagnostic() {
+  if (!(await latestStateDatabase())) return ''
+  const [major, minor] = process.versions.node.split('.').map(Number)
+  if (major < 22 || (major === 22 && minor < 13) || !(await sqliteApi())?.DatabaseSync) {
+    return 'Codex requires Node 22.13 or newer; restart Bot Crossing with a supported Node version'
+  }
+  return ''
+}
+
+let codexHomeRealPromise
+async function safeCodexFile(file) {
+  if (typeof file !== 'string' || !file) return ''
+  if (!codexHomeRealPromise) {
+    codexHomeRealPromise = fsp.realpath(CODEX_HOME).catch(() => path.resolve(CODEX_HOME))
+  }
+  try {
+    const [home, real] = await Promise.all([codexHomeRealPromise, fsp.realpath(file)])
+    const relative = path.relative(home, real)
+    if (relative === '..' || relative.startsWith('..' + path.sep) || path.isAbsolute(relative)) {
+      return ''
+    }
+    return real
+  } catch {
+    return ''
+  }
+}
+
+/** Pick the highest schema version, not the most recently touched WAL sibling. */
+async function latestStateDatabase() {
+  let entries
+  try {
+    entries = await fsp.readdir(CODEX_HOME, { withFileTypes: true })
+  } catch {
+    return ''
+  }
+  return entries
+    .filter((entry) => entry.isFile() && STATE_DATABASE.test(entry.name))
+    .map((entry) => ({
+      file: path.join(CODEX_HOME, entry.name),
+      version: Number(entry.name.match(STATE_DATABASE)[1]),
+    }))
+    .sort((a, b) => b.version - a.version)[0]?.file || ''
+}
+
+const column = (columns, name, fallback = "''") =>
+  columns.has(name) ? `t.${name}` : fallback
+
+function timestampExpression(columns, milliseconds, seconds) {
+  if (columns.has(milliseconds) && columns.has(seconds)) {
+    return `COALESCE(t.${milliseconds}, t.${seconds} * 1000)`
+  }
+  if (columns.has(milliseconds)) return `t.${milliseconds}`
+  if (columns.has(seconds)) return `t.${seconds} * 1000`
+  return '0'
+}
+
+/** Read the canonical thread index. The connection itself refuses writes. */
+async function databaseThreads() {
+  const [databaseFile, sqlite] = await Promise.all([latestStateDatabase(), sqliteApi()])
+  const error = await diagnostic()
+  if (error) throw new Error(error)
+  if (!databaseFile) return { rows: [], projectRoots: new Map() }
+
+  const database = new sqlite.DatabaseSync(databaseFile, { readOnly: true })
+  try {
+    const tables = new Set(
+      database
+        .prepare("SELECT name FROM sqlite_master WHERE type = 'table'")
+        .all()
+        .map((row) => row.name)
+    )
+    if (!tables.has('threads')) return { rows: [], projectRoots: new Map() }
+
+    const columns = new Set(database.prepare('PRAGMA table_info(threads)').all().map((row) => row.name))
+    if (!['id', 'cwd', 'source'].every((name) => columns.has(name))) {
+      throw new Error('Codex state database is missing required thread columns')
+    }
+
+    const children = new Set()
+    if (tables.has('thread_spawn_edges')) {
+      const edgeColumns = new Set(
+        database.prepare('PRAGMA table_info(thread_spawn_edges)').all().map((row) => row.name)
+      )
+      if (edgeColumns.has('child_thread_id')) {
+        for (const row of database.prepare('SELECT child_thread_id FROM thread_spawn_edges').all()) {
+          if (typeof row.child_thread_id === 'string') children.add(row.child_thread_id)
+        }
+      }
+    }
+
+    const projectRoots = new Map()
+    if (columns.has('project_id') && tables.has('project_roots')) {
+      const rootColumns = new Set(
+        database.prepare('PRAGMA table_info(project_roots)').all().map((row) => row.name)
+      )
+      if (['project_id', 'path', 'position'].every((name) => rootColumns.has(name))) {
+        const roots = database
+          .prepare('SELECT project_id, path FROM project_roots ORDER BY project_id, position')
+          .all()
+        for (const root of roots) {
+          if (!projectRoots.has(root.project_id) && typeof root.path === 'string') {
+            projectRoots.set(root.project_id, root.path)
+          }
+        }
+      }
+    }
+
+    const createdAt = timestampExpression(columns, 'created_at_ms', 'created_at')
+    const updatedAt = timestampExpression(columns, 'updated_at_ms', 'updated_at')
+    const rows = database
+      .prepare(`
+        SELECT
+          t.id,
+          ${column(columns, 'name')} AS name,
+          ${column(columns, 'title')} AS title,
+          ${column(columns, 'preview')} AS preview,
+          ${column(columns, 'first_user_message')} AS first_user_message,
+          t.cwd,
+          t.source,
+          ${column(columns, 'thread_source')} AS thread_source,
+          ${column(columns, 'git_branch')} AS git_branch,
+          ${column(columns, 'git_origin_url')} AS git_origin_url,
+          ${column(columns, 'model')} AS model,
+          ${column(columns, 'reasoning_effort')} AS reasoning_effort,
+          ${column(columns, 'rollout_path')} AS rollout_path,
+          ${column(columns, 'project_id')} AS project_id,
+          ${column(columns, 'archived', '0')} AS archived,
+          ${column(columns, 'is_pinned', '0')} AS is_pinned,
+          ${createdAt} AS created_at_ms,
+          ${updatedAt} AS updated_at_ms
+        FROM threads t
+        WHERE t.source IN ('cli', 'vscode', 'exec')
+      `)
+      .all()
+      .filter(
+        (row) =>
+          typeof row.id === 'string' && UUID.test(row.id) && typeof row.cwd === 'string' &&
+          !children.has(row.id) &&
+          !['subagent', 'guardian_review'].includes(row.thread_source)
+      )
+
+    return { rows, projectRoots }
+  } finally {
+    database.close()
+  }
+}
+
+/** Drop UI context injected ahead of the prompt; it is not card copy a person authored. */
+function cleanPrompt(value) {
+  const text = String(value || '')
+    .replace(/<(in-app-browser-context|environment_context)\b[^>]*>[\s\S]*?<\/\1>/gi, ' ')
+  const request = text.lastIndexOf('## My request:')
+  return (request === -1 ? text : text.slice(request + '## My request:'.length))
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function shortTitle(value) {
+  const title = cleanPrompt(value)
+  if (title.length <= 120) return title
+  const cut = title.slice(0, 117)
+  const boundary = cut.lastIndexOf(' ')
+  return (boundary > 72 ? cut.slice(0, boundary) : cut).trimEnd() + '…'
+}
+
+/** Older desktop threads have project assignments here rather than in the database. */
+async function desktopState() {
+  try {
+    const state = JSON.parse(await fsp.readFile(APP_STATE, 'utf8'))
+    const ids = state?.['electron-persisted-atom-state']?.['unread-thread-ids-by-host-v1']?.local
+    const roots = new Map()
+    for (const [id, root] of Object.entries(state?.['thread-workspace-root-hints'] || {})) {
+      if (typeof root === 'string' && path.isAbsolute(root)) roots.set(id, root)
+    }
+    for (const [id, assignment] of Object.entries(state?.['thread-project-assignments'] || {})) {
+      const root = state?.['local-projects']?.[assignment?.projectId]?.rootPaths?.[0]
+      if (!roots.has(id) && typeof root === 'string' && path.isAbsolute(root)) roots.set(id, root)
+    }
+    return { unread: new Set(Array.isArray(ids) ? ids.filter((id) => UUID.test(id)) : []), roots }
+  } catch {
+    return { unread: new Set(), roots: new Map() }
+  }
+}
+
+async function readTail(handle, size, bytes) {
+  const length = Math.min(size, bytes)
+  const start = Math.max(0, size - length)
+  const buffer = Buffer.allocUnsafe(length)
+  const { bytesRead } = await handle.read(buffer, 0, length, start)
+  let text = buffer.subarray(0, bytesRead).toString('utf8')
+  if (start) text = text.slice(text.indexOf('\n') + 1)
+  if (!text.endsWith('\n')) text = text.slice(0, text.lastIndexOf('\n') + 1)
+  return text
+}
+
+function readLifecycle(records) {
+  let lifecycle = null
+  for (const record of records) {
+    if (!record || typeof record !== 'object') continue
+    const payload = record?.payload || {}
+    if (
+      record.type === 'event_msg' &&
+      ['task_started', 'task_complete', 'turn_aborted'].includes(payload.type)
+    ) {
+      lifecycle = { type: payload.type, error: Boolean(payload.error) }
+    }
+  }
+  return lifecycle
+}
+
+/** Small boundary check distinguishes append-only growth from a rewritten transcript. */
+async function boundary(handle, size) {
+  const buffer = Buffer.alloc(Math.min(size, 128))
+  const { bytesRead } = await handle.read(buffer, 0, buffer.length, size - buffer.length)
+  return buffer.subarray(0, bytesRead).toString('base64')
+}
+
+/** Rollout tails supply only ephemeral state not represented in the SQLite index. */
+const lifecycleCache = new Map()
+async function rolloutLifecycle(file) {
+  const safeFile = await safeCodexFile(file)
+  const empty = { lifecycle: null, size: 0, mtime: 0 }
+  if (!safeFile) {
+    lifecycleCache.delete(file)
+    return empty
+  }
+  let handle
+  try {
+    handle = await fsp.open(safeFile, 'r')
+    const stat = await handle.stat()
+    if (!stat.isFile()) {
+      lifecycleCache.delete(file)
+      return empty
+    }
+    const cached = lifecycleCache.get(file)
+    const sameFile = cached && cached.ino === stat.ino && cached.dev === stat.dev &&
+      cached.birthtime === stat.birthtimeMs
+    if (sameFile && cached.mtime === stat.mtimeMs && cached.ctime === stat.ctimeMs &&
+        cached.size === stat.size) return cached
+
+    const appended = sameFile && stat.size > cached.size &&
+      await boundary(handle, cached.size) === cached.boundary
+    let lifecycle = readLifecycle(jsonLines(await readTail(handle, stat.size, TAIL_BYTES)))
+    if (!lifecycle && !(appended && cached.lifecycle) && Date.now() - stat.mtimeMs < ACTIVE_WINDOW_MS) {
+      lifecycle = readLifecycle(jsonLines(await readTail(handle, stat.size, MAX_ACTIVE_TAIL_BYTES)))
+    }
+    if (!lifecycle && appended) lifecycle = cached.lifecycle
+    const result = {
+      mtime: stat.mtimeMs, ctime: stat.ctimeMs, size: stat.size,
+      ino: stat.ino, dev: stat.dev, birthtime: stat.birthtimeMs,
+      boundary: await boundary(handle, stat.size), lifecycle,
+    }
+    lifecycleCache.set(file, result)
+    return result
+  } catch {
+    // One disappearing, unreadable, or mid-replacement rollout must not hide the other tasks.
+    lifecycleCache.delete(file)
+    return empty
+  } finally {
+    await handle?.close()
+  }
+}
+
+/** Use Codex's project index when available. Older rows safely fall back to their cwd. */
+function projectOf(row, projectRoots, desktopRoots) {
+  const indexedRoot = projectRoots.get(row.project_id) || desktopRoots.get(row.id) || ''
+  const projectPath = indexedRoot || row.cwd || ''
+  const relative = path.relative(path.join(CODEX_HOME, 'worktrees'), row.cwd || '')
+  const isCodexWorktree = relative && !relative.startsWith('..') && !path.isAbsolute(relative)
+  const worktree = isCodexWorktree ? relative.split(path.sep)[0] :
+    indexedRoot && indexedRoot !== row.cwd ? path.basename(row.cwd) : ''
+  return { projectPath, project: path.basename(projectPath) || projectPath || 'unknown', worktree }
+}
+
+async function scanThreads() {
+  const [{ rows, projectRoots }, desktop] = await Promise.all([databaseThreads(), desktopState()])
+  const rollouts = new Set(rows.map((row) => row.rollout_path))
+  for (const file of lifecycleCache.keys()) if (!rollouts.has(file)) lifecycleCache.delete(file)
+  return await Promise.all(
+    rows.map(async (row) => {
+      const rollout = await rolloutLifecycle(row.rollout_path)
+      const { lifecycle } = rollout
+      const firstPrompt = cleanPrompt(row.preview || row.first_user_message)
+      const title = shortTitle(row.name || row.title || firstPrompt) || 'Untitled thread'
+      const { projectPath, project, worktree } = projectOf(row, projectRoots, desktop.roots)
+      const lastActivityAt = Math.max(num(row.updated_at_ms), rollout.mtime)
+      return {
+        id: row.id,
+        title,
+        preview: firstPrompt.slice(0, 240),
+        project,
+        projectPath,
+        worktree,
+        cwd: row.cwd || '',
+        gitBranch: row.git_branch || '',
+        model: row.model || '',
+        effort: row.reasoning_effort || '',
+        createdAt: num(row.created_at_ms) || lastActivityAt,
+        lastActivityAt,
+        lastFocusedAt: 0,
+        // ponytail: transcript activity is a heuristic; use a live event stream if exact state is needed.
+        running: !row.archived && lifecycle?.type === 'task_started' &&
+          Date.now() - rollout.mtime < ACTIVE_WINDOW_MS,
+        activityNote: 'Codex activity is inferred from recent transcript events (30-minute ceiling)',
+        unread: desktop.unread.has(row.id),
+        hasError: lifecycle?.type === 'task_complete' && lifecycle.error,
+        starred: Boolean(row.is_pinned),
+        routine: '',
+        prState: '',
+        archived: Boolean(row.archived),
+        sizeBytes: rollout.size,
+        source: row.source,
+        canOpen: true,
+        canArchive: true,
+        ref: { sessionId: row.id },
+      }
+    })
+  )
+}
+
+function openThread(ref) {
+  const id = ref?.sessionId || ''
+  if (!UUID.test(id)) return { ok: false, error: 'No openable Codex session id on that thread' }
+  return { ok: true, url: 'codex://threads/' + id }
+}
+
+function newSession(dir) {
+  return { ok: true, url: 'codex://threads/new?' + new URLSearchParams({ path: dir }) }
+}
+
+/** Resolve only an explicit override or PATH entry, and only after Archive is clicked. */
+async function codexBinary() {
+  const override = process.env[CODEX_BINARY_ENV]
+  const candidates = []
+  if (override) candidates.push(path.isAbsolute(override) ? override : path.resolve(override))
+  for (const dir of (process.env.PATH || '').split(path.delimiter).filter(Boolean)) {
+    candidates.push(path.join(dir, 'codex'))
+  }
+  for (const candidate of candidates) {
+    try {
+      await fsp.access(candidate, fsConstants.X_OK)
+      const real = await fsp.realpath(candidate)
+      // PATH can itself contain an app's Resources directory, and a harmless-looking symlink
+      // can resolve back into one. Never execute either form from another app's bundle.
+      if (APP_BUNDLE_EXECUTABLE.test(real)) continue
+      return real
+    } catch {
+      /* try the next PATH entry */
+    }
+  }
+  return ''
+}
+
+async function setArchived(ref, archived) {
+  const id = ref?.sessionId || ''
+  if (!UUID.test(id)) return { ok: false, error: 'No archivable Codex session id on that thread' }
+  if (typeof archived !== 'boolean') return { ok: false, error: 'Archive state must be a boolean' }
+  const binary = await codexBinary()
+  if (!binary) {
+    return {
+      ok: false,
+      error: `No standalone Codex CLI found; install it or set ${CODEX_BINARY_ENV}`,
+    }
+  }
+  try {
+    await execFileAsync(binary, [archived ? 'archive' : 'unarchive', id], {
+      timeout: 15000,
+      maxBuffer: 1024 * 1024,
+    })
+    return { ok: true, archived: Boolean(archived) }
+  } catch (error) {
+    const detail = String(error?.stderr || error?.message || '').trim().split('\n').pop()
+    return { ok: false, error: detail || 'Codex could not update that session' }
+  }
+}
+
+async function detect() {
+  return Boolean(await latestStateDatabase())
+}
+
+export default {
+  id: 'codex',
+  name: 'Codex',
+  detect,
+  diagnostic,
+  archiveSync: 'database',
+  scanThreads,
+  openThread,
+  newSession,
+  setArchived,
+  paths: { CODEX_HOME, APP_STATE },
+}

--- a/server/harnesses/index.mjs
+++ b/server/harnesses/index.mjs
@@ -7,8 +7,9 @@
  * `server/harnesses/README.md`.
  */
 import claudeCode from './claude-code.mjs'
+import codex from './codex.mjs'
 
-export const HARNESSES = [claudeCode]
+export const HARNESSES = [claudeCode, codex]
 
 export const harnessById = (id) => HARNESSES.find((h) => h.id === id) || null
 

--- a/server/scan.mjs
+++ b/server/scan.mjs
@@ -82,8 +82,14 @@ export async function scanThreads() {
 /** What the HUD shows in the harness list: who is installed, and what they can do. */
 export async function harnessStatus() {
   const detected = new Set((await detectedHarnesses()).map((h) => h.id))
-  return HARNESSES.map((h) => ({ id: h.id, name: h.name, detected: detected.has(h.id) }))
+  return Promise.all(HARNESSES.map(async (h) => ({
+    id: h.id, name: h.name, detected: detected.has(h.id),
+    error: h.diagnostic ? await h.diagnostic() : '',
+  })))
 }
+
+/** Database-backed adapters confirm archiving on the next read, without an app restart. */
+export const harnessArchiveSync = (id) => harnessById(id)?.archiveSync || 'restart'
 
 /** The harness to use when a caller has not said — the first one present on this machine. */
 export async function defaultHarness() {

--- a/src/main.js
+++ b/src/main.js
@@ -283,6 +283,8 @@ function harnessLabel(id) {
  * a new thread in whichever one it is mostly used from.
  */
 function harnessForProject(name) {
+  const selected = threads.find((t) => t.id === selectedId && t.project === name)
+  if (selected?.harness) return selected.harness
   const counts = new Map()
   for (const thread of colony.threads.values()) {
     if (thread.project !== name || !thread.harness) continue
@@ -574,12 +576,16 @@ function applyThreads(list) {
 }
 
 let polling = false
+let scannerWarnings = ''
 async function poll() {
   if (polling) return
   polling = true
   try {
     const res = await fetchThreads()
     applyThreads(res.threads || [])
+    const warnings = (res.warnings || []).join('\n')
+    if (warnings && warnings !== scannerWarnings) hud.toast(warnings, 'err')
+    scannerWarnings = warnings
     hud.removeBoot()
   } catch (err) {
     hud.toast(err.message || 'Could not reach the thread scanner', 'err')

--- a/src/ui/hud.js
+++ b/src/ui/hud.js
@@ -499,18 +499,22 @@ export class Hud {
     this.$('.thread-pop .title').textContent = thread.title || 'Untitled thread'
     const status = STATUS_LABEL[agent.status] || agent.status
     const meta = this.$('.thread-pop .meta')
+    meta.title = thread.activityNote || ''
     const bits = [
       `<span class="tag"><i class="swatch" style="background:${hex(agent.trim.getHex())}"></i>${escapeHtml(status)}</span>`,
     ]
     // The repo is the panel's own heading now, so the card says what the *thread* is.
+    if (thread.harnessName) bits.push(`<span class="tag">${escapeHtml(thread.harnessName)}</span>`)
     if (thread.worktree) bits.push(`<span class="tag">⑂ ${escapeHtml(thread.worktree)}</span>`)
     if (thread.gitBranch) bits.push(`<span class="tag">${escapeHtml(thread.gitBranch)}</span>`)
     if (thread.model) bits.push(`<span class="tag">${escapeHtml(shortModel(thread.model))}</span>`)
+    if (thread.effort) bits.push(`<span class="tag">${escapeHtml(thread.effort)}</span>`)
     bits.push(`<span>${ago(thread.lastActivityAt)}</span>`)
     meta.innerHTML = bits.join('')
 
     const pct = Math.round((this.actions.progressFor?.(thread.id) ?? 0) * 100)
     this.$('.thread-pop .progress > i').style.width = `${pct}%`
+    this.$('.thread-pop .progress').title = 'Transcript activity volume, not task completion'
     this.$('.thread-pop .progress > i').style.background = hex(agent.trim.getHex())
     // Measured once per selection rather than per frame: placing the card beside its
     // astronaut needs its size sixty times a second, and asking the layout for it that

--- a/test/codex.test.mjs
+++ b/test/codex.test.mjs
@@ -1,0 +1,302 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fsp from 'node:fs/promises'
+import path from 'node:path'
+import os from 'node:os'
+import { randomUUID, createHash } from 'node:crypto'
+import { DatabaseSync } from 'node:sqlite'
+import childProcess from 'node:child_process'
+import { syncBuiltinESMExports } from 'node:module'
+import { PassThrough } from 'node:stream'
+
+const adapterURL = new URL('../server/harnesses/codex.mjs', import.meta.url)
+const event = (type, error = false) => JSON.stringify({
+  timestamp: new Date().toISOString(), type: 'event_msg', payload: { type, error },
+}) + '\n'
+
+async function fixture(t) {
+  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'bot-crossing-test-'))
+  const names = ['CODEX_HOME', 'BOT_CROSSING_CODEX_BIN', 'BOT_CROSSING_DATA', 'PATH']
+  const env = Object.fromEntries(names.map((name) => [name, process.env[name]]))
+  process.env.CODEX_HOME = dir
+  process.env.BOT_CROSSING_DATA = path.join(dir, 'colony')
+  delete process.env.BOT_CROSSING_CODEX_BIN
+  t.after(async () => {
+    for (const name of names) {
+      if (env[name] === undefined) delete process.env[name]
+      else process.env[name] = env[name]
+    }
+    await fsp.rm(dir, { recursive: true, force: true })
+  })
+  const file = path.join(dir, 'state_5.sqlite')
+  const db = new DatabaseSync(file)
+  db.exec(`
+    CREATE TABLE threads (
+      id TEXT PRIMARY KEY, cwd TEXT, source TEXT DEFAULT 'vscode', title TEXT, name TEXT,
+      preview TEXT, first_user_message TEXT, model TEXT, reasoning_effort TEXT,
+      rollout_path TEXT, project_id TEXT, thread_source TEXT, archived INTEGER DEFAULT 0,
+      tokens_used INTEGER DEFAULT 999999, is_pinned INTEGER DEFAULT 0, git_branch TEXT,
+      created_at INTEGER, updated_at INTEGER, created_at_ms INTEGER, updated_at_ms INTEGER
+    );
+    CREATE TABLE thread_spawn_edges (child_thread_id TEXT);
+    CREATE TABLE project_roots (project_id TEXT, position INTEGER, path TEXT);
+  `)
+  t.after(() => db.close())
+  const add = async (overrides = {}, text = event('task_complete')) => {
+    const id = overrides.id || randomUUID()
+    const rollout = path.join(dir, id + '.jsonl')
+    await fsp.writeFile(rollout, text)
+    const now = Date.now()
+    const row = {
+      id, cwd: path.join(dir, 'repo'), source: 'vscode', title: 'Task', rollout_path: rollout,
+      created_at: Math.floor(now / 1000), updated_at: Math.floor(now / 1000), ...overrides,
+    }
+    const keys = Object.keys(row)
+    db.prepare(`INSERT INTO threads (${keys.join(',')}) VALUES (${keys.map(() => '?').join(',')})`)
+      .run(...Object.values(row))
+    return { id, rollout: row.rollout_path }
+  }
+  const load = async () => (await import(`${adapterURL}?test=${randomUUID()}`)).default
+  return { dir, file, db, add, load }
+}
+
+test('canonical metadata, children, desktop project fallback and byte counts; scans are read-only', async (t) => {
+  const f = await fixture(t)
+  const root = path.join(f.dir, 'repo')
+  f.db.prepare('INSERT INTO project_roots VALUES (?, ?, ?)').run('p', 0, root)
+  const parent = await f.add({
+    name: 'Named task', title: 'Older title', preview: '<environment_context>noise</environment_context> Hello',
+    project_id: 'p', cwd: path.join(f.dir, 'worktrees', 'abc', 'repo'),
+    model: 'test-model', reasoning_effort: 'high', is_pinned: 1, git_branch: 'feature',
+  }, event('task_started'))
+  const child = await f.add()
+  f.db.prepare('INSERT INTO thread_spawn_edges VALUES (?)').run(child.id)
+  await f.add({ thread_source: 'subagent' })
+  await f.add({ cwd: null })
+  await f.add({ id: 'malformed-id' })
+  await f.add({ source: '{"subagent":{"other":"guardian"}}', thread_source: 'guardian_review' })
+  const archived = await f.add({ source: 'cli', archived: 1 })
+  const exec = await f.add({ source: 'exec', thread_source: 'user' })
+  const legacy = await f.add({ cwd: path.join(f.dir, 'worktrees', 'old', 'repo') })
+  const assigned = await f.add({ cwd: path.join(f.dir, 'worktrees', 'assigned', 'repo') })
+  await fsp.writeFile(path.join(f.dir, '.codex-global-state.json'), JSON.stringify({
+    'electron-persisted-atom-state': { 'unread-thread-ids-by-host-v1': { local: [parent.id] } },
+    'thread-workspace-root-hints': { [legacy.id]: root },
+    'thread-project-assignments': { [assigned.id]: { projectId: 'legacy-project' } },
+    'local-projects': { 'legacy-project': { rootPaths: [root] } },
+  }))
+  const fingerprint = async () => {
+    const result = {}
+    for (const file of await fsp.readdir(f.dir)) {
+      const full = path.join(f.dir, file)
+      const stat = await fsp.stat(full)
+      if (stat.isFile()) result[file] = [stat.mtimeMs, createHash('sha256').update(await fsp.readFile(full)).digest('hex')]
+    }
+    return result
+  }
+  const before = await fingerprint()
+  const mock = t.mock.method(childProcess, 'execFile', () => { throw new Error('scan spawned a process') })
+  syncBuiltinESMExports()
+  try {
+    const c = await f.load()
+    assert.equal(await c.detect(), true)
+    const rows = await c.scanThreads()
+    assert.equal(rows.length, 5)
+    assert.equal(mock.mock.callCount(), 0)
+    const row = rows.find((r) => r.id === parent.id)
+    assert.equal(row.title, 'Named task')
+    assert.equal(row.preview, 'Hello')
+    assert.equal(row.projectPath, root)
+    assert.equal(row.worktree, 'abc')
+    assert.equal(row.model, 'test-model')
+    assert.equal(row.effort, 'high')
+    assert.equal(row.starred, true)
+    assert.equal(row.unread, true)
+    assert.equal(row.running, true)
+    assert.equal(row.sizeBytes, (await fsp.stat(parent.rollout)).size)
+    assert.equal(rows.find((r) => r.id === archived.id).archived, true)
+    assert.equal(rows.find((r) => r.id === exec.id).source, 'exec')
+    assert.equal(rows.find((r) => r.id === legacy.id).projectPath, root)
+    assert.equal(rows.find((r) => r.id === assigned.id).projectPath, root)
+    assert.ok(rows.every((r) => Object.values(r).every((v) => v !== undefined)))
+    await c.scanThreads()
+    assert.deepEqual(await fingerprint(), before)
+  } finally {
+    mock.mock.restore()
+    syncBuiltinESMExports()
+  }
+})
+
+test('lifecycle transitions, errors, cancellation, malformed and partial records, and stale activity', async (t) => {
+  const f = await fixture(t)
+  const row = await f.add({}, event('task_started'))
+  const c = await f.load()
+  const scan = async () => (await c.scanThreads())[0]
+  assert.equal((await scan()).running, true)
+  await fsp.appendFile(row.rollout, '{broken\nnull\n' + event('task_complete', true).trimEnd())
+  assert.equal((await scan()).running, true, 'unfinished JSONL records are not authoritative')
+  await fsp.appendFile(row.rollout, '\n')
+  assert.equal((await scan()).running, false)
+  assert.equal((await scan()).hasError, true)
+  await fsp.appendFile(row.rollout, event('task_started'))
+  assert.equal((await scan()).hasError, false)
+  assert.equal((await scan()).running, true)
+  await fsp.appendFile(row.rollout, event('turn_aborted'))
+  assert.equal((await scan()).running, false)
+  assert.equal((await scan()).hasError, false)
+  await fsp.appendFile(row.rollout, event('task_started'))
+  const old = new Date(Date.now() - 31 * 60 * 1000)
+  await fsp.utimes(row.rollout, old, old)
+  assert.equal((await scan()).running, false)
+})
+
+test('bounded tails retain append state but invalidate truncation, rewrite and replacement', async (t) => {
+  const f = await fixture(t)
+  const row = await f.add({}, event('task_started'))
+  const c = await f.load()
+  const scan = async () => (await c.scanThreads())[0]
+  await scan()
+  const noise = (JSON.stringify({ type: 'response_item', payload: { text: 'x'.repeat(1024) } }) + '\n')
+    .repeat(2100)
+  await fsp.appendFile(row.rollout, noise)
+  assert.equal((await scan()).running, true, 'cached lifecycle survives genuine append beyond tail budget')
+  await fsp.writeFile(row.rollout, '{}\n')
+  assert.equal((await scan()).running, false)
+  await fsp.writeFile(row.rollout, event('task_started'))
+  assert.equal((await scan()).running, true)
+  await fsp.writeFile(row.rollout, noise)
+  assert.equal((await scan()).running, false, 'larger in-place rewrite is not an append')
+  await fsp.writeFile(row.rollout, event('task_started'))
+  await scan()
+  const previous = await fsp.stat(row.rollout)
+  const replacement = row.rollout + '.tmp'
+  await fsp.writeFile(replacement, ' '.repeat(previous.size - 3) + '{}\n')
+  await fsp.utimes(replacement, previous.atime, previous.mtime)
+  await fsp.rename(replacement, row.rollout)
+  assert.equal((await scan()).running, false, 'same-size replacement with preserved mtime loses cached state')
+})
+
+test('missing, non-file and escaping rollouts do not hide other tasks', async (t) => {
+  const f = await fixture(t)
+  const good = await f.add()
+  const missing = await f.add()
+  await fsp.unlink(missing.rollout)
+  const directory = await f.add({ rollout_path: f.dir })
+  const escaping = await f.add({ rollout_path: '/etc/hosts' })
+  const rows = await (await f.load()).scanThreads()
+  assert.equal(rows.length, 4)
+  assert.ok(rows.find((r) => r.id === good.id).sizeBytes > 0)
+  for (const { id } of [missing, directory, escaping]) {
+    const row = rows.find((r) => r.id === id)
+    assert.equal(row.sizeBytes, 0)
+    assert.equal(row.running, false)
+  }
+})
+
+test('highest schema version, optional columns and unsupported runtime diagnostics', async (t) => {
+  const f = await fixture(t)
+  await f.add()
+  const newer = new DatabaseSync(path.join(f.dir, 'state_12.sqlite'))
+  const id = randomUUID()
+  newer.exec('CREATE TABLE threads (id TEXT, cwd TEXT, source TEXT, created_at INTEGER, updated_at INTEGER)')
+  newer.prepare('INSERT INTO threads VALUES (?, ?, ?, ?, ?)').run(id, f.dir, 'cli', 100, 200)
+  newer.close()
+  const c = await f.load()
+  const rows = await c.scanThreads()
+  assert.equal(rows.length, 1)
+  assert.equal(rows[0].id, id)
+  assert.equal(rows[0].createdAt, 100000)
+  assert.equal(rows[0].lastActivityAt, 200000)
+  assert.equal(rows[0].model, '')
+  const version = Object.getOwnPropertyDescriptor(process.versions, 'node')
+  try {
+    Object.defineProperty(process.versions, 'node', { ...version, value: '22.11.0' })
+    assert.match(await c.diagnostic(), /Node 22\.13/)
+    await assert.rejects(c.scanThreads(), /Node 22\.13/)
+  } finally {
+    Object.defineProperty(process.versions, 'node', version)
+  }
+})
+
+test('deep links validate IDs and encode paths; archive invokes only the standalone CLI', async (t) => {
+  const f = await fixture(t)
+  const c = await f.load()
+  const id = randomUUID()
+  assert.equal(c.openThread({ sessionId: '../bad' }).ok, false)
+  assert.equal(c.openThread({ sessionId: id }).url, `codex://threads/${id}`)
+  const folder = path.join(f.dir, 'a & b?#雪')
+  const url = new URL(c.newSession(folder).url)
+  assert.equal(url.searchParams.get('path'), folder)
+  const log = path.join(f.dir, 'calls.json')
+  const bin = path.join(f.dir, 'codex')
+  await fsp.writeFile(bin, `#!${process.execPath}\n` +
+    `require('fs').writeFileSync(${JSON.stringify(log)}, JSON.stringify(process.argv.slice(2)))\n`, { mode: 0o700 })
+  process.env.PATH = f.dir
+  assert.equal((await c.setArchived({ sessionId: id }, true)).ok, true)
+  assert.deepEqual(JSON.parse(await fsp.readFile(log)), ['archive', id])
+  assert.equal((await c.setArchived({ sessionId: id }, false)).ok, true)
+  assert.deepEqual(JSON.parse(await fsp.readFile(log)), ['unarchive', id])
+  assert.equal((await c.setArchived({ sessionId: id }, 'false')).ok, false)
+  assert.equal((await c.setArchived({ sessionId: '../bad' }, true)).ok, false)
+  await fsp.writeFile(bin, `#!${process.execPath}\nprocess.stderr.write('archive failed');process.exit(1)\n`)
+  assert.match((await c.setArchived({ sessionId: id }, true)).error, /archive failed/)
+  await fsp.unlink(bin)
+  assert.match((await c.setArchived({ sessionId: id }, true)).error, /No standalone Codex CLI/)
+  const bundled = path.join(f.dir, 'Unsafe.app', 'Contents', 'Resources', 'codex')
+  await fsp.mkdir(path.dirname(bundled), { recursive: true })
+  await fsp.writeFile(bundled, `#!${process.execPath}\nprocess.exit(0)\n`, { mode: 0o700 })
+  await fsp.symlink(bundled, bin)
+  process.env.BOT_CROSSING_CODEX_BIN = bin
+  assert.equal((await c.setArchived({ sessionId: id }, true)).ok, false)
+})
+
+test('API confirms database archives without subprocesses and preserves Claude restart semantics', async (t) => {
+  const f = await fixture(t)
+  const { HARNESSES } = await import('../server/harnesses/index.mjs')
+  const previous = [...HARNESSES]
+  t.after(() => HARNESSES.splice(0, HARNESSES.length, ...previous))
+  let codexArchived = false
+  let codexCalls = 0
+  let claudeCalls = 0
+  let restarted = false
+  const now = Date.now()
+  HARNESSES.splice(0, HARNESSES.length,
+    { id: 'codex', name: 'Codex', archiveSync: 'database', detect: async () => true,
+      diagnostic: async () => 'Runtime diagnostic',
+      scanThreads: async () => [{ id: 'codex-task', archived: codexArchived, canArchive: true, lastActivityAt: now }],
+      setArchived: async () => { codexCalls++; return { ok: false, error: 'No standalone Codex CLI' } },
+    },
+    { id: 'claude-code', name: 'Claude Code', detect: async () => true,
+      scanThreads: async () => [{ id: 'claude-task', archived: false, canArchive: true, lastActivityAt: now }],
+      appStartedAt: async () => restarted ? now + 1000 : now - 1000,
+      setArchived: async () => { claudeCalls++; return { ok: true } },
+    })
+  await fsp.mkdir(process.env.BOT_CROSSING_DATA)
+  await fsp.writeFile(path.join(process.env.BOT_CROSSING_DATA, 'colony.json'), JSON.stringify({
+    archived: ['codex-task', 'claude-task'], archivedAt: { 'codex-task': now, 'claude-task': now },
+  }))
+  const { apiMiddleware } = await import(`../server/api.mjs?test=${randomUUID()}`)
+  const request = (url, method = 'GET', body) => new Promise((resolve, reject) => {
+    const req = new PassThrough()
+    Object.assign(req, { url, method, headers: { host: '127.0.0.1:5274', origin: 'http://127.0.0.1:5274' } })
+    let status
+    const res = { writeHead(code) { status = code }, end(text) { resolve({ status, body: JSON.parse(text) }) } }
+    apiMiddleware(req, res).catch(reject)
+    if (body) req.end(JSON.stringify(body))
+  })
+  let response = await request('/api/threads')
+  assert.equal(response.body.threads.find((r) => r.id === 'codex-task').archivePending, true)
+  assert.equal(response.body.threads.find((r) => r.id === 'claude-task').archivePending, true)
+  assert.equal(codexCalls, 0)
+  assert.equal(claudeCalls, 1)
+  assert.deepEqual(response.body.warnings, ['Runtime diagnostic'])
+  codexArchived = true
+  restarted = true
+  response = await request('/api/threads')
+  assert.ok(response.body.threads.every((r) => r.archivePending === false))
+  assert.equal(codexCalls, 0)
+  response = await request('/api/archive', 'POST', { id: 'codex-task', harness: 'codex', ref: {}, archived: true })
+  assert.equal(response.status, 400)
+  assert.equal(response.body.ok, false)
+  assert.match(response.body.error, /No standalone/)
+})


### PR DESCRIPTION
Codex tasks currently do not appear in the colony. This adds local desktop and CLI tasks alongside Claude, with project/worktree placement, task cards, unread and inferred activity states, opening, new-session navigation, and native archive/unarchive.

Builds on Austin Schenoni's adapter in #5, pinned at `c6ccb1fe55d9e6e835efa1ef2fa04ffbb2a2fcf7`, with the following gaps addressed:

- Read the newest versioned state database with Node's built-in SQLite in read-only mode; honor `CODEX_HOME`, retain desktop project/unread hints, and exclude internal reviewers and spawned children. Codex requires Node 22.13+; unsupported runtimes surface a setup error while Claude remains available.
- Use bounded, cached transcript tails for activity inference with the existing 30-minute ceiling. Handle missing/malformed records, partial lines, truncation and replacement. Building growth uses actual transcript bytes rather than tokens and is documented as accumulated activity, not percentage complete.
- Use validated Codex deep links for existing tasks and the folder composer. Invoke standalone CLI `archive`/`unarchive` only on explicit actions, using argument arrays and `PATH` or `BOT_CROSSING_CODEX_BIN`; never execute app-bundle binaries or write directly to Codex's database.

The shared adapter seam gains optional diagnostics and `archiveSync: 'database'`: Codex archive failures return an error, and the next scan confirms completion without a desktop restart or repeated CLI calls. Claude stays first in the registry and retains its existing restart-based reconciliation. Small HUD changes show provider/effort tags and let the selected task determine the composer provider in mixed projects. Artwork and plot/building logic are unchanged. No dependencies added.

### Validation

- `npm test`: 7 focused Node test-runner tests pass, including fixture integrity/no subprocess scanning, lifecycle/cache edge cases, metadata, link validation, CLI success/failure and both archive-sync modes.
- Syntax checks, `git diff --check`, and `npm run build` pass on Node 24.8.0. The existing Vite chunk-size warning remains.
- Local browser verification against 83 Codex tasks and 97 Claude sessions: project placement, both providers' cards, unread states and an isolated working-animation smoke test.
- Existing-task and new-composer buttons dispatched their expected native links. Standalone CLI 0.153.4 archive/unarchive succeeded on a disposable session; subsequent scans confirmed the transitions and cleared `archivePending`.
- Native Codex destination screens were not visually verified because the available computer-use tool does not permit inspecting that app. Running state remains a transcript-based inference.
