### PR TITLE
Running means mid-turn, not merely a live process

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ thread can only ever be doing one thing. First match wins:
 | Signal | What the astronaut does | Badge |
 | --- | --- | --- |
 | Errored | Slumps, red eyes, fault light stutters | `!` |
-| Running now | Hammers away at its building, sparks fly | `⚒` |
+| Running now | Hammers away at its building, sparks fly — a live process *mid-turn*, not merely open | `⚒` |
 | PR merged | Jumps, confetti, heart eyes | `✓` |
-| Unread | **Stops and waits on you** | `?` |
+| Handed the turn back | **Stops and waits on you** — unread, or its transcript ends on a finished turn | `?` |
 | Nothing for 3 days | Sits down and sleeps, `z` bubbles | — |
 | Anything else | Potters around its plot | — |
 

--- a/server/harnesses/README.md
+++ b/server/harnesses/README.md
@@ -95,8 +95,8 @@ what earns a repo its own zone, and `lastActivityAt` is what sorts the whole map
 | `createdAt` | number | Epoch ms |
 | `lastActivityAt` | number | Epoch ms. Sorts the colony and drives the "asleep for 3 days" behaviour |
 | `lastFocusedAt` | number | Epoch ms, `0` if unknowable |
-| `running` | boolean | Working **right now** — the astronaut hammers away |
-| `unread` | boolean | Moved on since you last looked — the astronaut stops and holds a `?` |
+| `running` | boolean | Working **right now** — the astronaut hammers away. A live process is not enough: a session sitting at its prompt is not running, so check that the thread is mid-turn |
+| `unread` | boolean | Wants you — moved on since you last looked, or handed the turn back and is waiting on a reply. The astronaut stops and holds a `?` |
 | `hasError` | boolean | Errored — the astronaut slumps, red eyes |
 | `starred` / `routine` / `prState` | | Optional extras; `prState: 'merged'` triggers the confetti |
 | `archived` | boolean | Archived in the harness's own records |

--- a/server/harnesses/claude-code.mjs
+++ b/server/harnesses/claude-code.mjs
@@ -15,7 +15,7 @@ import path from 'node:path'
 import os from 'node:os'
 import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
-import { exists, jsonLines, listDirs, listFiles, num, readHead } from '../lib/fsutil.mjs'
+import { exists, jsonLines, listDirs, listFiles, num, readHead, readTail } from '../lib/fsutil.mjs'
 
 const execFileAsync = promisify(execFile)
 const HOME = os.homedir()
@@ -143,6 +143,45 @@ async function scanTranscripts() {
   return byId
 }
 
+/** How much of a transcript's end it takes to see whose turn it is. One record is plenty. */
+const TAIL_BYTES = 64 * 1024
+
+/**
+ * Whether a transcript ends with the turn handed back to you.
+ *
+ * A live process is not the same thing as work in progress. The CLI holds its process open
+ * while it sits at the prompt, so "the pid exists and the file moved recently" marks a thread
+ * that finished four minutes ago and asked you a question as *working* — an astronaut
+ * hammering away at a thread whose whole point is that it is waiting.
+ *
+ * The transcript says which it is. A last assistant message that called a tool is mid-turn;
+ * one that called nothing has handed the turn back and the reply is yours to make. Note that
+ * `stop_reason` alone will not do — it is `end_turn` on a main thread's last message and
+ * empty on some others — so what the message *called* is the half worth testing.
+ *
+ * Reads the tail rather than the whole file, and only for threads that could plausibly be
+ * running, so it costs one small read each.
+ */
+async function awaitingReply(file) {
+  let records
+  try {
+    records = jsonLines(await readTail(file, TAIL_BYTES))
+  } catch {
+    return false
+  }
+  for (let i = records.length - 1; i >= 0; i--) {
+    const r = records[i]
+    // A user turn, a tool result or an attachment all mean the model is expected to speak
+    // next — whatever the process is doing, it is not waiting on anyone.
+    if (r.type === 'user') return false
+    if (r.type !== 'assistant') continue
+    const content = r.message?.content
+    const calling = Array.isArray(content) && content.some((c) => c?.type === 'tool_use')
+    return !calling && r.message?.stop_reason !== 'tool_use'
+  }
+  return false
+}
+
 /** Transcript metadata is expensive to parse, so keep it until the file changes. */
 const metaCache = new Map()
 async function transcriptMeta(entry) {
@@ -241,7 +280,17 @@ function mergeThread(existing, next) {
  * id looks like.
  */
 function toThread(t) {
-  const { desktopSessionId, desktopSessionIds, cliSessionId, bridgeSessionId, titled, hasLiveProcess, ...rest } = t
+  const {
+    desktopSessionId,
+    desktopSessionIds,
+    cliSessionId,
+    bridgeSessionId,
+    titled,
+    hasLiveProcess,
+    transcriptFile,
+    recordActivityAt,
+    ...rest
+  } = t
   return {
     ...rest,
     canOpen: Boolean((desktopSessionId && DESKTOP_ID.test(desktopSessionId)) || (cliSessionId && UUID.test(cliSessionId))),
@@ -289,7 +338,20 @@ async function scanThreads() {
       model: s.model || '',
       effort: s.effort || '',
       createdAt: num(s.createdAt) || meta?.startedAt || 0,
-      lastActivityAt: num(s.lastActivityAt) || num(s.lastFocusedAt) || num(s.createdAt) || 0,
+      // The desktop record's own timestamp lags: the app writes it when the thread is
+      // focused, so a session running in a terminal — or in a window you are not looking at
+      // — reads as hours old while its transcript is being written to right now. Whichever
+      // of the two is later is the truth about when the thread last did anything.
+      lastActivityAt: Math.max(
+        num(s.lastActivityAt) || num(s.lastFocusedAt) || num(s.createdAt) || 0,
+        entry?.mtime || 0
+      ),
+      // The record's own timestamp, kept apart from the one above. "Unread" is a comparison
+      // against when you last *looked*, and both sides of it have to come from the app's own
+      // bookkeeping: measure the transcript's mtime against `lastFocusedAt` instead and every
+      // thread whose file was touched after you last opened it — a resumed CLI session, a
+      // background write — reads as unread, which puts a `?` over half the colony.
+      recordActivityAt: num(s.lastActivityAt) || num(s.lastFocusedAt) || num(s.createdAt) || 0,
       lastFocusedAt: num(s.lastFocusedAt),
       hasLiveProcess: live.has(cliSessionId),
       hasError: Boolean(s.error),
@@ -299,6 +361,7 @@ async function scanThreads() {
       archived: s.isArchived === true || s.isArchived === 'True',
       hasTranscript: Boolean(entry),
       sizeBytes: entry?.size || 0,
+      transcriptFile: entry?.file || '',
       source: 'desktop',
     })
   }
@@ -336,6 +399,7 @@ async function scanThreads() {
       archived: false,
       hasTranscript: true,
       sizeBytes: entry.size,
+      transcriptFile: entry.file,
       source: 'cli',
     })
   }
@@ -345,8 +409,16 @@ async function scanThreads() {
   // Terminal-only threads have no focus history at all, so "unread" is unknowable — not true.
   const now = Date.now()
   for (const thread of threads) {
-    thread.unread = thread.desktopSessionIds.length > 0 && thread.lastActivityAt > thread.lastFocusedAt
-    thread.running = thread.hasLiveProcess && now - thread.lastActivityAt < ACTIVE_WINDOW_MS
+    const seenAt = thread.recordActivityAt ?? thread.lastActivityAt
+    thread.unread = thread.desktopSessionIds.length > 0 && seenAt > thread.lastFocusedAt
+    const fresh = now - thread.lastActivityAt < ACTIVE_WINDOW_MS
+    // Only threads that could plausibly be working pay for the tail read.
+    const waiting =
+      thread.hasLiveProcess && fresh && thread.transcriptFile ? await awaitingReply(thread.transcriptFile) : false
+    thread.running = thread.hasLiveProcess && fresh && !waiting
+    // A thread that handed the turn back wants you, whether or not the desktop app has ever
+    // seen it — which is the only way a terminal-only thread can ask for anything at all.
+    if (waiting) thread.unread = true
   }
   return threads.map(toThread)
 }

--- a/server/lib/fsutil.mjs
+++ b/server/lib/fsutil.mjs
@@ -21,6 +21,24 @@ export async function readHead(file, bytes) {
   }
 }
 
+/**
+ * The last `bytes` of a file, with a leading partial line dropped. The mirror of `readHead`,
+ * for the questions only the end of a transcript can answer — whose turn it is.
+ */
+export async function readTail(file, bytes) {
+  const fh = await fsp.open(file, 'r')
+  try {
+    const { size } = await fh.stat()
+    const want = Math.min(bytes, size)
+    const buf = Buffer.allocUnsafe(want)
+    const { bytesRead } = await fh.read(buf, 0, want, size - want)
+    const text = buf.subarray(0, bytesRead).toString('utf8')
+    return want === size ? text : text.slice(text.indexOf('\n') + 1)
+  } finally {
+    await fh.close()
+  }
+}
+
 /** Parse a JSONL blob, skipping the partial or malformed lines a live file always has. */
 export function jsonLines(text) {
   const out = []


### PR DESCRIPTION
### The bug

A thread that finished, answered you and is sitting at its prompt is drawn as `working` — an astronaut hammering away at a thread whose whole point is that it is waiting.

`running` was `hasLiveProcess && lastActivityAt < ACTIVE_WINDOW_MS`, and the CLI holds its process open the entire time it is idle at the prompt. So "the pid exists and the file moved in the last 30 minutes" is true of a session that stopped four minutes ago to ask a question.

### The fix

The transcript settles it. `readTail` (new in `server/lib/fsutil.mjs`, mirroring `readHead`) reads the end of the file; a last assistant message that **called a tool** is mid-turn, one that called nothing has handed the turn back.

`stop_reason` alone will not do it — it is `end_turn` on a main thread's last message and empty in other cases — so what the message *called* is the reliable half. My first attempt tested `stop_reason` and got it wrong.

This also gives a terminal-only thread a way to ask for anything at all: it has no `lastFocusedAt` history, so it could never be `unread` before.

Only threads that are both live and fresh pay for the read — a handful per poll, 64KB each.

### Two related corrections in the same path

- **`lastActivityAt` for a desktop thread** now takes the later of the record and the transcript's mtime. The app writes its own timestamp when a thread is *focused*, so a session running in a terminal reads as hours old while its transcript is being written to this second. Measured 102 minutes on a session that was actively working.
- **`unread` keeps comparing the record's own timestamp** (`recordActivityAt`) against `lastFocusedAt`. I tried feeding the merged value into that comparison and it flipped **190 threads** to unread, because a transcript's mtime moves for reasons that have nothing to do with whether you have read something. Both sides of that comparison have to come from the app's own bookkeeping.

### What I verified

Against 530 real threads on one machine, before → after:

| Thread | Before | After |
| --- | --- | --- |
| Finished session that asked a question | working | needs you |
| Its five spawned workers | working | idle |
| A session actively working | idle, "102m ago" | working, 0m |

Structurally, the three transcript-tail shapes that matter: a finished turn ends `["text"]` / `stop_reason: "end_turn"`, a busy one ends `["tool_use"]` / `"tool_use"`, and a finished worker ends `["text"]` with no `stop_reason` at all — which is why the check is on the tool call.

`npm run build` clean. No new dependencies. Nothing new written to disk.

### Notes

- Style: no semicolons, single quotes, 2-space, comments explaining *why*.
- Built directly on `main` rather than cherry-picked out of my fork, so it carries none of my other work.
- I have a second PR coming for archiving correctness; they are independent, but that one reads `lastActivityAt`, so it behaves better with this one in.