### PR TITLE
Make archiving hold, and make it undoable

### DIFF
--- a/server/api.mjs
+++ b/server/api.mjs
@@ -132,6 +132,13 @@ async function resolveFolder(folder) {
  * poll. `archivePending` is true while the flag is on disk but the running app has not read
  * it yet — that astronaut is walking to the ship but has not boarded.
  */
+/**
+ * How much later than the archive itself a write has to be before it counts as the thread
+ * coming back. Archiving a live thread makes the harness touch its own records, so a couple
+ * of seconds of slack keeps that from reading as activity and undoing the archive instantly.
+ */
+const REVIVE_GRACE_MS = 5000
+
 async function reconcileArchived(threads) {
   const state = await readState()
   if (!state.archived.length) return threads
@@ -143,13 +150,43 @@ async function reconcileArchived(threads) {
     startedAt.set(id, await harnessAppStartedAt(id))
   }
 
+  /**
+   * An archive is remembered by the thread id the page saw, but that id is only the
+   * *canonical* one: a thread keyed by a desktop record today can be keyed by its transcript
+   * tomorrow, once the CLI writes one. Matching on the ids inside `ref` as well means an
+   * archive survives that hand-over instead of the thread quietly reappearing under its new
+   * name.
+   */
+  const isArchived = (thread) => {
+    if (wanted.has(thread.id)) return true
+    const ref = thread.ref || {}
+    if (ref.cliSessionId && wanted.has(ref.cliSessionId)) return true
+    return (ref.desktopSessionIds || []).some((id) => wanted.has(id))
+  }
+
   return Promise.all(
     threads.map(async (thread) => {
-      if (!wanted.has(thread.id)) return thread
+      if (!isArchived(thread)) return thread
       if (!thread.archived && thread.canArchive) {
         await setThreadArchived(thread.harness, thread.ref, true).catch(() => {})
       }
-      const at = state.archivedAt[thread.id] ?? 0
+      const ids = [thread.id, thread.ref?.cliSessionId, ...(thread.ref?.desktopSessionIds || [])]
+      const at = Math.max(0, ...ids.map((id) => (id && state.archivedAt[id]) || 0))
+      /**
+       * A thread that has been worked on since you archived it is not archived any more.
+       *
+       * Archiving says "I am done with this". Going back to the session says the opposite,
+       * and it is the more recent of the two — so the flag comes off rather than the colony
+       * arguing with the harness about a thread you are visibly using. The page owns the
+       * list, so it is told through `unarchivedByActivity` rather than written to here.
+       */
+      if (at && thread.lastActivityAt > at + REVIVE_GRACE_MS) {
+        if (thread.archived && thread.canArchive) {
+          await setThreadArchived(thread.harness, thread.ref, false).catch(() => {})
+        }
+        return { ...thread, archived: false, unarchivedByActivity: true }
+      }
+
       const appStart = startedAt.get(thread.harness) || 0
       return { ...thread, archived: true, archivePending: !(appStart && appStart > at) }
     })
@@ -290,8 +327,11 @@ export async function apiMiddleware(req, res, next) {
       const { id, harness, ref, archived } = await readJsonBody(req)
       if (!id) return send(res, 400, { ok: false, error: 'Missing thread id' })
 
-      // Only the harness's own records are touched here — the page records the intent.
-      if (!ref || !harness) {
+      // Only the harness's own records are touched here — the page records the intent. A
+      // thread the harness has no record for is archived in the colony alone, which is a
+      // success rather than a failure: the astronaut goes home either way.
+      const records = ref?.desktopSessionIds?.length || 0
+      if (!ref || !harness || !records) {
         return send(res, 200, {
           ok: true,
           archived: Boolean(archived),

--- a/server/harnesses/claude-code.mjs
+++ b/server/harnesses/claude-code.mjs
@@ -245,7 +245,10 @@ function toThread(t) {
   return {
     ...rest,
     canOpen: Boolean((desktopSessionId && DESKTOP_ID.test(desktopSessionId)) || (cliSessionId && UUID.test(cliSessionId))),
-    canArchive: desktopSessionIds.length > 0,
+    // Every thread can be retired, including one the desktop app has never heard of: a
+    // terminal-only session has no record to flag, so archiving it is recorded in the colony
+    // alone — which is the whole reason the colony keeps a list of its own.
+    canArchive: true,
     ref: { desktopSessionId, desktopSessionIds, cliSessionId },
   }
 }
@@ -340,10 +343,31 @@ async function scanThreads() {
     })
   }
 
-  const threads = [...byId.values()]
+  const now = Date.now()
+  /**
+   * Drop the app's empty bookkeeping records.
+   *
+   * Resuming a thread makes the desktop app write a second record for the same conversation,
+   * and one of the two carries the title and the transcript link while the other carries
+   * nothing. When the empty one has no `cliSessionId` there is no key to merge the pair on,
+   * so it survives as a thread of its own: an untitled entry with no transcript behind it.
+   * Archiving the real thread does not touch it — the ids in `ref` are the ones the real
+   * record named — so an archived conversation appears to come back as a nameless twin.
+   *
+   * A record with no transcript, no title and no live process is not a conversation. The age
+   * check is what keeps a genuinely new session — opened seconds ago, nothing written yet —
+   * from being swept up with them.
+   */
+  const NEW_SESSION_MS = 10 * 60 * 1000
+  const threads = [...byId.values()].filter(
+    (t) =>
+      t.hasTranscript ||
+      t.titled ||
+      t.hasLiveProcess ||
+      now - (t.lastActivityAt || t.createdAt || 0) < NEW_SESSION_MS
+  )
   // Unread = the thread moved on after you last looked at it; never opened counts as unread.
   // Terminal-only threads have no focus history at all, so "unread" is unknowable — not true.
-  const now = Date.now()
   for (const thread of threads) {
     thread.unread = thread.desktopSessionIds.length > 0 && thread.lastActivityAt > thread.lastFocusedAt
     thread.running = thread.hasLiveProcess && now - thread.lastActivityAt < ACTIVE_WINDOW_MS

--- a/src/main.js
+++ b/src/main.js
@@ -194,6 +194,31 @@ const actions = {
     }
   },
 
+  /**
+   * Un-archive a thread. Archiving wrote to the colony's list *and* to the harness's own
+   * record, and nothing anywhere could undo either — an `A` pressed by accident took a live
+   * thread off the map for good.
+   */
+  restoreThread: async (id) => {
+    const thread = threads.find((t) => t.id === id)
+    state.archived = state.archived.filter((x) => x !== id)
+    const { [id]: _dropped, ...rest } = state.archivedAt || {}
+    state.archivedAt = rest
+    queueSave()
+    // The harness's own flag is best-effort, exactly as it is when archiving: the colony's
+    // list is the authority, and a thread the app has no record for is fine either way.
+    if (thread) {
+      try {
+        await archiveThread(thread, false)
+      } catch {
+        /* the colony has already let it go; the app's flag catches up or does not */
+      }
+    }
+    applyThreads(threads)
+    hud.toast(thread ? `${shortTitle(thread)} is back` : 'Restored')
+    poll()
+  },
+
   archiveThread: async () => {
     const thread = threads.find((t) => t.id === selectedId)
     if (!thread) return
@@ -538,8 +563,35 @@ window.addEventListener('keydown', (e) => {
 
 // ── data ──────────────────────────────────────────────────────────────────────────────
 
+/**
+ * A thread's title, trimmed to something a one-line row can hold. Skill threads open with the
+ * skill's own preamble, so an untrimmed title is a paragraph.
+ */
+function shortTitle(thread) {
+  const title = (thread.title || 'Untitled thread').replace(/\s+/g, ' ').trim()
+  return title.length > 52 ? `${title.slice(0, 51)}…` : title
+}
+
 function applyThreads(list) {
   threads = list
+
+  /**
+   * Anything worked on since you archived it comes off the list — the scanner spots that and
+   * says so, and the page is the one writer of the file, so the forgetting happens here.
+   */
+  const revived = list.filter((t) => t.unarchivedByActivity && state.archived.includes(t.id))
+  if (revived.length) {
+    const back = new Set(revived.map((t) => t.id))
+    state.archived = state.archived.filter((id) => !back.has(id))
+    state.archivedAt = Object.fromEntries(Object.entries(state.archivedAt || {}).filter(([id]) => !back.has(id)))
+    queueSave()
+    hud.toast(
+      revived.length === 1
+        ? `${shortTitle(revived[0])} is active again — back on the map`
+        : `${revived.length} threads are active again — back on the map`
+    )
+  }
+
   const archivedSet = new Set(state.archived)
   const stats = colony.setThreads(list, archivedSet)
   hud.setStats(stats)
@@ -559,6 +611,19 @@ function applyThreads(list) {
     if (still) hud.setSelection(still, list.find((t) => t.id === selectedId) || still.thread)
     else select(null, {})
   }
+  // What you archived, newest first — the only route back onto the map.
+  const archivedList = list
+    .filter((t) => archivedSet.has(t.id))
+    .sort((a, b) => (b.lastActivityAt ?? 0) - (a.lastActivityAt ?? 0))
+  hud.setArchived({
+    total: archivedList.length,
+    rows: archivedList.slice(0, 12).map((t) => ({
+      id: t.id,
+      title: shortTitle(t),
+      project: t.project,
+      lastActivityAt: t.lastActivityAt,
+    })),
+  })
   // Which also repaints the legend, so the open zone's chip is lit by the same pass.
   syncProject()
 

--- a/src/ui/hud.js
+++ b/src/ui/hud.js
@@ -229,6 +229,17 @@ export class Hud {
       this._toggle('Show FPS', 'showFps')
     )
     body.appendChild(view)
+
+    // The way back from an archive. Hidden until there is something in it.
+    const archived = group('Archived threads')
+    this.archivedRow = this._row('Archived threads', 'Click one to bring its astronaut back.')
+    this.archivedList = document.createElement('div')
+    this.archivedList.className = 'restore'
+    this.archivedRow.appendChild(this.archivedList)
+    archived.appendChild(this.archivedRow)
+    this.archivedGroup = archived
+    archived.hidden = true
+    body.appendChild(archived)
   }
 
   _row(label, hint) {
@@ -357,6 +368,38 @@ export class Hud {
   syncSettings() {
     for (const c of this.controls) c.sync()
     this.$('.fps').classList.toggle('on', Boolean(this.settings.get('showFps')))
+  }
+
+  /**
+   * What you archived, newest first, each row a click away from coming back.
+   *
+   * Capped at what the panel can hold: with a few hundred archived threads a full list is a
+   * scroll nobody reads, and the ones you want back are the ones you just put away.
+   */
+  setArchived({ total = 0, rows = [] } = {}) {
+    const signature = `${total}|${rows.map((r) => r.id).join(',')}`
+    if (this._last.archived === signature) return
+    this._last.archived = signature
+    this.archivedGroup.hidden = rows.length === 0
+    this.archivedList.innerHTML = ''
+    for (const row of rows) {
+      const b = document.createElement('button')
+      b.type = 'button'
+      b.className = 'restore-row'
+      b.title = `Bring ${row.title} back onto the map`
+      b.innerHTML =
+        `<span class="t">${escapeHtml(row.title)}</span>` +
+        `<span class="r">${escapeHtml(row.project || '')}</span>` +
+        `<span class="a">${ago(row.lastActivityAt)}</span>`
+      b.addEventListener('click', () => this.actions.restoreThread?.(row.id))
+      this.archivedList.appendChild(b)
+    }
+    if (total > rows.length) {
+      const more = document.createElement('div')
+      more.className = 'restore-more'
+      more.textContent = `${total - rows.length} more archived, oldest first off the list`
+      this.archivedList.appendChild(more)
+    }
   }
 
   setStats(stats) {

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1349,3 +1349,68 @@ kbd {
   }
 }
 .bot-crossing-canvas { cursor: grab; }
+
+/* The way back from an archive: a short list of what you put away, newest first. Rows are
+   full-width buttons rather than chips because a thread needs its title, its repo and when it
+   last moved to be identifiable at all — three things a chip cannot hold. */
+.restore {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  width: 100%;
+  max-height: 190px;
+  overflow-y: auto;
+}
+
+.restore-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-areas: 't a' 'r a';
+  gap: 0 8px;
+  align-items: center;
+  padding: 5px 8px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--muted);
+  font: inherit;
+  font-size: 12px;
+  text-align: left;
+  cursor: pointer;
+  transition: background 140ms ease, color 140ms ease, border-color 140ms ease;
+}
+
+.restore-row:hover {
+  background: rgba(255, 255, 255, 0.1);
+  border-color: var(--line);
+  color: var(--text);
+}
+
+.restore-row .t {
+  grid-area: t;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.restore-row .r {
+  grid-area: r;
+  font-size: 11px;
+  opacity: 0.6;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.restore-row .a {
+  grid-area: a;
+  font-size: 11px;
+  opacity: 0.55;
+  font-variant-numeric: tabular-nums;
+}
+
+.restore-more {
+  padding: 4px 8px;
+  font-size: 11px;
+  opacity: 0.5;
+}


### PR DESCRIPTION
Four ways an archive failed to stick, and no way to undo one. All four are the same story — the colony saying a thread is gone while it is not — so they are here together.

### 1. Archived threads came back as nameless twins

Resuming a thread makes the desktop app write a **second, empty record** for the same conversation. One carries the title and the transcript link; the other carries nothing. When the empty one has no `cliSessionId` there is no key to merge the pair on, so it survives as a thread of its own — an untitled entry with no transcript behind it.

Archiving the real thread writes `isArchived` to the ids in *its* `ref` and never touches the twin, so a conversation archived days ago reappears as a nameless astronaut.

A record with no transcript, no title and no live process is not a conversation. Those are now dropped, with a 10-minute grace so a genuinely new session — opened seconds ago, nothing written yet — is not swept up with them. **16 phantoms** on this machine, all 8+ days old, none live.

### 2. An archive lost when a thread is re-keyed

The colony remembers an archive by the id the page saw, but that is only the *canonical* id: a thread keyed by a desktop record today is keyed by its transcript tomorrow, once the CLI writes one. `reconcileArchived` now matches every id inside `ref` as well, and takes the newest `archivedAt` across them so `archivePending` stays honest.

### 3. Terminal-only threads could not be archived at all

`canArchive` meant "the desktop app has a record to flag", which is false for every thread started in a terminal — **72 of 387** here. But the colony's own list is the authority and the harness write is best-effort on top of it, so any real thread can be retired.

`/api/archive` now takes the colony-only path explicitly when there is no record to write to, returning `ok: true, harnessRecord: false` — which the page already reports correctly as "Archived here (no harness record for it)" — rather than falling through to a write that fails.

### 4. No undo

Fix 3 widens what can be archived, so its mitigation belongs in the same change.

- **A list of what you archived**, newest first, in the settings panel, each row a click from coming back. Capped at 12 with a count of the rest: with a few hundred archived threads a full list is a scroll nobody reads, and the one you want back is the one you just put away.
- **A thread worked on since you archived it un-archives itself.** Archiving says "I am done with this"; going back to the session says the opposite, more recently. The server clears the harness flag and reports `unarchivedByActivity`; the page owns `data/colony.json` and does the forgetting, so there is still exactly **one writer** of that file. A 5-second grace stops the harness's own write during archiving from reading as activity and undoing the archive on the next poll.

### What I verified

Live scan of 394 real threads after the change:

- 0 untitled-with-no-transcript threads survive the filter
- 394 of 394 archivable, including the terminal-only ones
- 97 ids in the archive list, all matched and flagged, **0 leaking back through**
- End-to-end through the real endpoint on a terminal-only thread: archive returns `{ ok: true, harnessRecord: false }`, and un-archiving immediately after returns the same, so the check leaves nothing retired

`npm run build` clean. No new dependencies.

### On writing to disk

Still exactly the one `isArchived` key — the same field, now also *cleared*. Nothing else is written to the harness's records, and `data/colony.json` keeps its single writer.

### Notes

- Built directly on `main` rather than cherry-picked out of my fork.
- The revive rule in part 4 reads `lastActivityAt`, which for a desktop thread lags until you focus it. #15 fixes that; without it this still works for anything the app has touched, just less promptly for a thread resumed in a terminal.