### PR TITLE
Codex and Cursor support, Windows and Linux fixes, and a read-only colony

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,9 +14,11 @@ Concretely:
 
 - **Issues** — I read them. I may not act on them, and I may not reply.
 - **Pull requests** — genuinely welcome, and I will try to look. **I use an AI agent to do the
-  first review pass**, and I read its summary before merging anything. I am telling you that
-  because you deserve to know how your work is being evaluated. A human — me — makes the call
-  on whether it merges.
+  first review pass**, and I read its summary before deciding anything. I am telling you that
+  because you deserve to know how your work is being evaluated. A human — me — makes the call.
+  Often that call is to take the *intent* of a PR and implement it directly rather than merge
+  the branch, especially when several PRs are circling the same seam. Your name goes on the
+  commit when that happens. See [DECISIONS.md](DECISIONS.md) for why it works that way.
 - **Response times** — no promises. Days, weeks, or never, depending on what else is going on.
 - **Feature requests** — probably not, unless they happen to be something I want too.
 
@@ -31,25 +33,32 @@ written down here.
 
 ## What is most worth contributing
 
-**Harness adapters, by a wide margin.** Right now Bot Crossing only reads Claude Code. The
-whole point of the seam in `server/harnesses/` is that adding Codex CLI, OpenCode, Antigravity,
-Amp, or anything else should be one new file and one line in a registry.
+**Harness adapters, by a wide margin.** Bot Crossing reads Claude Code and Codex. The whole
+point of the seam in `server/harnesses/` is that adding OpenCode, Antigravity, Amp, Cursor or
+anything else should be one new file and one line in a registry.
 
 Everything you need is in **[`server/harnesses/README.md`](server/harnesses/README.md)** — the
 interface, the thread shape, the ground rules, and how to find where a given harness keeps its
 sessions on disk.
 
-One caveat worth knowing before you start: **the interface has only ever been implemented once**,
-by the Claude Code adapter it was extracted from. It is very likely the first genuinely different
-harness will not fit perfectly. If yours does not, that is a bug in the seam and not in your
-work — say so in the PR and change what you need to. I would much rather widen the interface
-than have you contort an adapter around it.
+The decisions that are already settled — and why — are in **[DECISIONS.md](DECISIONS.md)**.
+Worth a skim before you start; it will save you writing something I have to say no to.
+
+Two hard rules, and I will not bend on either — both are there because breaking them has
+already cost somebody's machine something:
+
+- **Nothing is ever written to a harness.** Not a transcript, not a session record, not one
+  flag. `data/colony.json` is the only file this project writes.
+- **Nothing is ever read from or executed inside another application's bundle.** Only files
+  under the user's own home directory. Opening a thread goes through a URL the OS resolves, or
+  a command the user already has on `PATH`.
+
+Beyond those, if the interface does not fit your harness, that is a bug in the seam and not in
+your work — say so in the PR and change what you need to. I would much rather widen the
+interface than have you contort an adapter around it.
 
 Also useful:
 
-- **Linux and Windows support.** The scanning half is portable; the opening half is not. Every
-  "open this thread", "reveal this folder" and "start a session here" path goes through macOS's
-  `open(1)` in `server/api.mjs`. That is the whole blocker.
 - **Bug fixes**, especially anything where the colony misrepresents what a thread is actually
   doing. That is the one thing the project has to get right.
 - **Performance**, if you can measure it. See the Performance section of the README for the kind
@@ -68,22 +77,22 @@ You need a real harness installed with real threads for anything interesting to 
 because the built files are checked in and the raw packs are not. You only need it if you are
 changing the art pipeline, and the README explains where to re-download the packs.
 
-There is no test suite and no linter. That is not a standard I am asking you to meet — it is
-just the state of things, and I would rather tell you than have you guess.
+`npm test` runs the suite — the colony file's merge and migration, and the harness contract
+against fixtures. It is not exhaustive and there is no linter. New tests are welcome but not
+demanded; keeping the existing ones green is.
 
 ## What makes a PR easy to say yes to
 
 - **One thing at a time.** A harness adapter, or a bug fix, or a refactor — not all three.
-- **Say what you verified and how.** There are no tests to lean on, so your description is the
-  evidence. "Ran it against 40 real Codex sessions, screenshots attached" is worth more than a
+- **Say what you verified and how.** The suite does not cover much, so your description is
+  still most of the evidence. "Ran it against 40 real Codex sessions, screenshots attached" is worth more than a
   clean diff.
 - **Match the surrounding code.** No semicolons, single quotes, 2-space indent, 110ish columns.
   Comments in this codebase explain *why* — particularly why an obvious approach was rejected.
   That style is deliberate; please keep it where you touch things.
 - **Do not add dependencies casually.** The runtime has two, and I would like it to stay small.
-- **Do not widen what gets written to disk.** The project reads your harness's files and writes
-  exactly one archive flag. That restraint is a feature and I will push back hard on changes to
-  it.
+- **Do not widen what gets written to disk.** See the two hard rules above. That restraint is
+  the feature.
 
 ## Licensing
 

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,0 +1,88 @@
+# Decisions
+
+Things that are settled, and why. If a PR argues with one of these, the PR is not wrong — but
+it needs to argue with the reason rather than work around it.
+
+Written down because the same questions kept arriving one PR at a time, and answering them
+per-PR was producing a codebase with three answers to each.
+
+## Bot Crossing never writes to a harness
+
+`data/colony.json` is the only file this project writes, anywhere.
+
+It used to write one flag — `isArchived` on Claude Code's own session record. That write landed
+on disk, and still looked broken: the desktop app serves from the copy of its records it loaded
+at launch, so a thread you archived here stayed put in its own list until the app restarted, and
+the app rewrote the record from memory the next time it touched the thread. Holding that
+together took a re-assert on every scan, a `ps` sweep to guess whether the app had re-read the
+file, and a *pending* state for the gap between them.
+
+So archiving is the colony's own bookkeeping now. The astronaut walks back to the ship exactly
+as before, and archiving in the harness's own UI still sends it home too, because the scan reads
+that flag. `setArchived` is not part of the adapter interface and adding one back is a bug.
+
+## Nothing is read from or executed inside another application's bundle
+
+Only files under the user's own home directory.
+
+This is not a style preference. An adapter that fell back to
+`/Applications/ChatGPT.app/Contents/Resources/codex` and ran it set off a Gatekeeper malware
+alert on the maintainer's machine and moved both Codex.app and ChatGPT.app to the Trash —
+nothing was wrong with either, but OpenAI's macOS signing certificate had been revoked after the
+Axios npm compromise, and macOS's answer to *executing* a binary under a revoked cert is to
+block it and bin the app. It also cost five seconds on the first scan while macOS decided.
+
+`claude-code.mjs` used to mention `/Claude.app/Contents/MacOS/Claude`, but that was matching a
+string in `ps` output to spot a running process, never launching anything. That code is gone
+now anyway; the scan starts no subprocess at all.
+
+## Opening a thread may run a command; nothing else may
+
+Opening is the one place a subprocess is allowed, because there is no other way to hand a
+session back on a machine with no desktop app. It goes through a URL the OS resolves, or a
+binary the user already has on `PATH` — never a path we guessed inside an app.
+
+## There is one way for an adapter to say "open this"
+
+`openThread(ref)` and `newSession(dir)` return `{ ok, url, command }`, either may be async, and
+the server decides what to do with it:
+
+- **macOS and Windows** — the URL goes to the OS opener. A scheme the harness's app registers is
+  always answered there, so nothing is probed.
+- **Linux** — the scheme is checked with `xdg-mime` first, because `xdg-open` on a scheme nobody
+  claims exits quietly and used to reach the page as "Opened". Failing that, `command` runs in a
+  terminal. Failing that, the page is told the truth.
+
+`command` is `{ argv, cwd }` with an absolute `argv[0]`. No harness knowledge reaches
+`launch()` — that seam is the reason `server/harnesses/` is swappable at all.
+
+## `sizeBytes` is bytes
+
+Every harness has a transcript file; not all of them report tokens, and a CLI-only session
+often has no token count at all. The field is a shared log scale across the whole map, so
+mixing units would make one harness's buildings taller than another's for the same work.
+
+## Thread ids are prefixed
+
+`claude-code:<uuid>`, `codex:<uuid>`. Two UUIDs will not collide, but the colony keys its
+archive list and saved layout on this string, and it is worth being unambiguous rather than
+merely lucky. `colony.json` v1 files are migrated on read — only Claude Code ever wrote a bare
+id, so the rewrite is unambiguous.
+
+## A harness that cannot read its own store says so
+
+Optional `diagnostic()` on an adapter returns a sentence, or `''`. Without it the failure mode
+is a harness that reports `detected: true`, throws inside `scanThreads` on every poll, and looks
+perfectly healthy in the HUD while contributing nothing.
+
+## Pull requests are treated as feature requests
+
+Contributions are read closely and their intent is usually implemented directly, rather than
+merged branch-by-branch. Nine adapters and fixes arriving at once produced five mutually
+incompatible widenings of the same interface; taking the intent and writing one version keeps
+the codebase coherent and is faster than negotiating each PR to a common shape.
+
+That means a PR can be closed unmerged and still be the reason something shipped. Where that
+happens the commit says so and the contributor is credited by name. It is a worse deal for
+contributors than merging their commit, and it is written down here so nobody has to discover
+it from a closed tab.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ is the only file it writes anywhere.
 npm install && npm run dev
 ```
 
+Needs Node 22.13 or newer. `npm test` runs the suite.
+
 `npm run dev` is the whole thing: the API lives inside the Vite dev server, so there is no
 second process. For a built version, `npm start` (build + serve) or `npm run serve` if
 `dist/` already exists. Binds to `127.0.0.1` by default, and answers only its own page — see
@@ -27,9 +29,9 @@ second process. For a built version, `npm start` (build + serve) or `npm run ser
 
 **macOS, Linux and Windows.** Opening a thread, revealing a folder and starting a new session
 all go through a `harness://` deep link handed to the OS opener — `open(1)` on macOS,
-`xdg-open` on Linux, ShellExecute on Windows. The scanning half was portable already. Note that
-the deep link needs a desktop app registered for that scheme, so on Linux the folder buttons
-work while opening a thread has nothing to reach yet.
+`xdg-open` on Linux, ShellExecute on Windows. The scanning half was portable already. On Linux,
+where a desktop app often is not installed, the scheme is checked first and a terminal running
+the harness's own CLI opens instead when nothing answers it.
 
 ## Which harnesses work
 
@@ -39,7 +41,7 @@ somebody writing that adapter.
 
 | Harness | Status |
 | --- | --- |
-| **[Claude Code](https://claude.com/claude-code)** (Anthropic) | ✅ **Supported** — desktop app and CLI, including worktrees, live-process detection and archiving |
+| **[Claude Code](https://claude.com/claude-code)** (Anthropic) | ✅ **Supported** — desktop app and CLI, including worktrees and live-process detection |
 | **[Codex](https://developers.openai.com/codex/cli)** (OpenAI) | ✅ **Supported** — desktop, VS Code and CLI sessions, opened through `codex://` |
 | [OpenCode](https://opencode.ai) | ⬜ Not yet |
 | [Antigravity CLI](https://antigravity.google) (Google) | ⬜ Not yet — the successor to Gemini CLI, which Google stopped serving individual accounts on 18 June 2026 |
@@ -195,12 +197,21 @@ browser makes without touching layout, so following a walking astronaut costs no
 - **Open** hands the thread back to whichever harness owns it and its app comes forward. On a
   Linux box with no desktop app to answer the deep link, a terminal opens with the CLI resuming
   the session instead.
+- **Viewed** (`V`), on a thread that is asking for you, puts its hand down. The harness only
+  counts a thread as read once it has been focused in its own app, so one you answered in a
+  terminal waves for good. This records when you looked, and the thread starts asking again the
+  moment it does something newer.
 - **Archive** retires the thread *here*: the astronaut walks back up the ramp and boards the
   ship. Nothing is written to the harness — see [Keeping it local](#keeping-it-local). A thread
   you archive in the harness's own app goes home on the next poll too, because the scan reads
   that flag.
 - **Hide** takes a whole repo off the map without touching a single thread. It comes back from
-  the *hidden* list at the foot of the sidebar, onto the same ground it left.
+  the list at the foot of the sidebar, onto the same ground it left.
+
+**Quiet repos fold away** by default: a repo where every thread has been silent for three days
+comes off the map, which on a machine with a few harnesses and a lot of checkouts is most of
+them. The sidebar keeps a count and a way back, and a repo returns to its own ground the moment
+a thread in it wakes up. *Hide dormant repos* in settings turns it off.
 
 Only one button in the panel is ever the accent colour: whichever action is the immediate
 one. `Esc` steps outward a notch at a time — the thread first, then its zone.
@@ -267,6 +278,7 @@ under **View → Return to isometric**.
 | `S` | Settings |
 | `N` | Fly to the next astronaut waiting on you |
 | `Enter` / `A` | Open / archive the selected thread |
+| `V` | Mark the selected thread viewed, so it stops asking |
 | `C` | New conversation in the open zone's folder |
 | `O` | Orbit mode |
 | `Tab` | Next planet |
@@ -278,8 +290,9 @@ under **View → Return to isometric**.
 
 ## Planets and light
 
-Three worlds — **Luna**, **Mars**, **Terra** — and a full day/night cycle you can scrub or
-let run. A planet is a bag of colours and two switches; terrain, scatter, sky and lighting all
+Three worlds — **Luna**, **Mars**, **Terra** — and a full day/night cycle you can scrub, let
+run, or set to **Live**, which follows this machine's own clock so the colony's light matches
+the light out of your window. A planet is a bag of colours and two switches; terrain, scatter, sky and lighting all
 read from the same preset, so a fourth world is a data change rather than a code change.
 
 ### The sky is the HDRI

--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@
 
 **[botcrossing.com](https://botcrossing.com)**
 
-Every coding-agent thread on this Mac is a little astronaut. They walk out of the ship, claim
+Every coding-agent thread on this machine is a little astronaut. They walk out of the ship, claim
 a plot for their repo, and build something. When one needs you it stops and holds a `?` over
 its head; click it and the thread opens back in whichever harness it came from.
 
 It reads the harness's own files, on your own machine. Nothing is uploaded, there is no
-account, and the only thing it ever writes back is a single archive flag.
+account, and **it never writes to a harness at all** — `data/colony.json`, where the map lives,
+is the only file it writes anywhere.
 
 > **Status:** published as-is. I built this for myself and cannot promise to maintain it —
 > issues and PRs are welcome but may go unanswered, and forking is an entirely reasonable
@@ -39,7 +40,7 @@ somebody writing that adapter.
 | Harness | Status |
 | --- | --- |
 | **[Claude Code](https://claude.com/claude-code)** (Anthropic) | ✅ **Supported** — desktop app and CLI, including worktrees, live-process detection and archiving |
-| [Codex CLI](https://developers.openai.com/codex/cli) (OpenAI) | ⬜ Not yet — transcripts found at `~/.codex/sessions/`, [notes here](server/harnesses/README.md#starting-points) |
+| **[Codex](https://developers.openai.com/codex/cli)** (OpenAI) | ✅ **Supported** — desktop, VS Code and CLI sessions, opened through `codex://` |
 | [OpenCode](https://opencode.ai) | ⬜ Not yet |
 | [Antigravity CLI](https://antigravity.google) (Google) | ⬜ Not yet — the successor to Gemini CLI, which Google stopped serving individual accounts on 18 June 2026 |
 | [Cursor](https://cursor.com) (`cursor-agent`) | ⬜ Not yet |
@@ -191,10 +192,15 @@ flipping to its left rather than sliding under the sidebar, and never leaving th
 It is moved with a transform rather than with `left`/`top`, the one geometric change a
 browser makes without touching layout, so following a walking astronaut costs nothing.
 
-- **Open** hands the thread back to Claude Code and the desktop app comes forward.
-- **Archive** sets `isArchived` on Claude Code's own session record — the thread lands in
-  Claude Code's Archived list, not just here — and the astronaut walks back up the ramp and
-  boards the ship.
+- **Open** hands the thread back to whichever harness owns it and its app comes forward. On a
+  Linux box with no desktop app to answer the deep link, a terminal opens with the CLI resuming
+  the session instead.
+- **Archive** retires the thread *here*: the astronaut walks back up the ramp and boards the
+  ship. Nothing is written to the harness — see [Keeping it local](#keeping-it-local). A thread
+  you archive in the harness's own app goes home on the next poll too, because the scan reads
+  that flag.
+- **Hide** takes a whole repo off the map without touching a single thread. It comes back from
+  the *hidden* list at the foot of the sidebar, onto the same ground it left.
 
 Only one button in the panel is ever the accent colour: whichever action is the immediate
 one. `Esc` steps outward a notch at a time — the thread first, then its zone.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ somebody writing that adapter.
 | **[Codex](https://developers.openai.com/codex/cli)** (OpenAI) | ✅ **Supported** — desktop, VS Code and CLI sessions, opened through `codex://` |
 | [OpenCode](https://opencode.ai) | ⬜ Not yet |
 | [Antigravity CLI](https://antigravity.google) (Google) | ⬜ Not yet — the successor to Gemini CLI, which Google stopped serving individual accounts on 18 June 2026 |
-| [Cursor](https://cursor.com) (`cursor-agent`) | ⬜ Not yet |
+| **[Cursor](https://cursor.com)** (Anysphere) | ✅ **Supported** — agent transcripts; the composer/sidebar threads are not read yet |
 | [Amp](https://ampcode.com) (Sourcegraph) | ⬜ Not yet |
 | [Aider](https://aider.chat) | ⬜ Not yet |
 | [Goose](https://block.github.io/goose/) (Block) | ⬜ Not yet |

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "type": "module",
-  "description": "A 3D colony sim where every coding-agent thread on your Mac is a little astronaut building something.",
+  "description": "A 3D colony sim where every coding-agent thread on your machine is a little astronaut building something.",
   "license": "MIT",
   "author": "Jarren Rocks",
   "homepage": "https://botcrossing.com",
@@ -24,7 +24,7 @@
     "visualization"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=22.13"
   },
   "os": [
     "darwin",
@@ -36,7 +36,8 @@
     "build": "npm run assets --silent && vite build",
     "start": "vite build && node server/serve.mjs",
     "serve": "node server/serve.mjs",
-    "assets": "node tools/build-assets.mjs"
+    "assets": "node tools/build-assets.mjs",
+    "test": "node --test \"test/**/*.test.mjs\""
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",

--- a/server/api.mjs
+++ b/server/api.mjs
@@ -42,7 +42,8 @@ function migrate(raw) {
 
 /**
  * Colony state is only ever the things the *game* invents — which plot a project got,
- * what a thread's building looks like, what you archived. The threads themselves stay
+ * what a thread's building looks like, what you archived, which repos you took off the map.
+ * The threads themselves stay
  * read-only: this file is the only thing Bot Crossing writes, anywhere.
  */
 const emptyState = () => ({
@@ -52,6 +53,7 @@ const emptyState = () => ({
   opened: [],
   plots: {},
   seen: {},
+  hiddenProjects: [],
   settings: null,
   updatedAt: 0,
 })
@@ -69,6 +71,7 @@ async function readState() {
       opened: asArray(raw.opened),
       plots: asObject(raw.plots),
       seen: asObject(raw.seen),
+      hiddenProjects: asArray(raw.hiddenProjects).map(String).filter(Boolean),
       settings: raw.settings && typeof raw.settings === 'object' ? raw.settings : null,
       updatedAt: Number(raw.updatedAt) || 0,
     }
@@ -102,6 +105,7 @@ async function writeState(next) {
     opened: asArray(next.opened),
     plots: asObject(next.plots),
     seen: asObject(next.seen),
+    hiddenProjects: asArray(next.hiddenProjects).map(String).filter(Boolean),
     settings: next.settings && typeof next.settings === 'object' ? next.settings : null,
     updatedAt: Date.now(),
   }

--- a/server/api.mjs
+++ b/server/api.mjs
@@ -5,12 +5,10 @@ import { spawn } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 import {
   defaultHarness,
-  harnessAppStartedAt,
   harnessStatus,
   newSession as harnessNewSession,
   openThread as harnessOpenThread,
   scanThreads,
-  setThreadArchived,
 } from './scan.mjs'
 
 const here = path.dirname(fileURLToPath(import.meta.url))
@@ -22,7 +20,7 @@ const STATE_VERSION = 1
 /**
  * Colony state is only ever the things the *game* invents — which plot a project got,
  * what a thread's building looks like, what you archived. The threads themselves stay
- * read-only: nothing here ever writes to a harness's data except the one archive flag.
+ * read-only: this file is the only thing Bot Crossing writes, anywhere.
  */
 const emptyState = () => ({
   version: STATE_VERSION,
@@ -57,9 +55,9 @@ async function readState() {
 }
 
 /**
- * One writer: the browser owns this file and PUTs it whole. `/api/archive` deliberately
- * does not touch it — if it did, the next save from a page holding older state would
- * silently drop every archive made since that page loaded.
+ * One writer: the browser owns this file and PUTs it whole. Nothing on the server writes it —
+ * if anything did, the next save from a page holding older state would silently drop every
+ * archive made since that page loaded.
  */
 async function writeState(next) {
   const state = {
@@ -126,34 +124,25 @@ async function resolveFolder(folder) {
 }
 
 /**
- * A harness loads its session records at launch and rewrites them whenever it touches one,
- * which silently clears an archive flag set from outside. So the colony keeps its own list
- * and re-asserts the flag on every scan; an archive that gets stomped comes back within one
- * poll. `archivePending` is true while the flag is on disk but the running app has not read
- * it yet — that astronaut is walking to the ship but has not boarded.
+ * Mark the threads the colony has retired.
+ *
+ * Nothing is written anywhere. Bot Crossing used to set `isArchived` on the desktop app's own
+ * session record, and it did land on disk — but the app serves from the copy it loaded at
+ * launch, so the thread stayed put in its own list until the next restart, and the app would
+ * rewrite the record from memory whenever it touched the thread. Papering over that took a
+ * re-assert on every poll, a `ps` sweep to guess whether the app had re-read the file, and a
+ * *pending* state for the gap between the two — a lot of machinery for something that still
+ * looked broken to anyone with the app open.
+ *
+ * So the colony keeps its own list and that is all it does. Archiving in the harness's own UI
+ * still sends the astronaut home, because the scan reads that flag; archiving here is the
+ * colony's own business. Nothing outside `data/colony.json` is ever written.
  */
 async function reconcileArchived(threads) {
   const state = await readState()
   if (!state.archived.length) return threads
   const wanted = new Set(state.archived)
-
-  // One `ps` sweep per harness rather than one per thread.
-  const startedAt = new Map()
-  for (const id of new Set(threads.map((t) => t.harness))) {
-    startedAt.set(id, await harnessAppStartedAt(id))
-  }
-
-  return Promise.all(
-    threads.map(async (thread) => {
-      if (!wanted.has(thread.id)) return thread
-      if (!thread.archived && thread.canArchive) {
-        await setThreadArchived(thread.harness, thread.ref, true).catch(() => {})
-      }
-      const at = state.archivedAt[thread.id] ?? 0
-      const appStart = startedAt.get(thread.harness) || 0
-      return { ...thread, archived: true, archivePending: !(appStart && appStart > at) }
-    })
-  )
+  return threads.map((t) => (wanted.has(t.id) ? { ...t, archived: true } : t))
 }
 
 function send(res, status, body) {
@@ -284,23 +273,6 @@ export async function apiMiddleware(req, res, next) {
       const result = harnessNewSession(harness || (await defaultHarness()), dir)
       if (result.ok) launch(result.url)
       return send(res, result.ok ? 200 : 400, result)
-    }
-
-    if (url.pathname === '/api/archive' && req.method === 'POST') {
-      const { id, harness, ref, archived } = await readJsonBody(req)
-      if (!id) return send(res, 400, { ok: false, error: 'Missing thread id' })
-
-      // Only the harness's own records are touched here — the page records the intent.
-      if (!ref || !harness) {
-        return send(res, 200, {
-          ok: true,
-          archived: Boolean(archived),
-          harnessRecord: false,
-          note: 'Archived in the colony. That harness has no session record for this thread.',
-        })
-      }
-      const result = await setThreadArchived(harness, ref, archived)
-      return send(res, 200, { ...result, ok: true, archived: Boolean(archived), harnessRecord: result.ok })
     }
 
     return send(res, 404, { error: 'Unknown endpoint' })

--- a/server/api.mjs
+++ b/server/api.mjs
@@ -238,7 +238,32 @@ async function reconcileArchived(threads) {
   const state = await readState()
   if (!state.archived.length) return threads
   const wanted = new Set(state.archived)
-  return threads.map((t) => (wanted.has(t.id) ? { ...t, archived: true } : t))
+
+  /**
+   * An archive is remembered by the thread id the page saw, but that id is only the *canonical*
+   * one. A thread the desktop app knows and the CLI has not written a transcript for is keyed on
+   * its desktop record; the moment a transcript appears it re-keys to that session's UUID, and a
+   * list keyed on the old string stops matching. The thread quietly comes back, which reads as
+   * the archive having failed.
+   *
+   * So the ids inside `ref` count too. They are opaque to everything else here — this only ever
+   * asks whether a string it already holds appears among them.
+   */
+  const archived = (thread) => {
+    if (wanted.has(thread.id)) return true
+    const ref = thread.ref
+    if (!ref || typeof ref !== 'object') return false
+    for (const value of Object.values(ref)) {
+      if (typeof value === 'string') {
+        if (value && wanted.has(value)) return true
+      } else if (Array.isArray(value)) {
+        for (const v of value) if (typeof v === 'string' && v && wanted.has(v)) return true
+      }
+    }
+    return false
+  }
+
+  return threads.map((t) => (archived(t) ? { ...t, archived: true } : t))
 }
 
 function send(res, status, body) {

--- a/server/api.mjs
+++ b/server/api.mjs
@@ -3,6 +3,7 @@ import os from 'node:os'
 import path from 'node:path'
 import { spawn } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
+import { openInTerminal, schemeHasHandler, schemeOf } from './lib/xdg.mjs'
 import {
   defaultHarness,
   harnessStatus,
@@ -121,6 +122,9 @@ async function writeState(next) {
  * Hand a `harness://…` deep link, or a folder, to whatever opens things on this OS. The
  * opener gets an argument list, never a shell string.
  *
+ * Only `present()` calls this, and no harness knowledge ever reaches it: an adapter says what it
+ * wants opened and this decides how, which is the seam that keeps `server/harnesses/` swappable.
+ *
  * macOS's `open(1)` does both jobs, and `xdg-open` is the Linux equivalent. On Windows the
  * equivalent is ShellExecute, reached through `rundll32 url.dll,FileProtocolHandler`: a
  * registered protocol URL goes to its app and a folder opens in Explorer, with the argument
@@ -160,6 +164,55 @@ async function resolveFolder(folder) {
   const dir = path.resolve(folder)
   const stat = await fsp.stat(dir).catch(() => null)
   return stat && stat.isDirectory() ? dir : null
+}
+
+/**
+ * Show a harness's answer to "open this" — `{ ok, url, command }` — and say truthfully whether
+ * anything happened.
+ *
+ * macOS and Windows hand the URL to the opener exactly as before: a scheme the harness's app
+ * registers is always answered there, so nothing is probed. Linux is the platform where the URL
+ * may have nowhere to go — the desktop app is optional and often absent, and `xdg-open` on a
+ * scheme nobody claims exits quietly, which used to reach the page as "Opened". So there the
+ * scheme is checked first; failing that, the harness's own CLI runs in a terminal, from the
+ * `command` the adapter offered alongside the URL; failing that, the page is told so.
+ *
+ * `command.cwd` came from the page — inside `ref`, or as the folder itself — so it gets the same
+ * check as any other folder the page names. There is no fallback directory on purpose:
+ * `claude --resume` looks a session up under the folder it ran in, and a terminal that opens on
+ * "No conversation found" and closes is worse than an error toast.
+ */
+async function present(result) {
+  // Only the reason reaches the page: a failure may still carry the adapter's command.
+  if (!result || !result.ok) return { ok: false, error: result?.error || 'Nothing to open' }
+
+  if (process.platform !== 'linux') {
+    if (!result.url) return { ok: false, error: 'That harness has no deep link to open on this platform' }
+    launch(result.url)
+    return { ok: true, url: result.url }
+  }
+
+  if (result.url && (await schemeHasHandler(result.url))) {
+    launch(result.url)
+    return { ok: true, url: result.url }
+  }
+  if (result.command) {
+    if (!result.command.cwd) return { ok: false, error: 'That thread has no folder on record to resume in' }
+    const cwd = await resolveFolder(result.command.cwd)
+    if (!cwd) return { ok: false, error: 'The folder that thread ran in is not on this machine any more' }
+    // A folder that exists but cannot be entered fails inside every terminal alike, and the
+    // terminal gets the blame; say what is actually wrong instead.
+    const enterable = await fsp.access(cwd, fsp.constants.X_OK).then(() => true, () => false)
+    if (!enterable) return { ok: false, error: 'The folder that thread ran in cannot be entered' }
+    return openInTerminal(result.command.argv, cwd)
+  }
+  const scheme = schemeOf(result.url)
+  return {
+    ok: false,
+    error: scheme
+      ? `Nothing on this machine opens ${scheme}:// links, and there is no CLI command to run instead`
+      : 'Nothing on this machine can open that',
+  }
 }
 
 /**
@@ -278,7 +331,10 @@ export async function apiMiddleware(req, res, next) {
   try {
     if (url.pathname === '/api/threads' && req.method === 'GET') {
       const threads = await reconcileArchived(await scanThreads())
-      return send(res, 200, { threads, scannedAt: Date.now() })
+      // A harness that is present but cannot read its own store says so here, rather than
+      // appearing healthy in the list while quietly contributing nothing.
+      const warnings = (await harnessStatus()).filter((h) => h.detected && h.error).map((h) => h.error)
+      return send(res, 200, { threads, scannedAt: Date.now(), warnings })
     }
 
     if (url.pathname === '/api/harnesses' && req.method === 'GET') {
@@ -318,9 +374,8 @@ export async function apiMiddleware(req, res, next) {
 
     if (url.pathname === '/api/open' && req.method === 'POST') {
       const { harness, ref } = await readJsonBody(req)
-      const result = harnessOpenThread(harness, ref)
-      if (result.ok) launch(result.url)
-      return send(res, result.ok ? 200 : 400, result)
+      const shown = await present(await harnessOpenThread(harness, ref))
+      return send(res, shown.ok ? 200 : 400, shown)
     }
 
     if ((url.pathname === '/api/new-session' || url.pathname === '/api/reveal') && req.method === 'POST') {
@@ -332,9 +387,8 @@ export async function apiMiddleware(req, res, next) {
         launch(dir)
         return send(res, 200, { ok: true })
       }
-      const result = harnessNewSession(harness || (await defaultHarness()), dir)
-      if (result.ok) launch(result.url)
-      return send(res, result.ok ? 200 : 400, result)
+      const shown = await present(await harnessNewSession(harness || (await defaultHarness()), dir))
+      return send(res, shown.ok ? 200 : 400, shown)
     }
 
     return send(res, 404, { error: 'Unknown endpoint' })

--- a/server/api.mjs
+++ b/server/api.mjs
@@ -15,7 +15,29 @@ const here = path.dirname(fileURLToPath(import.meta.url))
 const DATA_DIR = process.env.BOT_CROSSING_DATA || path.join(here, '..', 'data')
 const STATE_FILE = path.join(DATA_DIR, 'colony.json')
 
-const STATE_VERSION = 1
+const STATE_VERSION = 2
+
+/**
+ * v1 keyed everything on a bare session id, because Claude Code was the only harness and its
+ * ids are UUIDs. Adapters now prefix (`claude-code:…`, `codex:…`) so two harnesses can never
+ * name the same thread, which means a v1 file's archive list no longer matches anything.
+ *
+ * Only Claude Code ever wrote a bare id, so the rewrite is unambiguous. One shot, on read.
+ */
+const BARE_UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+const migrateId = (id) => (BARE_UUID.test(id) ? `claude-code:${id}` : id)
+
+function migrate(raw) {
+  if (Number(raw.version) >= 2) return raw
+  const keys = (o) => Object.fromEntries(Object.entries(asObject(o)).map(([k, v]) => [migrateId(k), v]))
+  return {
+    ...raw,
+    archived: asArray(raw.archived).map(migrateId),
+    archivedAt: keys(raw.archivedAt),
+    opened: asArray(raw.opened).map(migrateId),
+    seen: keys(raw.seen),
+  }
+}
 
 /**
  * Colony state is only ever the things the *game* invents — which plot a project got,
@@ -38,7 +60,7 @@ const asArray = (v) => (Array.isArray(v) ? v : [])
 
 async function readState() {
   try {
-    const raw = JSON.parse(await fsp.readFile(STATE_FILE, 'utf8'))
+    const raw = migrate(JSON.parse(await fsp.readFile(STATE_FILE, 'utf8')))
     return {
       version: STATE_VERSION,
       archived: asArray(raw.archived),
@@ -59,6 +81,18 @@ async function readState() {
  * if anything did, the next save from a page holding older state would silently drop every
  * archive made since that page loaded.
  */
+/**
+ * Writes are serialised through one chain, and each gets its own temp file.
+ *
+ * Both halves matter and neither is theoretical. A shared `colony.json.tmp` means two saves
+ * landing together race on the rename and one throws ENOENT — a 500 the page has no idea what
+ * to do with, so the save is simply lost. And read-then-write is not atomic across an `await`,
+ * so without the chain two callers can both pass the version check below before either writes.
+ */
+let writeQueue = Promise.resolve()
+let tmpSeq = 0
+const serialise = (fn) => (writeQueue = writeQueue.then(fn, fn))
+
 async function writeState(next) {
   const state = {
     version: STATE_VERSION,
@@ -71,9 +105,14 @@ async function writeState(next) {
     updatedAt: Date.now(),
   }
   await fsp.mkdir(DATA_DIR, { recursive: true })
-  const tmp = STATE_FILE + '.tmp'
-  await fsp.writeFile(tmp, JSON.stringify(state, null, 2))
-  await fsp.rename(tmp, STATE_FILE)
+  const tmp = `${STATE_FILE}.${process.pid}.${++tmpSeq}.tmp`
+  try {
+    await fsp.writeFile(tmp, JSON.stringify(state, null, 2))
+    await fsp.rename(tmp, STATE_FILE)
+  } catch (err) {
+    await fsp.rm(tmp, { force: true }).catch(() => {})
+    throw err
+  }
   return state
 }
 
@@ -250,8 +289,31 @@ export async function apiMiddleware(req, res, next) {
       return send(res, 200, await readState())
     }
 
+    /**
+     * Optimistic concurrency, so a second tab cannot paste over the first one's work.
+     *
+     * `baseUpdatedAt` is the version the caller last agreed with. If the file no longer carries
+     * it, the caller's whole-file body describes a colony that no longer exists — so the disk
+     * state comes back with a 409 and the page merges against it. Merging here was the other
+     * option and it is the wrong place: the server has no idea which of two `plots` layouts a
+     * person actually dragged.
+     *
+     * The test is inequality rather than "older than", because a colony file also moves
+     * *backwards* — restored from a backup, edited by hand — and a page open across that holds
+     * a base newer than disk, which sails through a greater-than check and pastes the
+     * pre-restore colony straight back.
+     *
+     * A missing or zero base is a first write and is allowed: nothing to lose on a fresh
+     * install, and it keeps the endpoint drivable from `curl`.
+     */
     if (url.pathname === '/api/state' && req.method === 'PUT') {
-      return send(res, 200, await writeState(await readJsonBody(req)))
+      const body = await readJsonBody(req)
+      const base = Number(body.baseUpdatedAt) || 0
+      return serialise(async () => {
+        const current = await readState()
+        if (base && current.updatedAt !== base) return send(res, 409, current)
+        return send(res, 200, await writeState(body))
+      })
     }
 
     if (url.pathname === '/api/open' && req.method === 'POST') {

--- a/server/api.mjs
+++ b/server/api.mjs
@@ -37,6 +37,7 @@ function migrate(raw) {
     archivedAt: keys(raw.archivedAt),
     opened: asArray(raw.opened).map(migrateId),
     seen: keys(raw.seen),
+    viewedAt: keys(raw.viewedAt),
   }
 }
 
@@ -54,6 +55,7 @@ const emptyState = () => ({
   plots: {},
   seen: {},
   hiddenProjects: [],
+  viewedAt: {},
   settings: null,
   updatedAt: 0,
 })
@@ -72,6 +74,7 @@ async function readState() {
       plots: asObject(raw.plots),
       seen: asObject(raw.seen),
       hiddenProjects: asArray(raw.hiddenProjects).map(String).filter(Boolean),
+      viewedAt: asObject(raw.viewedAt),
       settings: raw.settings && typeof raw.settings === 'object' ? raw.settings : null,
       updatedAt: Number(raw.updatedAt) || 0,
     }
@@ -106,6 +109,7 @@ async function writeState(next) {
     plots: asObject(next.plots),
     seen: asObject(next.seen),
     hiddenProjects: asArray(next.hiddenProjects).map(String).filter(Boolean),
+    viewedAt: asObject(next.viewedAt),
     settings: next.settings && typeof next.settings === 'object' ? next.settings : null,
     updatedAt: Date.now(),
   }

--- a/server/harnesses/README.md
+++ b/server/harnesses/README.md
@@ -20,8 +20,6 @@ export default {
   scanThreads,                   // () => Promise<Thread[]>
   openThread,                    // (ref) => { ok, url } | { ok: false, error }
   newSession,                    // (dir) => { ok, url } | { ok: false, error }
-  setArchived,                   // (ref, archived) => Promise<{ ok, error? }>
-  appStartedAt,                  // optional: () => Promise<number>
 }
 ```
 
@@ -55,26 +53,21 @@ server has already checked still exists.
 If your harness has no deep link, return `{ ok: false, error: '…' }` and say why — the UI
 shows the message rather than pretending the click worked.
 
-### `setArchived(ref, archived)`
+### There is no `setArchived`, and that is deliberate
 
-Flip whatever "archived" means in that harness's own records, so the thread lands in *its*
-archived list rather than only disappearing here. If the harness has no such concept, return
-`{ ok: false, error: '…' }`: the colony still records the archive on its own side, and the
-astronaut still walks back to the ship.
+Bot Crossing does not write to a harness. Not the transcripts, not the session records, not one
+flag. Archiving is recorded in `data/colony.json` and nowhere else: the thread leaves the map and
+the astronaut walks back to the ship.
 
-Be conservative about what you write. The Claude Code adapter touches exactly one key, writes
-through a temp file and renames over the original, and re-reads the record first to check it
-is the session it thinks it is. Someone's real work is in these files.
+It used to write one flag — `isArchived` on Claude Code's own session record — and that write
+genuinely landed on disk. It just did not *mean* anything: the desktop app serves from the copy it
+loaded at launch, so the thread stayed in its list until the app restarted, and the app rewrote the
+record from memory the next time it touched the thread. Holding that together took a re-assert on
+every scan, a `ps` sweep to guess whether the app had re-read the file, and a *pending* state for
+the gap between them. All of that is gone, and the scan no longer starts a subprocess at all.
 
-### `appStartedAt()` — optional
-
-Epoch milliseconds of when the harness's long-lived app last launched, or `0`.
-
-This exists for one specific problem: an app that loads its session records at startup and
-rewrites them from memory will silently stomp an archive flag set from outside. The colony
-re-asserts the flag every scan, and uses this timestamp to tell "already picked up" from
-"still waiting on disk" — which is what drives the *pending* look on an astronaut walking to
-the ship. A CLI-only harness has no such app; omit the method.
+Archiving in the harness's own UI still works and is still the right way to do it — your adapter
+reports it through the `archived` field and the astronaut goes home on the next poll.
 
 ## The `Thread` your adapter returns
 
@@ -99,10 +92,10 @@ what earns a repo its own zone, and `lastActivityAt` is what sorts the whole map
 | `unread` | boolean | Moved on since you last looked — the astronaut stops and holds a `?` |
 | `hasError` | boolean | Errored — the astronaut slumps, red eyes |
 | `starred` / `routine` / `prState` | | Optional extras; `prState: 'merged'` triggers the confetti |
-| `archived` | boolean | Archived in the harness's own records |
+| `archived` | boolean | Archived in the harness's own records. Read-only — reporting it is all an adapter does |
 | `sizeBytes` | number | Transcript size. **This is how finished a building looks**, on a log scale |
 | `source` | string | Free-form, for your own bookkeeping (the Claude adapter uses `desktop` / `cli`) |
-| `canOpen` / `canArchive` | boolean | Whether this thread supports those actions. The UI greys the buttons out |
+| `canOpen` | boolean | Whether this thread can be opened. The UI greys the button out |
 | `ref` | object | **Opaque.** Whatever *you* need to find this thread again |
 
 ### About `ref`
@@ -116,8 +109,12 @@ Do not put a file handle, a class instance, or a secret in it.
 
 ## Ground rules
 
-- **Read-only by default.** The one exception in the whole project is the archive flag. A
-  harness's transcripts are somebody's actual work; the colony is a viewer, not an editor.
+- **Read-only. No exceptions.** `data/colony.json` is the only file Bot Crossing writes,
+  anywhere. A harness's transcripts and records are somebody's actual work; the colony is a
+  viewer, not an editor. If an adapter seems to need a write, it does not — say so in an issue.
+- **Never run anything out of another application's bundle.** Not to read from it, not to
+  execute it. Only files under the user's own home directory. Opening a thread goes through a
+  URL the OS resolves, or a command the user already has on `PATH`.
 - **Never block the scan.** It runs on a poll. Cache anything expensive against file mtime —
   see `transcriptMeta` in `claude-code.mjs`, which is what keeps a 12MB transcript from being
   reparsed every few seconds.

--- a/server/harnesses/claude-code.mjs
+++ b/server/harnesses/claude-code.mjs
@@ -17,7 +17,7 @@ import fsp from 'node:fs/promises'
 import { existsSync, readdirSync } from 'node:fs'
 import path from 'node:path'
 import os from 'node:os'
-import { exists, jsonLines, listDirs, listFiles, num, readHead, readTail } from '../lib/fsutil.mjs'
+import { exists, findExecutable, jsonLines, listDirs, listFiles, num, readHead, readTail } from '../lib/fsutil.mjs'
 
 const HOME = os.homedir()
 
@@ -97,6 +97,10 @@ const ID = (raw) => `claude-code:${raw}`
 
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 const DESKTOP_ID = /^local_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+// The type check matters wherever an id came back from the page: `RegExp.test` stringifies, so a
+// one-element array holding a valid id would pass the pattern and then travel on as an array.
+const isCliId = (v) => typeof v === 'string' && UUID.test(v)
+const isDesktopId = (v) => typeof v === 'string' && DESKTOP_ID.test(v)
 
 function firstText(content) {
   if (typeof content === 'string') return content
@@ -328,8 +332,10 @@ function toThread(t) {
   } = t
   return {
     ...rest,
-    canOpen: Boolean((desktopSessionId && DESKTOP_ID.test(desktopSessionId)) || (cliSessionId && UUID.test(cliSessionId))),
-    ref: { desktopSessionId, desktopSessionIds, cliSessionId },
+    canOpen: isDesktopId(desktopSessionId) || isCliId(cliSessionId),
+    // The cwd rides along because resuming from a terminal has to happen in the folder the
+    // session ran in — the worktree, not the repo root.
+    ref: { desktopSessionId, desktopSessionIds, cliSessionId, cwd: t.cwd || '' },
   }
 }
 
@@ -475,20 +481,38 @@ async function scanThreads() {
 }
 
 /**
+ * Where the `claude` CLI is, for a machine that has it but no desktop app to answer the deep
+ * link. PATH first, then the places its installers put it — never inside an application bundle.
+ * Only Linux asks: on macOS and Windows the deep link is always answered, so the walk is wasted.
+ */
+const CLI_DIRS = [
+  path.join(HOME, '.local', 'bin'),
+  path.join(HOME, '.claude', 'local'),
+  '/usr/local/bin',
+  '/usr/bin',
+]
+const cliBinary = () => findExecutable('claude', CLI_DIRS)
+
+/**
  * Hands the thread back to Claude Code. `epitaxy/<local_…>` *navigates* the desktop app
  * to a thread it already has; `resume` *imports* the transcript, which spawns a second
  * untitled session and rewrites the .jsonl — so it is only ever the fallback for threads
  * the app has never seen. Ids are pattern-checked before they reach the opener.
  */
-function openThread(ref) {
-  const { desktopSessionId, cliSessionId } = ref || {}
-  if (desktopSessionId && DESKTOP_ID.test(desktopSessionId)) {
-    return { ok: true, url: `claude://claude.ai/epitaxy/${desktopSessionId}` }
+async function openThread(ref) {
+  const { desktopSessionId, cliSessionId, cwd } = ref || {}
+  let url = ''
+  if (isDesktopId(desktopSessionId)) url = `claude://claude.ai/epitaxy/${desktopSessionId}`
+  else if (isCliId(cliSessionId)) url = `claude://resume?session=${cliSessionId}`
+
+  let command
+  if (process.platform === 'linux' && isCliId(cliSessionId)) {
+    const bin = await cliBinary()
+    if (bin) command = { argv: [bin, '--resume', cliSessionId], cwd: typeof cwd === 'string' ? cwd : '' }
   }
-  if (cliSessionId && UUID.test(cliSessionId)) {
-    return { ok: true, url: `claude://resume?session=${cliSessionId}` }
-  }
-  return { ok: false, error: 'No openable session id on that thread' }
+
+  if (!url && !command) return { ok: false, error: 'No openable session id on that thread' }
+  return { ok: true, url, command }
 }
 
 /**
@@ -496,8 +520,14 @@ function openThread(ref) {
  * "New Claude Code Session Here" quick action uses. Nothing is resumed and nothing is
  * written: the desktop app just opens an empty session with that folder as its workspace.
  */
-function newSession(dir) {
-  return { ok: true, url: `claude://code/new?${new URLSearchParams({ folder: dir })}` }
+async function newSession(dir) {
+  const url = `claude://code/new?${new URLSearchParams({ folder: dir })}`
+  let command
+  if (process.platform === 'linux') {
+    const bin = await cliBinary()
+    if (bin) command = { argv: [bin], cwd: dir }
+  }
+  return { ok: true, url, command }
 }
 
 export default {

--- a/server/harnesses/claude-code.mjs
+++ b/server/harnesses/claude-code.mjs
@@ -14,9 +14,10 @@
  *   - the CLI keeps the raw transcript, which is the only source for terminal-started work
  */
 import fsp from 'node:fs/promises'
+import { existsSync, readdirSync } from 'node:fs'
 import path from 'node:path'
 import os from 'node:os'
-import { exists, jsonLines, listDirs, listFiles, num, readHead } from '../lib/fsutil.mjs'
+import { exists, jsonLines, listDirs, listFiles, num, readHead, readTail } from '../lib/fsutil.mjs'
 
 const HOME = os.homedir()
 
@@ -27,12 +28,47 @@ const HOME = os.homedir()
 function desktopDataDir() {
   switch (process.platform) {
     case 'win32':
-      return path.join(process.env.APPDATA || path.join(HOME, 'AppData', 'Roaming'), 'Claude')
+      return windowsDataDir()
     case 'linux':
       return path.join(process.env.XDG_CONFIG_HOME || path.join(HOME, '.config'), 'Claude')
     default:
       return path.join(HOME, 'Library', 'Application Support', 'Claude')
   }
+}
+
+/**
+ * Windows has two answers, because the app ships two ways.
+ *
+ * The classic installer writes to `%APPDATA%\Claude`, which is what Electron's `userData` means
+ * everywhere else. Installed from the Microsoft Store the app is an MSIX package, and MSIX
+ * *redirects* what a packaged app believes is `%APPDATA%` into its own private
+ * `…\Packages\<family>\LocalCache\Roaming`. The app is installed, running and writing session
+ * records — and `%APPDATA%\Claude` does not exist at all.
+ *
+ * The package folder is globbed rather than named: its suffix is a hash of the publisher, and
+ * hard-coding that buys a constant which is right until it is not, and then wrong in a way that
+ * looks exactly like the app having been uninstalled.
+ *
+ * Resolved once, at import. Installing the app while the colony is running therefore wants a
+ * restart to be noticed — a knowing trade, since the alternative is globbing `Packages` on every
+ * scan to catch something that happens once.
+ */
+function windowsDataDir() {
+  const roaming = path.join(process.env.APPDATA || path.join(HOME, 'AppData', 'Roaming'), 'Claude')
+  const local = process.env.LOCALAPPDATA || path.join(HOME, 'AppData', 'Local')
+  const candidates = [roaming]
+  try {
+    for (const entry of readdirSync(path.join(local, 'Packages'), { withFileTypes: true })) {
+      if (entry.isDirectory() && entry.name.startsWith('Claude_')) {
+        candidates.push(path.join(local, 'Packages', entry.name, 'LocalCache', 'Roaming', 'Claude'))
+      }
+    }
+  } catch {
+    /* no Packages directory — this machine has no Store apps at all */
+  }
+  // Whichever actually holds the records. Falling back to the unpackaged path keeps every
+  // caller working against a real path when neither exists, which `detect()` reads as "no app".
+  return candidates.find((dir) => existsSync(path.join(dir, 'claude-code-sessions'))) || roaming
 }
 
 /** Where the Claude desktop app keeps one JSON record per thread. */
@@ -51,6 +87,13 @@ const HEAD_BYTES = 192 * 1024
  * warmed ones sat 16 hours to 3 days idle while genuinely active work was minutes old.
  */
 const ACTIVE_WINDOW_MS = 30 * 60 * 1000
+
+/**
+ * Every id this adapter hands out is prefixed. `server/harnesses/README.md` asks for ids unique
+ * across harnesses, and while two UUIDs will not collide, the colony keys its archive list and
+ * saved layout on this string — so it is worth being unambiguous rather than merely lucky.
+ */
+const ID = (raw) => `claude-code:${raw}`
 
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 const DESKTOP_ID = /^local_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
@@ -141,6 +184,44 @@ async function scanTranscripts() {
     }
   }
   return byId
+}
+
+/** How much of a transcript's end it takes to see whose turn it is. One record is plenty. */
+const TAIL_BYTES = 64 * 1024
+
+/**
+ * Whether a transcript ends with the turn handed back to you.
+ *
+ * A live process is not the same thing as work in progress. The CLI holds its process open while
+ * it sits at the prompt, so "the pid exists and the file moved recently" marks a thread that
+ * finished four minutes ago and asked you a question as *working* — an astronaut hammering away
+ * at a thread whose whole point is that it is waiting.
+ *
+ * The transcript says which it is. A last assistant message that called a tool is mid-turn; one
+ * that called nothing has handed the turn back and the reply is yours. `stop_reason` alone will
+ * not do — it is `end_turn` on a main thread's last message and empty on some others — so what
+ * the message *called* is the half worth testing.
+ *
+ * Only threads that could plausibly be running pay for this, so it costs one small read each.
+ */
+async function awaitingReply(file) {
+  let records
+  try {
+    records = jsonLines(await readTail(file, TAIL_BYTES))
+  } catch {
+    return false
+  }
+  for (let i = records.length - 1; i >= 0; i--) {
+    const r = records[i]
+    // A user turn, a tool result or an attachment all mean the model speaks next — whatever the
+    // process is doing, it is not waiting on anyone.
+    if (r.type === 'user') return false
+    if (r.type !== 'assistant') continue
+    const content = r.message?.content
+    const calling = Array.isArray(content) && content.some((c) => c?.type === 'tool_use')
+    return !calling && r.message?.stop_reason !== 'tool_use'
+  }
+  return false
 }
 
 /** Transcript metadata is expensive to parse, so keep it until the file changes. */
@@ -241,7 +322,10 @@ function mergeThread(existing, next) {
  * id looks like.
  */
 function toThread(t) {
-  const { desktopSessionId, desktopSessionIds, cliSessionId, bridgeSessionId, titled, hasLiveProcess, ...rest } = t
+  const {
+    desktopSessionId, desktopSessionIds, cliSessionId, bridgeSessionId,
+    titled, hasLiveProcess, transcriptFile, recordActivityAt, ...rest
+  } = t
   return {
     ...rest,
     canOpen: Boolean((desktopSessionId && DESKTOP_ID.test(desktopSessionId)) || (cliSessionId && UUID.test(cliSessionId))),
@@ -272,7 +356,7 @@ async function scanThreads() {
     const meta = entry ? await transcriptMeta(entry) : null
 
     add({
-      id: cliSessionId || s.sessionId,
+      id: ID(cliSessionId || s.sessionId),
       cliSessionId,
       desktopSessionId: s.sessionId || '',
       desktopSessionIds: s.sessionId ? [s.sessionId] : [],
@@ -288,7 +372,17 @@ async function scanThreads() {
       model: s.model || '',
       effort: s.effort || '',
       createdAt: num(s.createdAt) || meta?.startedAt || 0,
-      lastActivityAt: num(s.lastActivityAt) || num(s.lastFocusedAt) || num(s.createdAt) || 0,
+      // The desktop record's own stamp lags: the app writes it when the thread is focused, so a
+      // session running in a terminal — or in a window you are not looking at — reads as hours
+      // old while its transcript is being written to right now. The later of the two is true.
+      lastActivityAt: Math.max(
+        num(s.lastActivityAt) || num(s.lastFocusedAt) || num(s.createdAt) || 0,
+        entry?.mtime || 0
+      ),
+      // Kept apart from the above. "Unread" compares against when you last *looked*, and both
+      // sides have to come from the app's own bookkeeping: measure a transcript mtime against
+      // `lastFocusedAt` instead and every background write puts a `?` over half the colony.
+      recordActivityAt: num(s.lastActivityAt) || num(s.lastFocusedAt) || num(s.createdAt) || 0,
       lastFocusedAt: num(s.lastFocusedAt),
       hasLiveProcess: live.has(cliSessionId),
       hasError: Boolean(s.error),
@@ -298,6 +392,7 @@ async function scanThreads() {
       archived: s.isArchived === true || s.isArchived === 'True',
       hasTranscript: Boolean(entry),
       sizeBytes: entry?.size || 0,
+      transcriptFile: entry?.file || '',
       source: 'desktop',
     })
   }
@@ -309,7 +404,7 @@ async function scanThreads() {
     const cwd = meta.cwd || decodeProjectDir(path.basename(entry.projectDir))
     const { projectPath, project, worktree } = projectOf(cwd, '')
     add({
-      id,
+      id: ID(id),
       cliSessionId: id,
       desktopSessionId: '',
       desktopSessionIds: [],
@@ -335,17 +430,46 @@ async function scanThreads() {
       archived: false,
       hasTranscript: true,
       sizeBytes: entry.size,
+      transcriptFile: entry?.file || '',
       source: 'cli',
     })
   }
 
-  const threads = [...byId.values()]
+  const now = Date.now()
+
+  /**
+   * Drop the app's empty bookkeeping records.
+   *
+   * Resuming a thread makes the desktop app write a second record for the same conversation, and
+   * one of the two carries the title and the transcript link while the other carries nothing.
+   * With no `cliSessionId` on the empty one there is no key to merge the pair on, so it survives
+   * as a thread of its own: an untitled entry with no transcript behind it, standing on the map
+   * as a nameless twin of a thread you have already dealt with.
+   *
+   * A record with no transcript, no title and no live process is not a conversation. The age
+   * check keeps a genuinely new session — opened seconds ago, nothing written yet — out of it.
+   */
+  const NEW_SESSION_MS = 10 * 60 * 1000
+  const threads = [...byId.values()].filter(
+    (t) =>
+      t.hasTranscript ||
+      t.titled ||
+      t.hasLiveProcess ||
+      now - (t.lastActivityAt || t.createdAt || 0) < NEW_SESSION_MS
+  )
+
   // Unread = the thread moved on after you last looked at it; never opened counts as unread.
   // Terminal-only threads have no focus history at all, so "unread" is unknowable — not true.
-  const now = Date.now()
   for (const thread of threads) {
-    thread.unread = thread.desktopSessionIds.length > 0 && thread.lastActivityAt > thread.lastFocusedAt
-    thread.running = thread.hasLiveProcess && now - thread.lastActivityAt < ACTIVE_WINDOW_MS
+    const seenAt = thread.recordActivityAt ?? thread.lastActivityAt
+    thread.unread = thread.desktopSessionIds.length > 0 && seenAt > thread.lastFocusedAt
+    const fresh = now - thread.lastActivityAt < ACTIVE_WINDOW_MS
+    const waiting =
+      thread.hasLiveProcess && fresh && thread.transcriptFile ? await awaitingReply(thread.transcriptFile) : false
+    thread.running = thread.hasLiveProcess && fresh && !waiting
+    // A thread that handed the turn back wants you, whether or not the desktop app has ever seen
+    // it — the only way a terminal-only thread can ask for anything at all.
+    if (waiting) thread.unread = true
   }
   return threads.map(toThread)
 }

--- a/server/harnesses/claude-code.mjs
+++ b/server/harnesses/claude-code.mjs
@@ -6,6 +6,9 @@
  * means writing a sibling of this file rather than editing the scanner. The contract is
  * written down in `server/harnesses/README.md`.
  *
+ * Read-only, without exception. Nothing here writes to Claude Code's files — see the note on
+ * archiving in `server/harnesses/README.md`.
+ *
  * Two stores, deliberately merged rather than picked between:
  *   - the desktop app keeps one JSON record per thread (title, cwd, model, timestamps)
  *   - the CLI keeps the raw transcript, which is the only source for terminal-started work
@@ -13,11 +16,8 @@
 import fsp from 'node:fs/promises'
 import path from 'node:path'
 import os from 'node:os'
-import { execFile } from 'node:child_process'
-import { promisify } from 'node:util'
 import { exists, jsonLines, listDirs, listFiles, num, readHead } from '../lib/fsutil.mjs'
 
-const execFileAsync = promisify(execFile)
 const HOME = os.homedir()
 
 /**
@@ -245,7 +245,6 @@ function toThread(t) {
   return {
     ...rest,
     canOpen: Boolean((desktopSessionId && DESKTOP_ID.test(desktopSessionId)) || (cliSessionId && UUID.test(cliSessionId))),
-    canArchive: desktopSessionIds.length > 0,
     ref: { desktopSessionId, desktopSessionIds, cliSessionId },
   }
 }
@@ -351,57 +350,6 @@ async function scanThreads() {
   return threads.map(toThread)
 }
 
-/** Locate the desktop app's record for a session. Id is pattern-checked, never joined raw. */
-async function findSessionFile(sessionId) {
-  if (!DESKTOP_ID.test(sessionId)) return null
-  for (const account of await listDirs(DESKTOP_SESSIONS)) {
-    for (const org of await listDirs(account)) {
-      const file = path.join(org, `${sessionId}.json`)
-      if (await exists(file)) return file
-    }
-  }
-  return null
-}
-
-/**
- * Flip `isArchived` on the desktop app's own session record — the same field its
- * Archived list reads. Only that one key is touched; everything else is written back
- * byte-for-byte from what was there, through a temp file so a crash can't truncate it.
- */
-async function setSessionArchived(sessionId, archived) {
-  const file = await findSessionFile(sessionId)
-  if (!file) return { ok: false, error: 'No Claude Code session record for that thread' }
-
-  let record
-  try {
-    record = JSON.parse(await fsp.readFile(file, 'utf8'))
-  } catch {
-    return { ok: false, error: 'Session record is unreadable' }
-  }
-  if (!record || typeof record !== 'object' || record.sessionId !== sessionId) {
-    return { ok: false, error: 'Session record did not look like the expected session' }
-  }
-
-  record.isArchived = Boolean(archived)
-  const tmp = `${file}.botcrossing.tmp`
-  await fsp.writeFile(tmp, JSON.stringify(record, null, 2))
-  await fsp.rename(tmp, file)
-  metaCache.delete(record.cliSessionId)
-  return { ok: true, file, archived: Boolean(archived) }
-}
-
-/** Archive every record that maps to a thread — the real one and any import ghosts. */
-async function setArchived(ref, archived) {
-  const ids = ref?.desktopSessionIds || []
-  if (!ids.length) return { ok: false, error: 'No session records for that thread' }
-  const results = []
-  for (const id of ids) results.push(await setSessionArchived(id, archived))
-  const ok = results.some((r) => r.ok)
-  return ok
-    ? { ok, archived: Boolean(archived), records: results.filter((r) => r.ok).length }
-    : results[0] || { ok: false, error: 'No session records for that thread' }
-}
-
 /**
  * Hands the thread back to Claude Code. `epitaxy/<local_…>` *navigates* the desktop app
  * to a thread it already has; `resume` *imports* the transcript, which spawns a second
@@ -428,71 +376,6 @@ function newSession(dir) {
   return { ok: true, url: `claude://code/new?${new URLSearchParams({ folder: dir })}` }
 }
 
-/**
- * When the Claude desktop app last launched. It loads every session record into memory at
- * startup and never re-reads them, so this timestamp is the line between an archive it has
- * seen and one still waiting on disk.
- */
-let appStartCache = { at: 0, checkedAt: 0 }
-async function appStartedAt() {
-  const now = Date.now()
-  if (now - appStartCache.checkedAt < 15000) return appStartCache.at
-
-  let started = 0
-  try {
-    started = process.platform === 'win32' ? await windowsAppStartedAt() : await darwinAppStartedAt()
-  } catch {
-    /* no process listing — treat the app as never having restarted */
-  }
-  appStartCache = { at: started, checkedAt: now }
-  return started
-}
-
-async function darwinAppStartedAt() {
-  const { stdout } = await execFileAsync('ps', ['-axo', 'pid=,lstart=,command='], { maxBuffer: 8 * 1024 * 1024 })
-  for (const line of stdout.split('\n')) {
-    const m = line.match(/^\s*\d+\s+(\w{3} \w{3}\s+\d+ \d{2}:\d{2}:\d{2} \d{4})\s+(\/.*)$/)
-    if (!m) continue
-    const [, when, command] = m
-    // The main process only — helper processes carry a --type= flag.
-    if (!command.includes('/Claude.app/Contents/MacOS/Claude') || command.includes('--type=')) continue
-    const parsed = Date.parse(when)
-    return Number.isNaN(parsed) ? 0 : parsed
-  }
-  return 0
-}
-
-/**
- * The same answer on Windows. There is no `ps`, and `tasklist` knows neither start times nor
- * command lines, so this asks CIM, which knows both. The desktop app and the CLI are both
- * `claude.exe` here, so the main process is picked out by shape rather than by path: the one
- * with no `--type=` flag whose children (the helpers, which all carry one) point back at it.
- * A PowerShell round trip is a few hundred milliseconds, which the 15s cache above absorbs.
- */
-async function windowsAppStartedAt() {
-  const script = [
-    "Get-CimInstance Win32_Process -Filter \"Name='claude.exe'\" | ForEach-Object {",
-    "  if ($_.CreationDate) { '{0}|{1}|{2}|{3}' -f $_.ProcessId, $_.ParentProcessId,",
-    "    $_.CreationDate.ToUniversalTime().ToString('o'), $_.CommandLine } }",
-  ].join(' ')
-  const { stdout } = await execFileAsync('powershell', ['-NoProfile', '-NonInteractive', '-Command', script], {
-    maxBuffer: 8 * 1024 * 1024,
-  })
-  const rows = stdout
-    .split(/\r?\n/)
-    .map((line) => line.split('|'))
-    .filter((parts) => parts.length >= 4)
-    .map(([pid, ppid, when, ...command]) => ({
-      pid,
-      ppid,
-      when: Date.parse(when),
-      command: command.join('|'),
-    }))
-  const helperParents = new Set(rows.filter((r) => r.command.includes('--type=')).map((r) => r.ppid))
-  const main = rows.find((r) => helperParents.has(r.pid) && !r.command.includes('--type='))
-  return main && !Number.isNaN(main.when) ? main.when : 0
-}
-
 export default {
   id: 'claude-code',
   name: 'Claude Code',
@@ -501,7 +384,5 @@ export default {
   scanThreads,
   openThread,
   newSession,
-  setArchived,
-  appStartedAt,
   paths: { DESKTOP_SESSIONS, CLI_PROJECTS, CLI_LIVE },
 }

--- a/server/harnesses/codex.mjs
+++ b/server/harnesses/codex.mjs
@@ -1,0 +1,347 @@
+/**
+ * Harness adapter: Codex (OpenAI) — the desktop app, the VS Code extension and the CLI together.
+ *
+ * Two stores, deliberately merged rather than picked between, the same shape `claude-code.mjs`
+ * ended up in:
+ *
+ *   - `~/.codex/state_<n>.sqlite` holds one row per thread — title, cwd, branch, model, effort,
+ *     archived — which is everything the colony wants and none of it inferred.
+ *   - `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` holds the transcript, which is the only
+ *     source for how big a thread is and whether it is mid-turn, and the only source at all for
+ *     a session the database has not caught up with.
+ *
+ * They join on the session id, which appears in the row, in the rollout's filename and in its
+ * `session_meta` record. Reading only the database loses transcript size and any CLI session it
+ * has not indexed; reading only the transcripts means reconstructing metadata the database
+ * already has correct.
+ *
+ * Read-only, without exception, and no subprocess anywhere. Codex has an archive of its own that
+ * only its CLI can set, so archiving here is recorded in the colony alone — see the note on
+ * archiving in `server/harnesses/README.md`.
+ */
+import fsp from 'node:fs/promises'
+import path from 'node:path'
+import os from 'node:os'
+import { exists, jsonLines, listDirs, listFiles, num, readHead, readTail } from '../lib/fsutil.mjs'
+
+const HOME = os.homedir()
+const CODEX_HOME = process.env.CODEX_HOME || path.join(HOME, '.codex')
+const SESSIONS_DIR = path.join(CODEX_HOME, 'sessions')
+const SESSION_INDEX = path.join(CODEX_HOME, 'session_index.jsonl')
+
+const HEAD_BYTES = 128 * 1024
+const TAIL_BYTES = 64 * 1024
+/** Codex writes nothing when it is killed, so a stale `task_started` needs a time bound too. */
+const ACTIVE_WINDOW_MS = 30 * 60 * 1000
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+const STATE_DB = /^state_(\d+)\.sqlite$/
+
+/** Prefixed, per the contract in `server/harnesses/README.md`. */
+const ID = (raw) => `codex:${raw}`
+
+/**
+ * `node:sqlite` is imported lazily and its absence is survivable.
+ *
+ * It needs Node 22.13, which `package.json` asks for — but asking is not enforcing, and a top
+ * level import would take the whole server down on an older Node rather than costing one
+ * harness. This way the transcript half still works and `diagnostic()` explains the rest.
+ */
+let sqlitePromise
+const sqliteApi = () => (sqlitePromise ??= import('node:sqlite').catch(() => null))
+
+/** The newest schema version, not the most recently touched WAL sibling. */
+async function latestStateDatabase() {
+  let entries
+  try {
+    entries = await fsp.readdir(CODEX_HOME, { withFileTypes: true })
+  } catch {
+    return ''
+  }
+  return (
+    entries
+      .filter((e) => e.isFile() && STATE_DB.test(e.name))
+      .map((e) => ({ file: path.join(CODEX_HOME, e.name), version: Number(e.name.match(STATE_DB)[1]) }))
+      .sort((a, b) => b.version - a.version)[0]?.file || ''
+  )
+}
+
+/**
+ * Every column is probed before it is named.
+ *
+ * This is undocumented private state that changes shape between Codex versions — the filename is
+ * versioned precisely because it does. A `SELECT` naming a column that has gone throws and costs
+ * the whole harness its threads, so anything not load-bearing is asked for only if it is there.
+ */
+const column = (columns, name, fallback = "''") => (columns.has(name) ? `t.${name}` : fallback)
+
+function timeExpr(columns, ms, secs) {
+  if (columns.has(ms) && columns.has(secs)) return `COALESCE(t.${ms}, t.${secs} * 1000)`
+  if (columns.has(ms)) return `t.${ms}`
+  if (columns.has(secs)) return `t.${secs} * 1000`
+  return '0'
+}
+
+/** The thread index, keyed by session id. Empty when there is no readable database. */
+async function databaseRows() {
+  const [file, sqlite] = await Promise.all([latestStateDatabase(), sqliteApi()])
+  if (!file || !sqlite?.DatabaseSync) return new Map()
+
+  let db
+  try {
+    db = new sqlite.DatabaseSync(file, { readOnly: true })
+  } catch {
+    // A WAL database whose shared-memory file cannot be used refuses a read-only open. The
+    // transcripts still answer everything the colony needs to draw something.
+    return new Map()
+  }
+  try {
+    const tables = new Set(
+      db.prepare("SELECT name FROM sqlite_master WHERE type = 'table'").all().map((r) => r.name)
+    )
+    if (!tables.has('threads')) return new Map()
+    const columns = new Set(db.prepare('PRAGMA table_info(threads)').all().map((r) => r.name))
+    if (!['id', 'cwd'].every((n) => columns.has(n))) return new Map()
+
+    // Threads a task spawned are not conversations anybody had; each would stand on the map as
+    // an astronaut nobody talks to.
+    const children = new Set()
+    if (tables.has('thread_spawn_edges')) {
+      const edge = new Set(db.prepare('PRAGMA table_info(thread_spawn_edges)').all().map((r) => r.name))
+      if (edge.has('child_thread_id')) {
+        for (const r of db.prepare('SELECT child_thread_id FROM thread_spawn_edges').all()) {
+          if (typeof r.child_thread_id === 'string') children.add(r.child_thread_id)
+        }
+      }
+    }
+
+    const rows = db
+      .prepare(`
+        SELECT
+          t.id,
+          t.cwd,
+          ${column(columns, 'title')} AS title,
+          ${column(columns, 'preview')} AS preview,
+          ${column(columns, 'first_user_message')} AS first_user_message,
+          ${column(columns, 'source')} AS source,
+          ${column(columns, 'thread_source')} AS thread_source,
+          ${column(columns, 'git_branch')} AS git_branch,
+          ${column(columns, 'model')} AS model,
+          ${column(columns, 'reasoning_effort')} AS reasoning_effort,
+          ${column(columns, 'rollout_path')} AS rollout_path,
+          ${column(columns, 'archived', '0')} AS archived,
+          ${timeExpr(columns, 'created_at_ms', 'created_at')} AS created_at_ms,
+          ${timeExpr(columns, 'updated_at_ms', 'updated_at')} AS updated_at_ms
+        FROM threads t
+      `)
+      .all()
+      .filter((r) => UUID.test(r.id || '') && !children.has(r.id) && r.thread_source !== 'subagent')
+
+    return new Map(rows.map((r) => [r.id, r]))
+  } catch {
+    return new Map()
+  } finally {
+    try {
+      db.close()
+    } catch {
+      /* already gone */
+    }
+  }
+}
+
+/** Every rollout transcript on disk, keyed by the session id in its filename. */
+async function scanRollouts() {
+  const byId = new Map()
+  for (const year of await listDirs(SESSIONS_DIR)) {
+    for (const month of await listDirs(year)) {
+      for (const day of await listDirs(month)) {
+        for (const file of await listFiles(day, (n) => n.startsWith('rollout-') && n.endsWith('.jsonl'))) {
+          const id = /([0-9a-f-]{36})\.jsonl$/i.exec(file)?.[1]
+          if (!id || !UUID.test(id)) continue
+          try {
+            const st = await fsp.stat(file)
+            byId.set(id, { id, file, size: st.size, mtime: st.mtimeMs })
+          } catch {
+            /* vanished between listing and stat */
+          }
+        }
+      }
+    }
+  }
+  return byId
+}
+
+/** `thread_name` per session, when Codex has written one. Optional; transcripts are the truth. */
+async function readIndex() {
+  const out = new Map()
+  try {
+    for (const row of jsonLines(await fsp.readFile(SESSION_INDEX, 'utf8'))) {
+      if (row?.id && UUID.test(row.id)) out.set(row.id, row)
+    }
+  } catch {
+    /* no index — every field it carries has another source */
+  }
+  return out
+}
+
+const clean = (v) => String(v || '').replace(/\s+/g, ' ').trim()
+
+function contentText(content) {
+  if (typeof content === 'string') return content
+  if (!Array.isArray(content)) return ''
+  return content.map((p) => (typeof p === 'string' ? p : p?.text || p?.input_text || '')).filter(Boolean).join('\n')
+}
+
+/** What the head of a transcript knows about itself, for a session the database has not indexed. */
+function readHeadMeta(records) {
+  const meta = { cwd: '', gitBranch: '', model: '', effort: '', createdAt: 0, prompt: '' }
+  for (const r of records) {
+    const p = r?.payload
+    if (!p || typeof p !== 'object') continue
+    if (r.type === 'session_meta') {
+      meta.cwd ||= p.cwd || ''
+      meta.gitBranch ||= p.git?.branch || ''
+      meta.createdAt ||= Date.parse(p.timestamp || r.timestamp || '') || 0
+    } else if (r.type === 'turn_context') {
+      meta.cwd = p.cwd || meta.cwd
+      meta.model = p.model || meta.model
+      meta.effort = p.effort || meta.effort
+    } else if (r.type === 'response_item' && p.type === 'message' && p.role === 'user') {
+      meta.prompt ||= clean(contentText(p.content))
+    }
+  }
+  return meta
+}
+
+/**
+ * The last lifecycle record. `task_started` with nothing after it is mid-turn; `turn_aborted` is
+ * somebody pressing escape, which is not an error and must not redden an astronaut's eyes.
+ */
+function readLifecycle(records) {
+  let last = null
+  for (const r of records) {
+    const p = r?.payload
+    if (r?.type === 'event_msg' && ['task_started', 'task_complete', 'turn_aborted'].includes(p?.type)) {
+      last = { type: p.type, error: Boolean(p.error) }
+    }
+  }
+  return last
+}
+
+/** Parsing is kept against mtime and size, so an unchanged transcript is read once. */
+const parseCache = new Map()
+async function transcriptFacts(entry, needHead) {
+  const cached = parseCache.get(entry.id)
+  if (cached && cached.mtime === entry.mtime && cached.size === entry.size && (cached.head || !needHead)) {
+    return cached.facts
+  }
+  const facts = { lifecycle: null, meta: null }
+  try {
+    facts.lifecycle = readLifecycle(jsonLines(await readTail(entry.file, TAIL_BYTES)))
+    if (needHead) facts.meta = readHeadMeta(jsonLines(await readHead(entry.file, HEAD_BYTES)))
+  } catch {
+    /* mid-write, or gone */
+  }
+  parseCache.set(entry.id, { mtime: entry.mtime, size: entry.size, head: needHead, facts })
+  return facts
+}
+
+function projectOf(cwd) {
+  const dir = typeof cwd === 'string' && path.isAbsolute(cwd) ? cwd : ''
+  return { projectPath: dir, project: dir ? path.basename(dir) : 'unknown' }
+}
+
+async function scanThreads() {
+  const [rows, rollouts, index] = await Promise.all([databaseRows(), scanRollouts(), readIndex()])
+  const ids = new Set([...rows.keys(), ...rollouts.keys()])
+  const now = Date.now()
+  const out = []
+
+  for (const id of ids) {
+    const row = rows.get(id)
+    const entry = rollouts.get(id)
+    // The head is only worth reading for a session the database cannot describe.
+    const facts = entry ? await transcriptFacts(entry, !row) : { lifecycle: null, meta: null }
+    const meta = facts.meta || {}
+
+    const cwd = row?.cwd || meta.cwd || ''
+    const { projectPath, project } = projectOf(cwd)
+    const prompt = clean(row?.preview || row?.first_user_message || meta.prompt || '')
+    const title = clean(row?.title) || clean(index.get(id)?.thread_name) || prompt || 'Untitled thread'
+    const lastActivityAt = Math.max(num(row?.updated_at_ms), entry?.mtime || 0)
+
+    out.push({
+      id: ID(id),
+      title: title.slice(0, 120),
+      preview: prompt.slice(0, 240),
+      project,
+      projectPath,
+      // Codex has no worktree concept of its own, and guessing one from the path would put a
+      // branch name on a thread that never had one.
+      worktree: '',
+      cwd,
+      gitBranch: row?.git_branch || meta.gitBranch || '',
+      model: row?.model || meta.model || '',
+      effort: row?.reasoning_effort || meta.effort || '',
+      createdAt: num(row?.created_at_ms) || meta.createdAt || entry?.mtime || 0,
+      lastActivityAt,
+      // Codex records no focus history, so "have you looked at this" is unknowable — not false.
+      lastFocusedAt: 0,
+      unread: false,
+      running: facts.lifecycle?.type === 'task_started' && now - lastActivityAt < ACTIVE_WINDOW_MS,
+      hasError: facts.lifecycle?.type === 'task_complete' && facts.lifecycle.error,
+      starred: false,
+      routine: '',
+      prState: '',
+      archived: row?.archived === 1 || row?.archived === true,
+      // Bytes, like every other harness: the field is a shared log scale across the whole map,
+      // and a token count would make Codex buildings taller than Claude ones for the same work.
+      sizeBytes: entry?.size || 0,
+      source: row?.source === 'vscode' ? 'vscode' : 'cli',
+      canOpen: true,
+      ref: { sessionId: id },
+    })
+  }
+  return out
+}
+
+/** `codex://` is registered by the Codex desktop app; the OS opener does the rest. */
+function openThread(ref) {
+  const id = ref?.sessionId
+  if (typeof id !== 'string' || !UUID.test(id)) {
+    return { ok: false, error: 'No openable Codex session id on that thread' }
+  }
+  return { ok: true, url: `codex://threads/${id}` }
+}
+
+function newSession(dir) {
+  return { ok: true, url: `codex://threads/new?${new URLSearchParams({ path: dir })}` }
+}
+
+/** Claim the machine if either store is there — a CLI-only install has no database. */
+async function detect() {
+  return (await exists(SESSIONS_DIR)) || Boolean(await latestStateDatabase())
+}
+
+/**
+ * Why a present Codex might still look thin. Without this the Node case is invisible: the
+ * database is simply skipped, every thread loses its title and model, and nothing says why.
+ */
+async function diagnostic() {
+  if (!(await latestStateDatabase())) return ''
+  if (!(await sqliteApi())?.DatabaseSync) {
+    return `Codex threads need Node 22.13 or newer for their titles and models (running ${process.versions.node})`
+  }
+  return ''
+}
+
+export default {
+  id: 'codex',
+  name: 'Codex',
+  detect,
+  diagnostic,
+  scanThreads,
+  openThread,
+  newSession,
+  paths: { CODEX_HOME, SESSIONS_DIR },
+}

--- a/server/harnesses/cursor.mjs
+++ b/server/harnesses/cursor.mjs
@@ -1,0 +1,236 @@
+/**
+ * Harness adapter: Cursor (Anysphere) — agent transcripts.
+ *
+ * Cursor writes one JSONL per agent session at
+ * `~/.cursor/projects/<encoded-cwd>/agent-transcripts/<uuid>/<uuid>.jsonl`. The records are
+ * plainer than most: `{ role, message }` for each turn and, in recent versions, a
+ * `{ type: 'turn_ended', status }` marker closing each one. There is no title, no cwd, no model
+ * and no branch anywhere in the file — the encoded directory name and the first user message are
+ * the whole of the metadata.
+ *
+ * Not covered: the composer / sidebar threads. Their bodies are not in these files — the
+ * per-workspace `state.vscdb` holds only pane layout, and the global one is a couple of
+ * gigabytes on a working machine and open read-write by the editor. Reading that on a
+ * fifteen-second poll is its own piece of work, and guessing at its shape would be worse than
+ * leaving it out and saying so.
+ *
+ * Read-only, no subprocess, and nothing is ever read from inside `Cursor.app`.
+ */
+import fsp from 'node:fs/promises'
+import path from 'node:path'
+import os from 'node:os'
+import { exists, jsonLines, listDirs, listFiles, readHead, readTail } from '../lib/fsutil.mjs'
+
+const HOME = os.homedir()
+const PROJECTS = process.env.BOT_CROSSING_CURSOR_PROJECTS || path.join(HOME, '.cursor', 'projects')
+const TRANSCRIPTS = 'agent-transcripts'
+
+const HEAD_BYTES = 96 * 1024
+const TAIL_BYTES = 32 * 1024
+/** Cursor writes nothing when it is killed, so an unclosed turn needs a time bound as well. */
+const ACTIVE_WINDOW_MS = 30 * 60 * 1000
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+/** Prefixed, per the contract in `server/harnesses/README.md`. */
+const ID = (raw) => `cursor:${raw}`
+
+const isDir = async (p) => {
+  try {
+    return (await fsp.stat(p)).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Turn `Users-jarren-Documents-GitHub-emra-app-builder` back into a path.
+ *
+ * Every separator became a dash and so did every dash already in a folder name, which makes the
+ * encoding lossy and the obvious reverse — replace each dash with a slash — wrong for most real
+ * repositories. On this machine it was wrong for *every* project with a transcript:
+ * `emra-app-builder` came back as `emra/app/builder`, `personal-site-2025` as
+ * `personal/site/2025`. Since `project` is what claims a hex zone, that is not cosmetic.
+ *
+ * So the disk decides. Walk the tokens and, at each step, take the longest run of them that
+ * names a directory that actually exists, backtracking when a greedy match leads nowhere. A
+ * repository that has since been deleted cannot be resolved by anyone, and falls back to
+ * attaching the rest as a single dashed name — the likelier reading, since a folder name with
+ * dashes in it is far more common than four nested single-word folders.
+ */
+async function resolvePath(tokens, from = '') {
+  if (!tokens.length) return from
+  for (let take = tokens.length; take >= 1; take--) {
+    const candidate = `${from}/${tokens.slice(0, take).join('-')}`
+    if (!(await isDir(candidate))) continue
+    const rest = await resolvePath(tokens.slice(take), candidate)
+    if (rest) return rest
+  }
+  return ''
+}
+
+const decodeCache = new Map()
+async function decodeProjectDir(name) {
+  if (decodeCache.has(name)) return decodeCache.get(name)
+  const tokens = name.split('-').filter(Boolean)
+  const resolved = await resolvePath(tokens)
+  // Nothing on disk answers to it any more: keep the deepest ancestor that does and let the
+  // remainder stand as one name.
+  let out = resolved
+  if (!out) {
+    let dir = ''
+    let i = 0
+    while (i < tokens.length && (await isDir(`${dir}/${tokens[i]}`))) dir = `${dir}/${tokens[i++]}`
+    out = i < tokens.length ? `${dir}/${tokens.slice(i).join('-')}` : dir
+  }
+  decodeCache.set(name, out)
+  return out
+}
+
+/**
+ * Cursor wraps a prompt in tags of its own — a timestamp, a note about attached images, the
+ * query itself. Only the query is something a person typed, and it is the only part worth
+ * putting on a card.
+ */
+function userText(record) {
+  const parts = record?.message?.content
+  const raw = Array.isArray(parts)
+    ? parts.map((p) => (typeof p === 'string' ? p : p?.text || '')).join('\n')
+    : String(parts || '')
+  const query = /<user_query>\s*([\s\S]*?)\s*<\/user_query>/.exec(raw)
+  const text = query ? query[1] : raw.replace(/<[a-z_]+>[\s\S]*?<\/[a-z_]+>/gi, ' ')
+  return text.replace(/\s+/g, ' ').trim()
+}
+
+/** `Tuesday, Sep 8, 2026, 4:08 PM (UTC-7)` if the first turn carried one. */
+function stamp(record) {
+  const parts = record?.message?.content
+  const raw = Array.isArray(parts) ? parts.map((p) => p?.text || '').join('\n') : ''
+  const m = /<timestamp>(.*?)<\/timestamp>/.exec(raw)
+  const t = m ? Date.parse(m[1].replace(/\s*\(UTC[^)]*\)\s*$/, '')) : NaN
+  return Number.isNaN(t) ? 0 : t
+}
+
+/** Every transcript on disk, with the project directory it sits under. */
+async function scanTranscripts() {
+  const out = []
+  for (const projectDir of await listDirs(PROJECTS)) {
+    const root = path.join(projectDir, TRANSCRIPTS)
+    for (const sessionDir of await listDirs(root)) {
+      const id = path.basename(sessionDir)
+      if (!UUID.test(id)) continue
+      for (const file of await listFiles(sessionDir, (n) => n.endsWith('.jsonl'))) {
+        try {
+          const st = await fsp.stat(file)
+          if (!st.size) continue
+          out.push({ id, file, dirName: path.basename(projectDir), size: st.size, mtime: st.mtimeMs, born: st.birthtimeMs })
+        } catch {
+          /* vanished between listing and stat */
+        }
+      }
+    }
+  }
+  return out
+}
+
+/** Parsing is kept against mtime and size, so an unchanged transcript is read once. */
+const cache = new Map()
+async function facts(entry) {
+  const hit = cache.get(entry.id)
+  if (hit && hit.mtime === entry.mtime && hit.size === entry.size) return hit.value
+  const value = { prompt: '', startedAt: 0, closed: true, modern: false, errored: false }
+  try {
+    for (const r of jsonLines(await readHead(entry.file, HEAD_BYTES))) {
+      if (r?.role !== 'user') continue
+      value.prompt = userText(r)
+      value.startedAt = stamp(r)
+      break
+    }
+    const tail = jsonLines(await readTail(entry.file, TAIL_BYTES))
+    // `turn_ended` is a recent addition: transcripts written before it exist in numbers and
+    // carry none at all. Treating "no marker" as "mid-turn" would light up every old thread on
+    // the map, so a file only gets read that way once it has proved it writes them.
+    const ended = tail.filter((r) => r?.type === 'turn_ended')
+    value.modern = ended.length > 0
+    const last = tail[tail.length - 1]
+    value.closed = last?.type === 'turn_ended'
+    value.errored = ended.length > 0 && ended[ended.length - 1].status !== 'success'
+  } catch {
+    /* mid-write, or gone */
+  }
+  cache.set(entry.id, { mtime: entry.mtime, size: entry.size, value })
+  return value
+}
+
+async function scanThreads() {
+  const entries = await scanTranscripts()
+  const now = Date.now()
+  const threads = []
+
+  for (const entry of entries) {
+    const f = await facts(entry)
+    const projectPath = await decodeProjectDir(entry.dirName)
+    const prompt = f.prompt
+    threads.push({
+      id: ID(entry.id),
+      title: (prompt || 'Untitled thread').slice(0, 120),
+      preview: prompt.slice(0, 240),
+      project: path.basename(projectPath) || 'unknown',
+      projectPath,
+      // Cursor records no worktree, and inferring one from the path would put a branch name on
+      // a thread that never had one.
+      worktree: '',
+      cwd: projectPath,
+      gitBranch: '',
+      model: '',
+      effort: '',
+      createdAt: f.startedAt || entry.born || entry.mtime,
+      lastActivityAt: entry.mtime,
+      // No focus history, so "have you read this" is unknowable rather than false.
+      lastFocusedAt: 0,
+      unread: false,
+      running: f.modern && !f.closed && now - entry.mtime < ACTIVE_WINDOW_MS,
+      hasError: f.errored,
+      starred: false,
+      routine: '',
+      prState: '',
+      archived: false,
+      sizeBytes: entry.size,
+      source: 'agent',
+      canOpen: false,
+      ref: { sessionId: entry.id, cwd: projectPath },
+    })
+  }
+  return threads
+}
+
+/**
+ * Cursor registers `cursor://`, but only for files and folders — nothing found so far addresses
+ * a single agent thread, and inventing a route would be a link that silently does nothing.
+ * Revealing the repo is the honest offer, and the UI greys the button and shows this instead.
+ */
+function openThread() {
+  return {
+    ok: false,
+    error: 'Cursor has no link to a single thread — open the repo and pick it from the agent list.',
+  }
+}
+
+/** `cursor://file/<abs>` is answered by the installed app; the OS opener does the finding. */
+function newSession(dir) {
+  const abs = String(dir || '').replace(/\\/g, '/')
+  if (!abs.startsWith('/')) return { ok: false, error: 'That folder is not somewhere Cursor can open' }
+  return { ok: true, url: `cursor://file${abs.split('/').map(encodeURIComponent).join('/')}` }
+}
+
+const detect = () => exists(PROJECTS)
+
+export default {
+  id: 'cursor',
+  name: 'Cursor',
+  detect,
+  scanThreads,
+  openThread,
+  newSession,
+  paths: { PROJECTS },
+}

--- a/server/harnesses/index.mjs
+++ b/server/harnesses/index.mjs
@@ -7,8 +7,9 @@
  * `server/harnesses/README.md`.
  */
 import claudeCode from './claude-code.mjs'
+import codex from './codex.mjs'
 
-export const HARNESSES = [claudeCode]
+export const HARNESSES = [claudeCode, codex]
 
 export const harnessById = (id) => HARNESSES.find((h) => h.id === id) || null
 

--- a/server/harnesses/index.mjs
+++ b/server/harnesses/index.mjs
@@ -8,8 +8,9 @@
  */
 import claudeCode from './claude-code.mjs'
 import codex from './codex.mjs'
+import cursor from './cursor.mjs'
 
-export const HARNESSES = [claudeCode, codex]
+export const HARNESSES = [claudeCode, codex, cursor]
 
 export const harnessById = (id) => HARNESSES.find((h) => h.id === id) || null
 

--- a/server/lib/fsutil.mjs
+++ b/server/lib/fsutil.mjs
@@ -21,6 +21,24 @@ export async function readHead(file, bytes) {
   }
 }
 
+/**
+ * The last `bytes` of a file, with a leading partial line dropped. The mirror of `readHead`,
+ * for the questions only the end of a transcript answers — whose turn it is right now.
+ */
+export async function readTail(file, bytes) {
+  const fh = await fsp.open(file, 'r')
+  try {
+    const { size } = await fh.stat()
+    const want = Math.min(bytes, size)
+    const buf = Buffer.allocUnsafe(want)
+    const { bytesRead } = await fh.read(buf, 0, want, size - want)
+    const text = buf.subarray(0, bytesRead).toString('utf8')
+    return want === size ? text : text.slice(text.indexOf('\n') + 1)
+  } finally {
+    await fh.close()
+  }
+}
+
 /** Parse a JSONL blob, skipping the partial or malformed lines a live file always has. */
 export function jsonLines(text) {
   const out = []
@@ -63,6 +81,32 @@ export async function exists(p) {
   } catch {
     return false
   }
+}
+
+/**
+ * Where an executable is, as an absolute path, or null. PATH first, then `extraDirs` — the
+ * places an installer puts a binary that a server started with a thin PATH (an IDE launcher, a
+ * service unit) would not see. Candidates are resolved rather than joined: the caller may spawn
+ * from a different working directory than this check ran in, and a relative PATH entry would
+ * then name two different files. X_OK alone passes for a directory, hence the stat.
+ *
+ * It never looks inside an application bundle, and no caller should hand it a path that does.
+ * Running a binary out of somebody else's `.app` is how you get the OS blaming us for it.
+ */
+export async function findExecutable(name, extraDirs = []) {
+  if (typeof name !== 'string' || !name) return null
+  const explicit = name.includes('/') || name.includes(path.sep)
+  const onPath = (process.env.PATH || '').split(path.delimiter).filter(Boolean)
+  for (const dir of explicit ? ['.'] : [...onPath, ...extraDirs]) {
+    const candidate = path.resolve(dir, name)
+    try {
+      await fsp.access(candidate, fsp.constants.X_OK)
+      if ((await fsp.stat(candidate)).isFile()) return candidate
+    } catch {
+      /* not here */
+    }
+  }
+  return null
 }
 
 export const num = (v) => {

--- a/server/lib/xdg.mjs
+++ b/server/lib/xdg.mjs
@@ -1,0 +1,229 @@
+/**
+ * Linux desktop plumbing: does anything on this machine answer a URL scheme, and how do you put
+ * a command in a terminal window here.
+ *
+ * Only `server/api.mjs` uses this, and only on Linux. It is split out because it is a page of
+ * desktop-environment trivia with nothing to do with HTTP, and nothing in here knows about a
+ * particular harness — an adapter never imports it. An adapter hands the server an argv; the
+ * server decides whether a terminal is the right place for it.
+ */
+import { execFile, spawn } from 'node:child_process'
+import fsp from 'node:fs/promises'
+import path from 'node:path'
+import { promisify } from 'node:util'
+import { findExecutable } from './fsutil.mjs'
+
+const execFileAsync = promisify(execFile)
+
+/** The scheme of a URL, or '' if it does not parse. */
+export function schemeOf(url) {
+  try {
+    return new URL(url).protocol.replace(/:$/, '')
+  } catch {
+    return ''
+  }
+}
+
+/**
+ * Is a desktop app registered for this URL's scheme?
+ *
+ * `xdg-mime query default x-scheme-handler/<scheme>` is what `xdg-open` itself consults. It
+ * checks that a `mimeapps.list` entry still points at an installed .desktop file, which is the
+ * common stale case — an uninstalled app leaves its line behind — though its `mimeinfo.cache`
+ * fallback takes an entry on trust, exactly as xdg-open would.
+ *
+ * Anything that stops the query counts as "no handler": the alternative is handing xdg-open a
+ * URL nothing answers, which fails silently and reaches the page as "Opened".
+ */
+export async function schemeHasHandler(url) {
+  const scheme = schemeOf(url)
+  if (!/^[a-z][a-z0-9+.-]*$/.test(scheme)) return false
+  try {
+    // Bounded: on KDE the query goes through the trader, which can sit on a D-Bus timeout.
+    const args = ['query', 'default', `x-scheme-handler/${scheme}`]
+    const { stdout } = await execFileAsync('xdg-mime', args, { timeout: 5000 })
+    return stdout.trim().length > 0
+  } catch {
+    return false
+  }
+}
+
+/**
+ * How each terminal wants "run this command in this directory". The command comes after the
+ * terminal's own end-of-options marker where it has one, so nothing in it is ever read as a
+ * flag; the working directory is also set on the spawn itself, which is all the xterm family
+ * needs and what the D-Bus terminals forward to their server anyway.
+ *
+ * Only terminals whose flags are documented are listed. `tilix` is deliberately absent: its `-e`
+ * takes one string that it re-splits itself, which would mean building a shell string.
+ */
+const TERMINALS = {
+  'gnome-terminal': (dir, cmd) => [`--working-directory=${dir}`, '--', ...cmd],
+  kgx: (dir, cmd) => [`--working-directory=${dir}`, '--', ...cmd],
+  ptyxis: (dir, cmd) => [`--working-directory=${dir}`, '--', ...cmd],
+  konsole: (dir, cmd) => ['--workdir', dir, '-e', ...cmd],
+  'xfce4-terminal': (dir, cmd) => [`--working-directory=${dir}`, '-x', ...cmd],
+  'mate-terminal': (dir, cmd) => [`--working-directory=${dir}`, '-x', ...cmd],
+  kitty: (dir, cmd) => [`--directory=${dir}`, ...cmd],
+  alacritty: (dir, cmd) => ['--working-directory', dir, '-e', ...cmd],
+  ghostty: (dir, cmd) => [`--working-directory=${dir}`, '-e', ...cmd],
+  wezterm: (dir, cmd) => ['start', '--cwd', dir, '--', ...cmd],
+  foot: (dir, cmd) => [`--working-directory=${dir}`, ...cmd],
+  terminator: (dir, cmd) => [`--working-directory=${dir}`, '-x', ...cmd],
+  xterm: (_dir, cmd) => ['-e', ...cmd],
+  uxterm: (_dir, cmd) => ['-e', ...cmd],
+  urxvt: (_dir, cmd) => ['-e', ...cmd],
+  rxvt: (_dir, cmd) => ['-e', ...cmd],
+  st: (_dir, cmd) => ['-e', ...cmd],
+}
+
+const GENERAL_ORDER = [
+  'gnome-terminal', 'konsole', 'xfce4-terminal', 'mate-terminal', 'kitty', 'alacritty', 'ghostty',
+  'wezterm', 'foot', 'terminator', 'ptyxis', 'kgx', 'xterm', 'uxterm', 'urxvt', 'rxvt', 'st',
+]
+
+/**
+ * A terminal that ships with the desktop first. `XDG_CURRENT_DESKTOP` is a colon list, such as
+ * `ubuntu:GNOME`, and GNOME gets the three it has shipped over the years in the order they are
+ * most likely to be the one actually configured.
+ */
+function desktopOrder() {
+  const parts = (process.env.XDG_CURRENT_DESKTOP || '').toLowerCase().split(':')
+  if (parts.includes('kde')) return ['konsole']
+  if (parts.includes('xfce')) return ['xfce4-terminal']
+  if (parts.includes('mate')) return ['mate-terminal']
+  if (parts.some((p) => ['gnome', 'ubuntu', 'unity', 'cinnamon', 'x-cinnamon'].includes(p))) {
+    return ['gnome-terminal', 'kgx', 'ptyxis']
+  }
+  return []
+}
+
+/**
+ * Is there anywhere for a window to appear? Deliberately loose: only the plainly headless case
+ * is refused here, so that it gets a message saying so, and anything less clear-cut is left to
+ * the launch itself, whose exit code is the real answer. Wayland clients find their socket
+ * without the variable being set, so the runtime dir is checked too.
+ */
+async function hasDisplay() {
+  if (process.env.DISPLAY || process.env.WAYLAND_DISPLAY) return true
+  const run = process.env.XDG_RUNTIME_DIR
+  if (!run) return false
+  try {
+    return (await fsp.readdir(run)).some((name) => name.startsWith('wayland-'))
+  } catch {
+    return false
+  }
+}
+
+/**
+ * A terminal that refuses does so at once — well under 50 ms on a GNOME desktop — while a window
+ * takes longer than this to come up. A refusal slower than this is knowingly reported as a
+ * success: the alternative, treating every late non-zero exit as a failure, would open a second
+ * terminal whenever the command inside the first one ended quickly.
+ */
+const REFUSAL_MS = 300
+/** After this a foreground terminal (xterm, Debian's `--wait` wrapper) is plainly up. */
+const GRACE_MS = 1500
+/**
+ * And a ceiling on the whole walk. Each candidate can cost `GRACE_MS`, and a machine with
+ * several terminals installed and a display that is misbehaving would otherwise hold the request
+ * for the sum of them while the page waits on a spinner. Better to give up and say so.
+ */
+const WALK_BUDGET_MS = 4000
+
+/**
+ * Spawn a terminal and say whether it actually came up. The D-Bus terminals hand the window to a
+ * service and exit 0 at once; when they cannot — no display, a flag they reject — they exit
+ * non-zero just as fast, and that is the failure worth reporting instead of a toast that says
+ * "opened". A non-zero exit that arrives *later* is different: the window came up and the command
+ * inside it has ended, which is the user's to see and no reason to open a second terminal on top.
+ */
+function trySpawn(cmd, args, cwd) {
+  return new Promise((resolve) => {
+    let child
+    try {
+      child = spawn(cmd, args, { cwd, stdio: 'ignore', detached: true })
+    } catch (err) {
+      resolve({ ok: false, error: err?.message || String(err) })
+      return
+    }
+    const startedAt = Date.now()
+    let timer = null
+    let settled = false
+    const done = (result) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      resolve(result)
+    }
+    child.on('error', (err) => done({ ok: false, error: err?.message || String(err) }))
+    child.on('exit', (code, signal) => {
+      if (code === 0 || Date.now() - startedAt >= REFUSAL_MS) return done({ ok: true })
+      const how = signal ? `signal ${signal}` : `code ${code}`
+      done({ ok: false, error: `${path.basename(cmd)} exited with ${how}` })
+    })
+    timer = setTimeout(() => {
+      child.unref()
+      done({ ok: true })
+    }, GRACE_MS)
+  })
+}
+
+/**
+ * Run `argv` in a new terminal window with `cwd` as its working directory.
+ *
+ * The caller has already resolved both: `argv[0]` is an absolute executable and `cwd` an
+ * existing directory. Which terminal is up to the machine — `$TERMINAL` if set, then the
+ * desktop's own, then whatever is installed, then Debian's `x-terminal-emulator` alternative.
+ * That last is tried by name and given `-e`, the one form Debian policy guarantees, because on
+ * Ubuntu it is a wrapper script that knows no other flags — pass it `--working-directory` and it
+ * opens an empty window. Which is also why a real `gnome-terminal` is looked for first.
+ *
+ * A `$TERMINAL` the table does not know is skipped rather than guessed at: `-e` means "the rest
+ * of the line" to xterm and "one string, which I will split" to tilix, and guessing wrong opens
+ * a window on the wrong command — worse than moving on to a terminal we do know.
+ */
+export async function openInTerminal(argv, cwd) {
+  const wellFormed = Array.isArray(argv) && argv.length > 0 && argv.every((a) => typeof a === 'string' && a)
+  if (!wellFormed || !path.isAbsolute(argv[0]) || typeof cwd !== 'string' || !path.isAbsolute(cwd)) {
+    return { ok: false, error: 'Invalid launch command' }
+  }
+  if (!(await hasDisplay())) return { ok: false, error: 'No graphical display to open a terminal on' }
+
+  const preferred = [process.env.TERMINAL || '', ...desktopOrder(), ...GENERAL_ORDER, 'x-terminal-emulator']
+  const names = [...new Set(preferred.filter(Boolean))]
+  const deadline = Date.now() + WALK_BUDGET_MS
+  const tried = new Set()
+  let lastError = ''
+  let ranOut = false
+
+  for (const name of names) {
+    if (Date.now() >= deadline) {
+      ranOut = true
+      break
+    }
+    const resolved = await findExecutable(name)
+    if (!resolved || tried.has(resolved)) continue
+    tried.add(resolved)
+
+    const base = path.basename(name)
+    let args
+    if (base === 'x-terminal-emulator') args = ['-e', ...argv]
+    else if (TERMINALS[base]) args = TERMINALS[base](cwd, argv)
+    else continue
+
+    const result = await trySpawn(resolved, args, cwd)
+    if (result.ok) return { ok: true }
+    lastError = result.error
+  }
+
+  if (ranOut) {
+    return { ok: false, error: 'Gave up waiting for a terminal to open — is the display responding?' }
+  }
+  return {
+    ok: false,
+    error: lastError
+      ? `Could not open a terminal (${lastError})`
+      : 'No terminal emulator found — set $TERMINAL or install one (gnome-terminal, konsole, kitty, xterm)',
+  }
+}

--- a/server/scan.mjs
+++ b/server/scan.mjs
@@ -20,18 +20,26 @@ import { HARNESSES, detectedHarnesses, harnessById } from './harnesses/index.mjs
  * move every plot on everybody's map to fix something most people never hit.
  */
 function disambiguateProjects(threads) {
+  // Windows hands the same checkout back as `c:\…` from one transcript and `C:\…` from
+  // another: the CLI's project-directory encoding keeps whatever case the drive letter was
+  // given. Those are one path, not two — and counted as two they make an unambiguous name look
+  // ambiguous, which renames a plot on a machine that has no collision at all.
+  const canonical = (p) => (/^[A-Za-z]:[\\/]/.test(p) ? p[0].toLowerCase() + p.slice(1) : p)
+
   const pathsByName = new Map()
   for (const t of threads) {
     if (!t.project) continue
     if (!pathsByName.has(t.project)) pathsByName.set(t.project, new Set())
-    pathsByName.get(t.project).add(t.projectPath || '')
+    pathsByName.get(t.project).add(canonical(t.projectPath || ''))
   }
 
   const renames = new Map()
   for (const [name, paths] of pathsByName) {
     if (paths.size < 2) continue
     const list = [...paths]
-    const segments = list.map((p) => p.split('/').filter(Boolean))
+    // Both separators. A Windows path splits on neither otherwise, leaving a single "segment"
+    // that is the whole absolute path — which then becomes the plot's name on the map.
+    const segments = list.map((p) => p.split(/[\\/]/).filter(Boolean))
     const deepest = Math.max(...segments.map((s) => s.length))
 
     // Take one more trailing segment until every path in the group reads differently. Paths
@@ -50,7 +58,7 @@ function disambiguateProjects(threads) {
 
   if (!renames.size) return threads
   return threads.map((t) => {
-    const next = renames.get(`${t.project || ''}\u0000${t.projectPath || ''}`)
+    const next = renames.get(`${t.project || ''}\u0000${canonical(t.projectPath || '')}`)
     return next && next !== t.project ? { ...t, project: next } : t
   })
 }

--- a/server/scan.mjs
+++ b/server/scan.mjs
@@ -100,19 +100,3 @@ const dispatch = (harnessId) => {
 export const openThread = (harnessId, ref) => dispatch(harnessId).openThread(ref)
 
 export const newSession = (harnessId, dir) => dispatch(harnessId).newSession(dir)
-
-export const setThreadArchived = (harnessId, ref, archived) => dispatch(harnessId).setArchived(ref, archived)
-
-/**
- * When a harness's own app last started, used to tell an archive it has already read from
- * one still waiting on disk. A harness with no long-lived app has nothing to report.
- */
-export async function harnessAppStartedAt(harnessId) {
-  const h = harnessById(harnessId)
-  if (!h?.appStartedAt) return 0
-  try {
-    return await h.appStartedAt()
-  } catch {
-    return 0
-  }
-}

--- a/server/scan.mjs
+++ b/server/scan.mjs
@@ -90,7 +90,16 @@ export async function scanThreads() {
 /** What the HUD shows in the harness list: who is installed, and what they can do. */
 export async function harnessStatus() {
   const detected = new Set((await detectedHarnesses()).map((h) => h.id))
-  return HARNESSES.map((h) => ({ id: h.id, name: h.name, detected: detected.has(h.id) }))
+  return Promise.all(
+    HARNESSES.map(async (h) => ({
+      id: h.id,
+      name: h.name,
+      detected: detected.has(h.id),
+      // Optional. An adapter that can see its harness but cannot read it — wrong Node, a store
+      // it does not understand — says why here instead of failing silently on every poll.
+      error: h.diagnostic ? await h.diagnostic().catch(() => '') : '',
+    }))
+  )
 }
 
 /** The harness to use when a caller has not said — the first one present on this machine. */
@@ -105,6 +114,7 @@ const dispatch = (harnessId) => {
   return h
 }
 
-export const openThread = (harnessId, ref) => dispatch(harnessId).openThread(ref)
+/** Both may be async: an adapter that has to look for a CLI on disk cannot answer synchronously. */
+export const openThread = async (harnessId, ref) => dispatch(harnessId).openThread(ref)
 
-export const newSession = (harnessId, dir) => dispatch(harnessId).newSession(dir)
+export const newSession = async (harnessId, dir) => dispatch(harnessId).newSession(dir)

--- a/src/agents/astronauts.js
+++ b/src/agents/astronauts.js
@@ -40,10 +40,16 @@ const AGENT_LOOK = {
   leaving: { trim: 0x6f7f75, eye: [1.0, 1.0, 1.1] },
 }
 
-/** Where the status badge floats, matching `indicators.js` — the picker aims there too. */
-const BADGE_HEIGHT = 1.52
 const WALK_SPEED = 2.1
 const TURN_RATE = 7.5
+/**
+ * How many astronauts may walk out of the ship in one reconcile. The rest of a big arrival —
+ * a reload, a first run, a hidden repo being shown again — are placed on their plots instead.
+ */
+const MAX_ENTRANCE = 6
+/** Around the ramp, where an astronaut standing still blocks everyone still coming out. */
+const DOORWAY_CLEAR = 5.5
+
 /** How close counts as "reached this waypoint". A shade over one nav cell. */
 const WAYPOINT_REACHED = 0.55
 /**
@@ -141,6 +147,7 @@ export class Astronauts {
     this._wp = new THREE.Vector3()
     this._sep = new THREE.Vector3()
     this._pickBadge = new THREE.Vector3()
+    this._pickLifted = new THREE.Vector3()
     /** Uniform bucket grid for the separation query, so it stays O(n) as the crew grows. */
     this._buckets = new Map()
     this.nav = null
@@ -463,11 +470,22 @@ export class Astronauts {
     const wanted = entries.slice(0, cap)
     const seen = new Set()
 
+    // The ramp is one door and the ship is a solid obstacle around it, so an entrance is a
+    // queue. A handful arriving together is the shot the colony is for; a hundred is a scrum
+    // that shoves its own members into the ship's footprint, where they give up, sit down and
+    // become the obstacle for everybody behind them. Past this many, the rest are simply
+    // already outside — which is what a thread the colony has seen before is anyway.
+    let entrances = MAX_ENTRANCE
     for (const entry of wanted) {
       seen.add(entry.id)
       const existing = this.byId.get(entry.id)
-      if (existing) this._updateAgent(existing, entry)
-      else this._spawnAgent(entry)
+      if (existing) {
+        this._updateAgent(existing, entry)
+        continue
+      }
+      const walksOut = !entry.known && entrances > 0
+      if (walksOut) entrances--
+      this._spawnAgent(entry, walksOut)
     }
 
     for (const agent of this.agents) {
@@ -476,9 +494,15 @@ export class Astronauts {
     return this.agents.length
   }
 
-  _spawnAgent(entry) {
+  _spawnAgent(entry, walksOut = true) {
     const door = this.world?.shipDoor?.() || new THREE.Vector3(0, 0, 0)
     const jitter = () => (Math.random() - 0.5) * 1.4
+    // Straight onto its plot, a pace off the exact spot so a zone's crew does not appear in a
+    // stack. The nav grid sorts out anything that lands on a building.
+    const site = entry.site || door
+    const start = walksOut
+      ? new THREE.Vector3(door.x + jitter(), 0, door.z + jitter())
+      : new THREE.Vector3(site.x + jitter(), 0, site.z + jitter())
 
     const agent = {
       id: entry.id,
@@ -489,14 +513,15 @@ export class Astronauts {
       anchor: entry.anchor ? entry.anchor.clone() : null,
       workSpot: new THREE.Vector3(),
       workAt: 0,
-      pos: new THREE.Vector3(door.x + jitter(), 0, door.z + jitter()),
+      pos: start,
       vel: new THREE.Vector3(),
       yaw: Math.random() * Math.PI * 2,
       targetYaw: 0,
       speed: WALK_SPEED * (0.86 + Math.random() * 0.28),
       phase: Math.random() * Math.PI * 2,
       bob: 0,
-      state: 'spawning',
+      // An astronaut already outside does not play the entrance; it is just there.
+      state: walksOut ? 'spawning' : 'walking',
       stateAge: 0,
       // Every astronaut runs its own clocks so a crowd never blinks in unison.
       blinkAt: 1 + Math.random() * 4,
@@ -520,12 +545,12 @@ export class Astronauts {
       driftBlocked: false,
       // Animation state: which baked clip, how far into it, and the row of the bone table
       // that lands on. Started at a random offset so a crowd never marches in step.
-      clipKey: 'spawn',
+      clipKey: walksOut ? 'spawn' : 'idle',
       clipTime: Math.random() * 0.6,
       frame: 0,
       wander: new THREE.Vector3(),
       wanderAt: 0,
-      scale: 0, // pops up out of the ship
+      scale: walksOut ? 0 : 1, // pops up out of the ship, or was already standing there
       alive: true,
       path: null,
       pathAt: 0,
@@ -581,6 +606,15 @@ export class Astronauts {
     if (agent.state !== 'spawning') agent.state = 'walking'
     agent.stateAge = 0
     agent.pathVersion = -1
+  }
+
+  /** Close enough to the ramp that standing still there is in somebody's way. */
+  _nearDoor(pos) {
+    const door = this.world?.shipDoor?.()
+    if (!door) return false
+    const dx = pos.x - door.x
+    const dz = pos.z - door.z
+    return dx * dx + dz * dz < DOORWAY_CLEAR * DOORWAY_CLEAR
   }
 
   _sendHome(agent) {
@@ -691,7 +725,18 @@ export class Astronauts {
         // and the next poll hands it a site that has been checked against the grid.
         const stuck = (agent.blocked && agent.stateAge > 8) || agent.stateAge > 45
         if (dist < ARRIVE_RADIUS || stuck) {
-          if (stuck && dist >= ARRIVE_RADIUS) agent.site.copy(agent.pos)
+          // Adopting the ground it reached is right for a site something got built on top of.
+          // It is exactly wrong next to the ship: an astronaut still shouldering its way out
+          // of the doorway would claim the doorway, and the queue behind it inherits a
+          // permanent wall. Out there it keeps its real site and tries again, which the crowd
+          // thinning out is usually enough to fix.
+          const inDoorway = this._nearDoor(agent.pos)
+          if (stuck && dist >= ARRIVE_RADIUS && !inDoorway) agent.site.copy(agent.pos)
+          if (stuck && inDoorway) {
+            agent.stateAge = 0
+            agent.pathVersion = -1
+            break
+          }
           agent.state = agent.status === 'leaving' ? 'leaving' : 'at-site'
           agent.stateAge = 0
         }
@@ -1209,6 +1254,7 @@ export class Astronauts {
     let bestScore = Infinity
     const v = this._v
     const b = this._pickBadge
+    const lifted = this._pickLifted
 
     for (const agent of this.agents) {
       if (agent.scale < 0.3 || agent.state === 'gone') continue
@@ -1221,11 +1267,40 @@ export class Astronauts {
 
       // The badge over an astronaut's head is what you actually aim at when one wants you —
       // it is bigger than the astronaut, it is the thing that caught your eye, and it sits
-      // clear of the crowd. So it picks the astronaut it belongs to.
-      b.set(agent.pos.x, agent.pos.y + BADGE_HEIGHT, agent.pos.z).project(camera)
-      if (b.z <= 1) {
-        const bd = Math.hypot((b.x - ndcX) * aspect, b.y - ndcY)
-        if (bd < d) d = bd
+      // clear of the crowd. So the whole bubble picks the astronaut it belongs to, not just
+      // a point at its middle.
+      //
+      // The geometry has to be recomputed the way `indicators.js` draws it rather than
+      // guessed at. That shader anchors the quad just above the helmet and then lifts it by
+      // half its own height *in view space*, where the height itself grows with distance so
+      // the badge holds a constant pixel size. A fixed world-space offset cannot follow that:
+      // it is right at one zoom and most of a metre low at another, which is why this used to
+      // demand a click on the astronaut's head.
+      const size = agent.badgeSize || 0
+      if (size > 0) {
+        // View space, exactly as the vertex shader has it.
+        b.set(agent.pos.x, agent.badgeY, agent.pos.z).applyMatrix4(camera.matrixWorldInverse)
+        const scale = size * (2 + -b.z * 0.22)
+        b.y += scale * 0.5
+        // A second point one half-height higher gives the quad's on-screen radius without
+        // re-deriving the projection: whatever the camera does to one, it does to both.
+        lifted.copy(b)
+        lifted.y += scale * 0.5
+        b.applyMatrix4(camera.projectionMatrix)
+        lifted.applyMatrix4(camera.projectionMatrix)
+        if (b.z <= 1) {
+          // The quad is square, and `bx` is already in the same units as `by`, so one
+          // half-extent covers both axes.
+          const half = Math.abs(lifted.y - b.y)
+          const bx = (b.x - ndcX) * aspect
+          const by = b.y - ndcY
+          // Anywhere inside the bubble is a hit outright; outside it, the distance to its
+          // edge, so a near-miss still competes with a nearer astronaut on the same pixel.
+          const ox = Math.max(0, Math.abs(bx) - half)
+          const oy = Math.max(0, Math.abs(by) - half)
+          const bd = Math.hypot(ox, oy)
+          if (bd < d) d = bd
+        }
       }
       if (d > maxDist) continue
       // Break ties by depth so the nearer of two overlapping agents wins.

--- a/src/agents/astronauts.js
+++ b/src/agents/astronauts.js
@@ -467,7 +467,11 @@ export class Astronauts {
     this.roster = entries
     this.world = world || this.world
     const cap = Math.min(this.capacity, this.settings.get('maxAgents'))
-    const wanted = entries.slice(0, cap)
+    // Agents on their way back to the ship still hold a slot, so the roster has to leave room
+    // for them. Without this the clamp above would quietly drop whoever sorted last, which is
+    // better than an empty planet but still not what the scan said.
+    const leaving = this.agents.reduce((n, a) => n + (a.state === 'leaving' ? 1 : 0), 0)
+    const wanted = entries.slice(0, Math.max(1, cap - leaving))
     const seen = new Set()
 
     // The ramp is one door and the ship is a solid obstacle around it, so an entrance is a
@@ -1153,6 +1157,16 @@ export class Astronauts {
     let hands = 0
     let staticDirty = false
     for (const agent of this.agents) {
+      // Never write past the end of the instance buffers. Going over is not a rendering
+      // artefact you can squint past: WebGL refuses the whole `drawElementsInstanced` call, so
+      // one agent too many takes *every* astronaut off screen at once.
+      //
+      // It can go over. `setRoster` caps how many agents it will spawn, but an agent that has
+      // left the roster stays in this list while it walks back to the ship — and the slot it
+      // vacated in the roster is immediately filled by a thread that was previously past the
+      // cap. Archive one thread on a colony sitting at the cap and there is briefly one more
+      // agent than there are slots, which is exactly when the colony would empty.
+      if (i >= this.capacity) break
       if (agent.state === 'gone') continue
       const s = agent.scale
       if (s <= 0.001) continue

--- a/src/agents/indicators.js
+++ b/src/agents/indicators.js
@@ -194,6 +194,9 @@ export class Indicators {
     let n = 0
 
     for (const agent of agents) {
+      // Cleared for everyone first: an agent that loses its badge this frame must lose its
+      // hit box with it, or the picker keeps offering a bubble that is no longer drawn.
+      agent.badgeSize = 0
       if (n >= this.capacity) break
       if (agent.scale < 0.4 || agent.state === 'gone') continue
       const badge = statusFor(agent)
@@ -217,6 +220,12 @@ export class Indicators {
       // Urgent badges breathe a little so they pull the eye across a busy colony.
       sizes[n] = urgent ? 0.166 + Math.sin(elapsed * 4.2 + agent.phase) * 0.013 : 0.126
       fades[n] = FADE_BY_BADGE[badge] ?? 1
+
+      // Handed to the picker so a click can hit the bubble itself rather than the head under
+      // it. It cannot be derived over there: the lift and the size are decided in view space
+      // by the vertex shader above, and only this loop knows which frame each agent got.
+      agent.badgeSize = sizes[n]
+      agent.badgeY = centers[n * 3 + 1]
 
       const c = BADGE_COLOR[badge] || [1, 1, 1]
       this._color.setRGB(c[0], c[1], c[2])

--- a/src/core/settings.js
+++ b/src/core/settings.js
@@ -121,8 +121,13 @@ const DEFAULTS = {
 
   // World
   planet: 'moon',
-  /** Fold away repos where every thread has been quiet for three days. */
-  hideDormant: false,
+  /**
+   * Fold away repos where every thread has been quiet for three days. On by default: with
+   * several harnesses read at once the map otherwise fills with every checkout you have ever
+   * opened, and the few repos actually being worked in get lost among them. It is reversible in
+   * one click and a folded repo returns to the same ground the moment a thread wakes up.
+   */
+  hideDormant: true,
   timeOfDay: 0.32, // 0..1 — 0 is midnight, 0.5 is noon
   autoTime: false,
   /** Sky follows this machine's own clock. Wins over `autoTime`; both off is manual. */
@@ -132,7 +137,7 @@ const DEFAULTS = {
   // Look
   exposure: 1.0,
   bloomStrength: 0.25,
-  tiltShiftStrength: 0.4, // 0..1 — share of the effect's full blur radius (2% of frame height)
+  tiltShiftStrength: 0.2, // 0..1 — share of the effect's full blur radius (2% of frame height)
   tiltShiftAngle: 0, // degrees — 0 keeps the sharp band horizontal
   iblIntensity: 1.0,
   fov: 38,

--- a/src/core/settings.js
+++ b/src/core/settings.js
@@ -115,6 +115,13 @@ export const SHADOW_SIZES = { off: 0, low: 1024, high: 2048, ultra: 4096 }
 const TEXTURE_SIZES = { low: 256, medium: 512, high: 1024, ultra: 1024 }
 const PARTICLE_BUDGET = { off: 0, low: 900, full: 3000 }
 
+/**
+ * The largest `maxAgents` any preset asks for. Anything sized once at boot — the badge buffers,
+ * which are never rebuilt — allocates against this rather than against whatever preset happened
+ * to be active, so raising quality later cannot outrun a buffer.
+ */
+export const MAX_AGENT_CAP = Math.max(...Object.values(PRESETS).map((p) => p.values.maxAgents || 0))
+
 const DEFAULTS = {
   preset: 'balanced',
   ...PRESETS.balanced.values,

--- a/src/core/settings.js
+++ b/src/core/settings.js
@@ -123,6 +123,8 @@ const DEFAULTS = {
   planet: 'moon',
   timeOfDay: 0.32, // 0..1 — 0 is midnight, 0.5 is noon
   autoTime: false,
+  /** Sky follows this machine's own clock. Wins over `autoTime`; both off is manual. */
+  clockTime: false,
   dayLength: 240, // seconds for a full cycle when autoTime is on
 
   // Look

--- a/src/core/settings.js
+++ b/src/core/settings.js
@@ -121,6 +121,8 @@ const DEFAULTS = {
 
   // World
   planet: 'moon',
+  /** Fold away repos where every thread has been quiet for three days. */
+  hideDormant: false,
   timeOfDay: 0.32, // 0..1 — 0 is midnight, 0.5 is noon
   autoTime: false,
   /** Sky follows this machine's own clock. Wins over `autoTime`; both off is manual. */

--- a/src/game/api.js
+++ b/src/game/api.js
@@ -1,3 +1,5 @@
+import { mergeState } from './merge-state.js'
+
 async function req(url, options) {
   const res = await fetch(url, options)
   const body = await res.json().catch(() => ({}))
@@ -13,14 +15,69 @@ const post = (url, payload) =>
   })
 
 export const fetchThreads = () => req('/api/threads')
-export const fetchState = () => req('/api/state')
 
-export const saveState = (state) =>
-  req('/api/state', {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(state),
-  })
+/**
+ * The colony file, and the base every later save is measured against.
+ *
+ * `baseUpdatedAt` is the file version this tab last agreed with; `baseSnapshot` is the state as
+ * it looked at that moment. The snapshot is the half that matters: without it a conflicted save
+ * can only union the two lists, and a union can never express "I un-archived this".
+ */
+let baseUpdatedAt = 0
+let baseSnapshot = null
+
+function adoptBase(state, updatedAt) {
+  baseUpdatedAt = Number(updatedAt ?? state?.updatedAt) || 0
+  // Cloned, because the page mutates the object it holds. Sharing the reference would let
+  // `local` and `base` drift into being the same thing, which reads as "this tab changed
+  // nothing" and quietly turns every save back into last-writer-wins.
+  baseSnapshot = structuredClone(state)
+}
+
+export const fetchState = async () => {
+  const state = await req('/api/state')
+  adoptBase(state)
+  return state
+}
+
+/** Enough attempts to get through a burst of saves from another tab, and no more. */
+const SAVE_TRIES = 3
+
+/**
+ * Save the colony, merging rather than clobbering if another tab got there first.
+ *
+ * The server answers 409 with what is on disk when this tab's base is stale. That is not a
+ * failure to report at the user — it is the normal shape of two tabs being open — so it is
+ * merged and re-sent here. The base for the next attempt is the disk state just merged against,
+ * which keeps a retry from re-applying edits it has already folded in.
+ *
+ * Returns the state the caller should hold from now on: the *same object* when nothing
+ * conflicted, so the common path never swaps the page's state out from under a click that
+ * happened mid-flight, and only a real merge hands back something new.
+ */
+export async function saveState(state) {
+  let local = state
+  for (let attempt = 0; attempt < SAVE_TRIES; attempt++) {
+    const res = await fetch('/api/state', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...local, baseUpdatedAt }),
+    })
+    const body = await res.json().catch(() => ({}))
+
+    if (res.status === 409) {
+      local = mergeState(baseSnapshot, local, body)
+      adoptBase(body)
+      continue
+    }
+    if (!res.ok) throw new Error(body.error || `${res.status} ${res.statusText}`)
+    adoptBase(local, body.updatedAt)
+    return local
+  }
+  // Losing three times running means the other tab is saving faster than we can merge. The
+  // caller swallows this: nothing local is lost, and the next save tries again.
+  throw new Error('Could not save the colony — another tab kept writing first')
+}
 
 /**
  * Hand a thread back to whichever harness owns it — the desktop app comes forward on its own.

--- a/src/game/api.js
+++ b/src/game/api.js
@@ -31,9 +31,6 @@ export const saveState = (state) =>
  */
 export const openThread = (thread) => post('/api/open', { harness: thread.harness, ref: thread.ref })
 
-export const archiveThread = (thread, archived) =>
-  post('/api/archive', { id: thread.id, harness: thread.harness, ref: thread.ref, archived })
-
 /** A brand new thread in a repo, via that harness's own new-session deep link. */
 export const newSession = (folder, harness) => post('/api/new-session', { folder, harness })
 

--- a/src/game/colony.js
+++ b/src/game/colony.js
@@ -258,7 +258,7 @@ export class Colony {
    * ids — repo name for plots, session id for buildings — so a poll that changes nothing
    * moves nothing on screen.
    */
-  setThreads(threads, archivedIds = new Set(), hiddenProjects = new Set()) {
+  setThreads(threads, archivedIds = new Set(), hiddenProjects = new Set(), knownIds = new Set()) {
     const now = Date.now()
     const live = liveThreadsForColony(threads, archivedIds, hiddenProjects)
 
@@ -321,6 +321,8 @@ export class Colony {
           // Where the work actually is. A working astronaut circles it rather than standing
           // at one spot, so it needs the building, not just a place to stand near it.
           anchor: building.mesh.position.clone(),
+          // Already on the colony's books, so it does not need an entrance.
+          known: knownIds.has(thread.id),
         })
       })
     }

--- a/src/game/colony.js
+++ b/src/game/colony.js
@@ -18,6 +18,7 @@ import { Astronauts } from '../agents/astronauts.js'
 import { Indicators, BADGE } from '../agents/indicators.js'
 import { Particles } from '../agents/particles.js'
 import { Navigation } from '../agents/navigation.js'
+import { liveThreadsForColony } from './hidden-projects.js'
 
 /**
  * The colony: everything that turns a list of agent threads into a place.
@@ -257,9 +258,9 @@ export class Colony {
    * ids — repo name for plots, session id for buildings — so a poll that changes nothing
    * moves nothing on screen.
    */
-  setThreads(threads, archivedIds = new Set()) {
+  setThreads(threads, archivedIds = new Set(), hiddenProjects = new Set()) {
     const now = Date.now()
-    const live = threads.filter((t) => !t.archived && !archivedIds.has(t.id))
+    const live = liveThreadsForColony(threads, archivedIds, hiddenProjects)
 
     // Group by repo, biggest project first so the busiest work lands nearest the middle.
     const byProject = new Map()
@@ -274,6 +275,16 @@ export class Colony {
     })
 
     this._syncPlots(projects)
+
+    // A hidden repo keeps its footprint in layout memory, so showing it again reclaims the same
+    // ground if it is still free. Re-inserting the entry also keeps LAYOUT_MEMORY from evicting
+    // a name you only hid — otherwise hiding a zone for a week loses where it used to be.
+    for (const name of hiddenProjects) {
+      const cells = this.plotCells.get(name)
+      if (!cells) continue
+      this.plotCells.delete(name)
+      this.plotCells.set(name, cells)
+    }
 
     const roster = []
     const seenBuildings = new Set()

--- a/src/game/colony.js
+++ b/src/game/colony.js
@@ -269,6 +269,30 @@ export class Colony {
       if (!byProject.has(key)) byProject.set(key, [])
       byProject.get(key).push(thread)
     }
+    /**
+     * Repos where nothing has stirred in days, folded away on request.
+     *
+     * A colony is a map you learn, and a map is only learnable if what is on it is worth
+     * looking at. Someone with a hundred checkouts has most of the ground given over to work
+     * they finished in the spring, and the six repos they are actually living in are somewhere
+     * in among it. Dormant is already a status the colony understands — nothing for three days
+     * — so this is that same line drawn one level up, at the repo rather than the thread.
+     *
+     * Deliberately all-or-nothing per repo: a zone with one live thread in it stays whole,
+     * because half a zone would misrepresent the repo rather than tidy the map.
+     */
+    const dormant = new Set()
+    if (this.settings.get('hideDormant')) {
+      for (const [name, list] of byProject) {
+        if (list.every((t) => statusFor(t, now) === 'sleeping')) dormant.add(name)
+      }
+      // Never fold away everything: a colony that answers a poll with an empty planet reads as
+      // broken rather than tidy, and there is nothing on screen to tell you which it was.
+      if (dormant.size === byProject.size) dormant.clear()
+      for (const name of dormant) byProject.delete(name)
+    }
+    this.dormantProjects = dormant
+
     const projects = [...byProject.entries()].sort((a, b) => {
       if (b[1].length !== a[1].length) return b[1].length - a[1].length
       return a[0].localeCompare(b[0])
@@ -276,10 +300,11 @@ export class Colony {
 
     this._syncPlots(projects)
 
-    // A hidden repo keeps its footprint in layout memory, so showing it again reclaims the same
-    // ground if it is still free. Re-inserting the entry also keeps LAYOUT_MEMORY from evicting
-    // a name you only hid — otherwise hiding a zone for a week loses where it used to be.
-    for (const name of hiddenProjects) {
+    // A repo that is off the map keeps its footprint in layout memory, so showing it again
+    // reclaims the same ground if it is still free. Re-inserting the entry also keeps
+    // LAYOUT_MEMORY from evicting a name you only hid — otherwise a zone folded away for a
+    // week loses where it used to be, and comes back somewhere else entirely.
+    for (const name of [...hiddenProjects, ...dormant]) {
       const cells = this.plotCells.get(name)
       if (!cells) continue
       this.plotCells.delete(name)

--- a/src/game/colony.js
+++ b/src/game/colony.js
@@ -16,6 +16,7 @@ import { createBuilding, buildingUniforms, Scaffolds } from '../world/buildings.
 import { Ship } from '../world/ship.js'
 import { Astronauts } from '../agents/astronauts.js'
 import { Indicators, BADGE } from '../agents/indicators.js'
+import { MAX_AGENT_CAP } from '../core/settings.js'
 import { Particles } from '../agents/particles.js'
 import { Navigation } from '../agents/navigation.js'
 import { liveThreadsForColony } from './hidden-projects.js'
@@ -138,7 +139,11 @@ export class Colony {
     this.ship = new Ship(scene, shipPosition())
     this.astronauts = new Astronauts(scene, settings)
     this.astronauts.world = this._world()
-    this.indicators = new Indicators(scene, settings, Math.max(64, settings.get('maxAgents')))
+    // Sized for the largest preset rather than the current one: unlike the astronaut meshes these
+    // buffers are never rebuilt, so allocating against today's `maxAgents` means raising quality
+    // later silently starves the badges — the one `?` that wants you being the thing that goes
+    // missing. A badge is a single quad; the spare instances cost almost nothing.
+    this.indicators = new Indicators(scene, settings, MAX_AGENT_CAP)
     this.particles = new Particles(scene, settings)
     this.scaffolds = new Scaffolds(scene, 320)
     this.nav = new Navigation()

--- a/src/game/hidden-projects.js
+++ b/src/game/hidden-projects.js
@@ -1,0 +1,44 @@
+/**
+ * Repos you have taken off the map.
+ *
+ * Colony-only, and that is the whole point: hiding writes nothing to any harness and archives
+ * nothing. The threads stay exactly where they are and keep working; the map just stops drawing
+ * that repo until you show it again. It is for the checkout you have forty dead threads in and
+ * do not want owning a third of your ground.
+ *
+ * Keyed on the project *name*, which is what plots are keyed on too. That has a consequence
+ * worth knowing: a second checkout of the same repo appearing renames `foo` to `1/foo` (see
+ * `disambiguateProjects` in server/scan.mjs) and the hide quietly stops matching. Keying on the
+ * path instead would fix it and break the moment somebody moves a folder, and the layout has the
+ * same trade — so both are wrong in the same direction, which is at least predictable.
+ */
+
+export function hideProject(hidden, name) {
+  const id = String(name || '')
+  if (!id || hidden.includes(id)) return [...hidden]
+  return [...hidden, id]
+}
+
+export function unhideProject(hidden, name) {
+  const id = String(name || '')
+  return hidden.filter((n) => n !== id)
+}
+
+/** The threads the colony should actually draw. */
+export function liveThreadsForColony(threads, archivedIds, hiddenProjects) {
+  const archived = archivedIds instanceof Set ? archivedIds : new Set(archivedIds)
+  const hidden = hiddenProjects instanceof Set ? hiddenProjects : new Set(hiddenProjects)
+  return threads.filter((t) => !t.archived && !archived.has(t.id) && !hidden.has(t.project || 'unknown'))
+}
+
+/**
+ * What the sidebar lists, with a live count each — so a hidden repo that has since gone quiet
+ * reads as `0` and you can tell it is safe to forget rather than having to show it to find out.
+ */
+export function hiddenCatalog(hidden, threads) {
+  const names = [...new Set(hidden.map(String).filter(Boolean))].sort((a, b) => a.localeCompare(b))
+  return names.map((name) => ({
+    name,
+    count: threads.filter((t) => !t.archived && (t.project || 'unknown') === name).length,
+  }))
+}

--- a/src/game/merge-state.js
+++ b/src/game/merge-state.js
@@ -1,0 +1,130 @@
+/**
+ * Three-way merge of a colony state.
+ *
+ * The colony file is written whole, by a page that read it once at boot. That is fine while
+ * there is only one tab: the page holds the truth and the file is its shadow. With two tabs it
+ * is two writers on one file, and the losing write is silent — the tab that saves last pastes
+ * over everything the other did since it loaded. In practice that looks like a plot you moved
+ * snapping back, or a thread you archived reappearing on its own.
+ *
+ * The server refuses a save whose base is stale and hands back what is on disk, so the page can
+ * work out what it actually changed rather than asserting its whole picture. Hence three inputs:
+ * `base` is the state as this tab last saw it agree with disk, `local` is what this tab holds
+ * now, `remote` is what is on disk. The result keeps the other tab's work and replays this tab's
+ * own edits on top.
+ *
+ * Pure and browser-free on purpose: this is the one piece worth being able to run under bare
+ * node, since every way of getting it wrong is a way of losing somebody's archive list.
+ */
+
+/**
+ * Structural equality, deep enough for the values that live in this file: `plots` holds arrays
+ * of `[q, r]` integer pairs and `seen` holds numbers. Reference equality is no use — every one
+ * of these values is rebuilt from scratch on each poll, so a cell list that never moved is still
+ * a different array than the one in `base`, and comparing by identity would call every zone
+ * "changed by this tab" and defeat the merge entirely.
+ */
+function sameValue(a, b) {
+  if (a === b) return true
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return a.length === b.length && a.every((v, i) => sameValue(v, b[i]))
+  }
+  if (a && b && typeof a === 'object' && typeof b === 'object') {
+    const ka = Object.keys(a)
+    const kb = Object.keys(b)
+    return ka.length === kb.length && ka.every((k) => sameValue(a[k], b[k]))
+  }
+  return false
+}
+
+const asArray = (v) => (Array.isArray(v) ? v : [])
+const asObject = (v) => (v && typeof v === 'object' && !Array.isArray(v) ? v : {})
+
+/**
+ * A set-like list — `archived`, `opened`, `hiddenProjects` — merged as
+ * `(remote ∪ (local \ base)) \ (base \ local)`.
+ *
+ * Both halves are needed, and it is tempting to write only the first. A plain union keeps every
+ * addition and is trivially safe against loss, but it makes removal *impossible* between two
+ * tabs: the id this tab dropped is still in the other tab's copy, so the union puts it straight
+ * back. Subtracting what this tab deleted is what lets an un-archive survive a merge.
+ *
+ * Order follows `remote` with this tab's additions appended, so the file does not churn.
+ */
+function mergeSet(base, local, remote) {
+  const baseSet = new Set(asArray(base))
+  const localSet = new Set(asArray(local))
+  // Deleted *here* — anything the base had and this tab no longer does.
+  const removed = new Set([...baseSet].filter((id) => !localSet.has(id)))
+
+  const out = []
+  const seen = new Set()
+  for (const id of asArray(remote)) {
+    if (removed.has(id) || seen.has(id)) continue
+    seen.add(id)
+    out.push(id)
+  }
+  for (const id of localSet) {
+    // Added *here* — not in the base, so it cannot be something the other tab deleted.
+    if (baseSet.has(id) || seen.has(id)) continue
+    seen.add(id)
+    out.push(id)
+  }
+  return out
+}
+
+/**
+ * A keyed map — `archivedAt`, `plots`, `seen` — merged key by key.
+ *
+ * `remote` is the starting point, because everything in it is either untouched or the other
+ * tab's work. This tab then replays its own diff against `base` on top: a key it added or
+ * changed wins, a key it deleted goes. A key neither tab touched is left exactly as the other
+ * tab left it, which is what stops a zone the other tab moved from snapping back.
+ */
+function mergeMap(base, local, remote) {
+  const baseMap = asObject(base)
+  const localMap = asObject(local)
+  const out = { ...asObject(remote) }
+
+  for (const [k, v] of Object.entries(localMap)) {
+    if (k in baseMap && sameValue(baseMap[k], v)) continue // untouched here; leave theirs
+    out[k] = v
+  }
+  for (const k of Object.keys(baseMap)) {
+    if (k in localMap) continue
+    delete out[k] // deleted here — the resurrection this whole file exists to prevent
+  }
+  return out
+}
+
+/**
+ * Merge one colony state, field by field.
+ *
+ * `settings` is the deliberate exception: local wins, whole. It is a per-browser preference blob
+ * — render scale, shadow quality, which planet — and two tabs are usually the same person on the
+ * same machine expressing the same intent. Merging it field-wise would hand somebody a colony at
+ * half quality on Mars at dusk because two tabs each contributed a third of a preset, which is a
+ * worse outcome than the last tab to touch a slider winning.
+ *
+ * `updatedAt` is not merged at all: the server stamps it, and the value here would only ever be
+ * a stale guess.
+ *
+ * Every field the state carries has to appear here. A field that is merely passed through by
+ * `readState` but forgotten in this function is silently dropped on the first conflict — which
+ * is exactly the bug this file exists to prevent, arriving through the back door.
+ */
+export function mergeState(base, local, remote) {
+  const b = base || {}
+  const l = local || {}
+  const r = remote || {}
+  return {
+    version: r.version ?? l.version ?? 2,
+    archived: mergeSet(b.archived, l.archived, r.archived),
+    archivedAt: mergeMap(b.archivedAt, l.archivedAt, r.archivedAt),
+    opened: mergeSet(b.opened, l.opened, r.opened),
+    plots: mergeMap(b.plots, l.plots, r.plots),
+    seen: mergeMap(b.seen, l.seen, r.seen),
+    hiddenProjects: mergeSet(b.hiddenProjects, l.hiddenProjects, r.hiddenProjects),
+    settings: l.settings && typeof l.settings === 'object' ? l.settings : r.settings ?? null,
+  }
+}

--- a/src/game/merge-state.js
+++ b/src/game/merge-state.js
@@ -125,6 +125,7 @@ export function mergeState(base, local, remote) {
     plots: mergeMap(b.plots, l.plots, r.plots),
     seen: mergeMap(b.seen, l.seen, r.seen),
     hiddenProjects: mergeSet(b.hiddenProjects, l.hiddenProjects, r.hiddenProjects),
+    viewedAt: mergeMap(b.viewedAt, l.viewedAt, r.viewedAt),
     settings: l.settings && typeof l.settings === 'object' ? l.settings : r.settings ?? null,
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -17,6 +17,7 @@ import {
   newSession,
   revealFolder,
 } from './game/api.js'
+import { hideProject, hiddenCatalog, unhideProject } from './game/hidden-projects.js'
 
 /**
  * Boot and the outer game loop.
@@ -46,7 +47,7 @@ const engine = new Engine(settings).mount(app)
 const rig = new CameraRig(engine.camera, engine.canvas, settings)
 const colony = new Colony(engine.scene, settings, engine.camera, engine.renderer)
 
-let state = { archived: [], archivedAt: {}, opened: [], plots: {}, seen: {} }
+let state = { archived: [], archivedAt: {}, opened: [], plots: {}, seen: {}, hiddenProjects: [] }
 let threads = []
 /** Last legend built for the bottom bar, kept so the open zone's chip can light up between polls. */
 let legendProjects = []
@@ -163,6 +164,29 @@ const actions = {
     } catch (err) {
       hud.toast(err.message || 'Could not open that folder', 'err')
     }
+  },
+
+  hideProject: () => {
+    const name = selectedProject
+    if (!name) return
+    state.hiddenProjects = hideProject(state.hiddenProjects || [], name)
+    queueSave()
+    // If the open thread belonged to the repo that just left, nothing is selected any more.
+    if (selectedId) {
+      const thread = threads.find((t) => t.id === selectedId)
+      if (thread?.project === name) select(null, {})
+    }
+    selectedProject = null
+    applyThreads(threads)
+    hud.toast(`Hidden ${name} — still in your harness, gone from the colony`)
+  },
+
+  unhideProject: (name) => {
+    if (!name) return
+    state.hiddenProjects = unhideProject(state.hiddenProjects || [], name)
+    queueSave()
+    applyThreads(threads)
+    hud.toast(`Showing ${name} again`)
   },
 
   copyProjectPath: async () => {
@@ -311,11 +335,12 @@ function pathForProject(name) {
 
 /** Push the open zone's current contents at the sidebar. Closes it if the zone is gone. */
 function syncProject() {
+  const hidden = hiddenCatalog(state.hiddenProjects || [], threads)
   const plot = selectedProject ? colony.plots.get(selectedProject) : null
   if (!plot) {
     selectedProject = null
     hud.setProject(null)
-    hud.setLegend(legendProjects, null)
+    hud.setLegend(legendProjects, null, hidden)
     return
   }
   const now = Date.now()
@@ -344,7 +369,7 @@ function syncProject() {
   })
   // The legend is the same selection seen from the bottom of the screen: keep it in step
   // here rather than only on the next poll.
-  hud.setLegend(legendProjects, selectedProject)
+  hud.setLegend(legendProjects, selectedProject, hidden)
 }
 
 // ── pointer ───────────────────────────────────────────────────────────────────────────
@@ -534,7 +559,8 @@ window.addEventListener('keydown', (e) => {
 function applyThreads(list) {
   threads = list
   const archivedSet = new Set(state.archived)
-  const stats = colony.setThreads(list, archivedSet)
+  const hiddenSet = new Set(state.hiddenProjects || [])
+  const stats = colony.setThreads(list, archivedSet, hiddenSet)
   hud.setStats(stats)
 
   legendProjects = colony.plotOrder

--- a/src/main.js
+++ b/src/main.js
@@ -586,7 +586,10 @@ function queueSave() {
   clearTimeout(pendingSave)
   pendingSave = setTimeout(async () => {
     try {
-      await saveState(state)
+      // Adopt whatever comes back: unchanged when the save was clean, and the merged colony when
+      // another tab had written since this one loaded. Dropping it would leave this page
+      // asserting a picture the file has already moved past, and the next save would fight.
+      state = await saveState(state)
     } catch {
       /* the colony still runs; only the archive list is at risk, and it retries next time */
     }

--- a/src/main.js
+++ b/src/main.js
@@ -224,12 +224,22 @@ const actions = {
   archiveThread: () => {
     const thread = threads.find((t) => t.id === selectedId)
     if (!thread) return
+    const foldedBefore = new Set(colony.dormantProjects || [])
     state.archived = [...new Set([...state.archived, thread.id])]
     state.archivedAt = { ...state.archivedAt, [thread.id]: Date.now() }
     queueSave()
     select(null, {})
     applyThreads(threads)
-    hud.toast('Archived — heading home')
+    // Retiring the last thread anybody has touched in a repo makes every thread left in it
+    // dormant, and the whole zone folds away — sixty astronauts can leave the map on one
+    // click. That is the setting working, but silently it reads as the colony breaking, so
+    // it says which repo went and why.
+    const folded = [...(colony.dormantProjects || [])].filter((n) => !foldedBefore.has(n))
+    hud.toast(
+      folded.length
+        ? `Archived — ${folded.join(', ')} ${folded.length === 1 ? 'is' : 'are'} all quiet now, folded off the map`
+        : 'Archived — heading home'
+    )
     colony.ship.ping()
   },
 
@@ -337,11 +347,14 @@ function pathForProject(name) {
 /** Push the open zone's current contents at the sidebar. Closes it if the zone is gone. */
 function syncProject() {
   const hidden = hiddenCatalog(state.hiddenProjects || [], threads)
+  // Folded-away repos are listed alongside the ones you hid by hand. Same principle: nothing
+  // leaves the map without somewhere on screen saying where it went.
+  const folded = hiddenCatalog([...(colony.dormantProjects || [])], threads)
   const plot = selectedProject ? colony.plots.get(selectedProject) : null
   if (!plot) {
     selectedProject = null
     hud.setProject(null)
-    hud.setLegend(legendProjects, null, hidden)
+    hud.setLegend(legendProjects, null, hidden, folded)
     return
   }
   const now = Date.now()
@@ -370,7 +383,7 @@ function syncProject() {
   })
   // The legend is the same selection seen from the bottom of the screen: keep it in step
   // here rather than only on the next poll.
-  hud.setLegend(legendProjects, selectedProject, hidden)
+  hud.setLegend(legendProjects, selectedProject, hidden, folded)
 }
 
 // ── pointer ───────────────────────────────────────────────────────────────────────────

--- a/src/main.js
+++ b/src/main.js
@@ -14,7 +14,6 @@ import {
   fetchState,
   saveState,
   openThread,
-  archiveThread,
   newSession,
   revealFolder,
 } from './game/api.js'
@@ -194,25 +193,19 @@ const actions = {
     }
   },
 
-  archiveThread: async () => {
+  // Archiving is the colony's own bookkeeping and nothing else: the thread leaves the map and
+  // the astronaut walks back to the ship. The harness's own records are never touched — see
+  // `reconcileArchived` in server/api.mjs for why that stopped being worth doing.
+  archiveThread: () => {
     const thread = threads.find((t) => t.id === selectedId)
     if (!thread) return
-    try {
-      const res = await archiveThread(thread, true)
-      state.archived = [...new Set([...state.archived, thread.id])]
-      state.archivedAt = { ...state.archivedAt, [thread.id]: Date.now() }
-      queueSave()
-      select(null, {})
-      applyThreads(threads)
-      hud.toast(
-        res.harnessRecord === false
-          ? `Archived here (no ${thread.harnessName || 'harness'} record for it)`
-          : 'Archived — heading home'
-      )
-      colony.ship.ping()
-    } catch (err) {
-      hud.toast(err.message || 'Could not archive that thread', 'err')
-    }
+    state.archived = [...new Set([...state.archived, thread.id])]
+    state.archivedAt = { ...state.archivedAt, [thread.id]: Date.now() }
+    queueSave()
+    select(null, {})
+    applyThreads(threads)
+    hud.toast('Archived — heading home')
+    colony.ship.ping()
   },
 
   uiVisibility: (visible) => colony.setUiVisible(visible),

--- a/src/main.js
+++ b/src/main.js
@@ -94,6 +94,7 @@ const actions = {
 
   cycleTime: () => {
     settings.set('autoTime', false)
+    settings.set('clockTime', false)
     const current = settings.get('timeOfDay')
     // Step to the next named time *after* the current one, wrapping at midnight.
     const next = TIMES.find((t) => t.value > current + 0.005) || TIMES[0]
@@ -560,7 +561,21 @@ function applyThreads(list) {
   threads = list
   const archivedSet = new Set(state.archived)
   const hiddenSet = new Set(state.hiddenProjects || [])
-  const stats = colony.setThreads(list, archivedSet, hiddenSet)
+
+  // Which threads the colony has met before. Walking out of the ship is meant to *mean*
+  // something — a thread that just appeared — and without this every reload staged a
+  // hundred-astronaut entrance, which piled up at the ramp and read as a bug because it was
+  // one. A thread already on the books is simply already outside.
+  const known = new Set(Object.keys(state.seen || {}))
+  let firstSeen = false
+  for (const t of list) {
+    if (state.seen?.[t.id]) continue
+    state.seen = { ...(state.seen || {}), [t.id]: Date.now() }
+    firstSeen = true
+  }
+  if (firstSeen) queueSave()
+
+  const stats = colony.setThreads(list, archivedSet, hiddenSet, known)
   hud.setStats(stats)
 
   legendProjects = colony.plotOrder

--- a/src/main.js
+++ b/src/main.js
@@ -693,6 +693,9 @@ settings.onChange((changed, scope) => {
   if (scope.render || changed.has('fov')) engine.applySettings()
   colony.onSettingsChanged(changed, scope)
   if (changed.has('showFps')) hud.syncSettings()
+  // Folding dormant repos away changes which threads are on the map, so the colony has to be
+  // rebuilt from the list rather than merely re-rendered.
+  if (changed.has('hideDormant')) applyThreads(threads)
   if (changed.has('maxAgents')) applyThreads(threads)
 })
 

--- a/src/main.js
+++ b/src/main.js
@@ -47,7 +47,7 @@ const engine = new Engine(settings).mount(app)
 const rig = new CameraRig(engine.camera, engine.canvas, settings)
 const colony = new Colony(engine.scene, settings, engine.camera, engine.renderer)
 
-let state = { archived: [], archivedAt: {}, opened: [], plots: {}, seen: {}, hiddenProjects: [] }
+let state = { archived: [], archivedAt: {}, opened: [], plots: {}, seen: {}, hiddenProjects: [], viewedAt: {} }
 let threads = []
 /** Last legend built for the bottom bar, kept so the open zone's chip can light up between polls. */
 let legendProjects = []
@@ -165,6 +165,24 @@ const actions = {
     } catch (err) {
       hud.toast(err.message || 'Could not open that folder', 'err')
     }
+  },
+
+  /**
+   * Stop a thread asking for you, without touching it.
+   *
+   * `unread` comes from the harness, and the harness only counts a thread as read when it is
+   * focused *in its own app*. Answer one in a terminal, or read it over somebody's shoulder,
+   * and it keeps its hand up forever. Marking it viewed here records when you looked; the
+   * moment the thread does something newer than that it goes back to waving, which is the
+   * behaviour you actually want and the reason this is a timestamp rather than a flag.
+   */
+  markViewed: () => {
+    const thread = threads.find((t) => t.id === selectedId)
+    if (!thread) return
+    state.viewedAt = { ...(state.viewedAt || {}), [thread.id]: Date.now() }
+    queueSave()
+    applyThreads(threads)
+    hud.toast(`Marked ${thread.title.slice(0, 40)} as viewed`)
   },
 
   hideProject: () => {
@@ -527,6 +545,10 @@ window.addEventListener('keydown', (e) => {
     case 'A':
       if (selectedId) actions.archiveThread()
       break
+    case 'v':
+    case 'V':
+      if (selectedId) actions.markViewed()
+      break
     case 'c':
     case 'C':
       if (selectedProject) actions.newConversation()
@@ -571,7 +593,14 @@ window.addEventListener('keydown', (e) => {
 // ── data ──────────────────────────────────────────────────────────────────────────────
 
 function applyThreads(list) {
-  threads = list
+  // A thread you have said you looked at stops counting as unread until it moves on again.
+  // Done here rather than in `statusFor` so the card, the badge and the astronaut all agree.
+  const viewed = state.viewedAt || {}
+  threads = list.map((t) => {
+    const at = viewed[t.id]
+    return at && t.lastActivityAt <= at ? { ...t, unread: false } : t
+  })
+  list = threads
   const archivedSet = new Set(state.archived)
   const hiddenSet = new Set(state.hiddenProjects || [])
 

--- a/src/ui/hud.js
+++ b/src/ui/hud.js
@@ -3,6 +3,7 @@ import { PLANETS } from '../world/planet.js'
 import { TIMES } from '../world/sky.js'
 import { STATUS_LABEL } from '../game/colony.js'
 import { FACE, FRAME_COLS, FRAME_ROWS } from '../agents/faces.js'
+import { PLOT_PALETTE, hashString } from '../world/plots.js'
 
 /**
  * The whole HUD, in plain DOM.
@@ -59,6 +60,7 @@ export class Hud {
     this.actions = actions
     this.visible = true
     this._last = {}
+    this.hiddenOpen = false
 
     this.el = document.createElement('div')
     this.el.className = 'hud'
@@ -341,6 +343,8 @@ export class Hud {
     on('#btn-new-session', 'click', () => this.actions.newConversation?.())
     on('#btn-reveal', 'click', () => this.actions.revealProject?.())
     on('#btn-copy-path', 'click', () => this.actions.copyProjectPath?.())
+    on('#btn-hide-project', 'click', () => this.actions.hideProject?.())
+    on('#btn-hidden-toggle', 'click', () => this.toggleHiddenList())
     on('#btn-locate', 'click', () => this.actions.focusProject?.(this.project?.name))
     on('#btn-close-project', 'click', () => this.actions.closeProject?.())
     on('.help', 'click', (e) => {
@@ -375,8 +379,11 @@ export class Hud {
    * it is a list now because the sidebar is where all the chrome lives, and because a list
    * can carry a count and an alarm without running out of room at eleven repos.
    */
-  setLegend(projects, activeName = null) {
-    const signature = projects.map((p) => `${p.name}:${p.count}:${p.accent}:${p.urgent ? 1 : 0}`).join('|') + `~${activeName}`
+  setLegend(projects, activeName = null, hidden = []) {
+    const signature =
+      projects.map((p) => `${p.name}:${p.count}:${p.accent}:${p.urgent ? 1 : 0}`).join('|') +
+      `~${activeName}~` +
+      hidden.map((p) => `${p.name}:${p.count}`).join('|')
     if (this._last.legend === signature) return
     this._last.legend = signature
 
@@ -397,6 +404,42 @@ export class Hud {
       wrap.appendChild(b)
     }
     this.$('.sec-head span').textContent = `${projects.length} repo${projects.length === 1 ? '' : 's'}`
+
+    // The hidden list is its own block at the foot of the sidebar: collapsed by default, because
+    // the whole point of hiding a repo is not to look at it.
+    const block = this.$('.hidden-block')
+    block.hidden = hidden.length === 0
+    this.$('#btn-hidden-toggle .label').textContent = `${hidden.length} hidden`
+    const hiddenWrap = this.$('.hidden-projects')
+    hiddenWrap.innerHTML = ''
+    for (const p of hidden) {
+      const accent = PLOT_PALETTE[hashString(p.name) % PLOT_PALETTE.length]
+      const row = document.createElement('div')
+      row.className = 'repo hidden-repo'
+      row.innerHTML =
+        `<i class="swatch" style="background:${hex(accent)};color:${hex(accent)}"></i>` +
+        `<span class="n">${escapeHtml(p.name)}</span>` +
+        `<span class="count">${p.count}</span>`
+      const show = document.createElement('button')
+      show.type = 'button'
+      show.className = 'btn ghost show-repo'
+      show.title = `Show ${p.name} on the map again`
+      show.textContent = 'Show'
+      show.addEventListener('click', () => this.actions.unhideProject?.(p.name))
+      row.appendChild(show)
+      hiddenWrap.appendChild(row)
+    }
+    this._syncHiddenList()
+  }
+
+  toggleHiddenList() {
+    this.hiddenOpen = !this.hiddenOpen
+    this._syncHiddenList()
+  }
+
+  _syncHiddenList() {
+    this.$('#btn-hidden-toggle').setAttribute('aria-expanded', String(this.hiddenOpen))
+    this.$('.hidden-projects').hidden = !this.hiddenOpen
   }
 
   /**
@@ -826,6 +869,12 @@ const TEMPLATE = `
     <div class="projects-pane">
       <div class="sec-head"><span>Repos</span></div>
       <div class="projects"></div>
+      <div class="hidden-block" hidden>
+        <button type="button" class="hidden-toggle" id="btn-hidden-toggle" aria-expanded="false">
+          <span class="label">0 hidden</span>
+        </button>
+        <div class="hidden-projects" hidden></div>
+      </div>
     </div>
 
     <div class="project-detail">
@@ -844,6 +893,7 @@ const TEMPLATE = `
           <button class="btn" id="btn-reveal" title="Show this folder in ${FILE_MANAGER}">${ICON.folder} ${FILE_MANAGER}</button>
           <button class="btn" id="btn-copy-path" title="Copy the folder path">${ICON.copy} Copy path</button>
         </div>
+        <button class="btn" id="btn-hide-project" title="Hide this repo from the colony — does not archive its threads">${ICON.eyeOff} Hide from colony</button>
       </div>
       <div class="threads-head"></div>
       <div class="threads"></div>
@@ -889,7 +939,7 @@ const TEMPLATE = `
 <div class="help">
   <div class="sheet panel">
     <h2>Bot Crossing</h2>
-    <p class="sub">Every coding-agent thread on this Mac is an astronaut. They walk out of the ship, claim a plot for their repo, and build. Click one to open its thread; click a zone — its deck or its name — for the repo itself, and start a new conversation there. Navigation works like Google Earth — drag the ground itself, right-drag to tilt, scroll to zoom in on whatever is under the cursor.</p>
+    <p class="sub">Every coding-agent thread on this machine is an astronaut. They walk out of the ship, claim a plot for their repo, and build. Click one to open its thread; click a zone — its deck or its name — for the repo itself, and start a new conversation there. Hide a repo from that panel if you would rather not see it — its threads stay in your harness, and you can show it again from the list. Navigation works like Google Earth — drag the ground itself, right-drag to tilt, scroll to zoom in on whatever is under the cursor.</p>
     <div class="cols">
       <div>
         <div class="k"><span>Drag the ground</span><kbd>drag</kbd></div>

--- a/src/ui/hud.js
+++ b/src/ui/hud.js
@@ -1,6 +1,6 @@
 import { PRESETS, PLANETS_ORDER } from './hud-data.js'
 import { PLANETS } from '../world/planet.js'
-import { TIMES } from '../world/sky.js'
+import { TIMES, systemTimeOfDay } from '../world/sky.js'
 import { STATUS_LABEL } from '../game/colony.js'
 import { FACE, FRAME_COLS, FRAME_ROWS } from '../agents/faces.js'
 import { PLOT_PALETTE, hashString } from '../world/plots.js'
@@ -199,16 +199,28 @@ export class Hud {
     const light = group('Lighting')
     light.append(
       chips(
-        TIMES.map((t) => ({ id: t.id, label: t.label })),
-        () => nearestTime(this.settings.get('timeOfDay')),
+        // `Live` is a time of day like the others from where you are standing, so it belongs
+        // in the same row rather than in a toggle further down.
+        [...TIMES.map((t) => ({ id: t.id, label: t.label })), { id: 'live', label: 'Live' }],
+        () => (this.settings.get('clockTime') ? 'live' : nearestTime(this.settings.get('timeOfDay'))),
         (id) => {
           this.settings.set('autoTime', false)
-          this.settings.set('timeOfDay', TIMES.find((t) => t.id === id).value)
+          this.settings.set('clockTime', id === 'live')
+          if (id === 'live') this.settings.set('timeOfDay', systemTimeOfDay())
+          else this.settings.set('timeOfDay', TIMES.find((t) => t.id === id).value)
         },
         this.controls
       ),
-      this._slider('Time of day', 'timeOfDay', 0, 1, 0.005, clockLabel),
-      this._toggle('Cycle day/night', 'autoTime', 'Runs the clock forward on its own.'),
+      this._slider('Time of day', 'timeOfDay', 0, 1, 0.005, clockLabel, undefined, () => {
+        // Reaching for the slider is a request for a particular light, so stop following the
+        // clock — otherwise the next frame would drag the thumb straight back.
+        this.settings.set('clockTime', false)
+      }),
+      this._toggle(
+        'Cycle day/night',
+        'autoTime',
+        'Runs the clock forward on its own. Ignored while the sky is following this machine’s clock.'
+      ),
       this._slider('Cycle length', 'dayLength', 30, 900, 30, (v) => `${Math.round(v / 60)}m`),
       this._toggle(
         'Environment light',
@@ -283,7 +295,7 @@ export class Hud {
     return row
   }
 
-  _slider(label, key, min, max, step, format, hint) {
+  _slider(label, key, min, max, step, format, hint, onInput) {
     const row = this._row(label, hint)
     const wrap = document.createElement('div')
     wrap.style.cssText = 'display:flex;align-items:center;gap:8px'
@@ -295,7 +307,10 @@ export class Hud {
     input.step = step
     const out = document.createElement('span')
     out.className = 'value'
-    input.addEventListener('input', () => this.settings.set(key, Number(input.value)))
+    input.addEventListener('input', () => {
+      onInput?.()
+      this.settings.set(key, Number(input.value))
+    })
     wrap.append(input, out)
     row.appendChild(wrap)
     this.controls.push({

--- a/src/ui/hud.js
+++ b/src/ui/hud.js
@@ -401,11 +401,12 @@ export class Hud {
    * it is a list now because the sidebar is where all the chrome lives, and because a list
    * can carry a count and an alarm without running out of room at eleven repos.
    */
-  setLegend(projects, activeName = null, hidden = []) {
+  setLegend(projects, activeName = null, hidden = [], folded = []) {
     const signature =
       projects.map((p) => `${p.name}:${p.count}:${p.accent}:${p.urgent ? 1 : 0}`).join('|') +
       `~${activeName}~` +
-      hidden.map((p) => `${p.name}:${p.count}`).join('|')
+      hidden.map((p) => `${p.name}:${p.count}`).join('|') +
+      `~${folded.length}`
     if (this._last.legend === signature) return
     this._last.legend = signature
 
@@ -430,8 +431,7 @@ export class Hud {
     // The hidden list is its own block at the foot of the sidebar: collapsed by default, because
     // the whole point of hiding a repo is not to look at it.
     const block = this.$('.hidden-block')
-    block.hidden = hidden.length === 0
-    this.$('#btn-hidden-toggle .label').textContent = `${hidden.length} hidden`
+    block.hidden = hidden.length === 0 && folded.length === 0
     const hiddenWrap = this.$('.hidden-projects')
     hiddenWrap.innerHTML = ''
     for (const p of hidden) {
@@ -451,6 +451,28 @@ export class Hud {
       row.appendChild(show)
       hiddenWrap.appendChild(row)
     }
+
+    // The dormant fold gets one line rather than a row each: it is a setting, not a list of
+    // decisions, and the thing worth offering is the way back rather than per-repo control.
+    if (folded.length) {
+      const n = folded.reduce((sum, p) => sum + p.count, 0)
+      const row = document.createElement('div')
+      row.className = 'repo hidden-repo folded-note'
+      row.innerHTML =
+        `<span class="n">${folded.length} quiet repo${folded.length === 1 ? '' : 's'}` +
+        `, ${n} thread${n === 1 ? '' : 's'}</span>`
+      const show = document.createElement('button')
+      show.type = 'button'
+      show.className = 'btn ghost show-repo'
+      show.title = 'Put dormant repos back on the map'
+      show.textContent = 'Show'
+      show.addEventListener('click', () => this.settings.set('hideDormant', false))
+      row.appendChild(show)
+      hiddenWrap.appendChild(row)
+    }
+
+    const total = hidden.length + folded.length
+    this.$('#btn-hidden-toggle .label').textContent = `${total} off the map`
     this._syncHiddenList()
   }
 

--- a/src/ui/hud.js
+++ b/src/ui/hud.js
@@ -236,6 +236,13 @@ export class Hud {
     // View.
     const view = group('View')
     view.append(
+      this._toggle(
+        'Hide dormant repos',
+        'hideDormant',
+        'Takes a repo off the map when every thread in it has been quiet for three days. Its threads are untouched, and it comes back to the same ground the moment one wakes up.'
+      )
+    )
+    view.append(
       this._toggle('Return to isometric', 'autoFrame', 'Eases the angle back when you stop dragging.'),
       this._slider('Field of view', 'fov', 20, 60, 1, (v) => `${v}°`),
       this._toggle('Project labels', 'showLabels'),

--- a/src/ui/hud.js
+++ b/src/ui/hud.js
@@ -360,6 +360,7 @@ export class Hud {
     on('#btn-planet', 'click', () => this.actions.cyclePlanet?.())
     on('#btn-time', 'click', () => this.actions.cycleTime?.())
     on('#btn-open', 'click', () => this.actions.openThread?.())
+    on('#btn-viewed', 'click', () => this.actions.markViewed?.())
     on('#btn-archive', 'click', () => this.actions.archiveThread?.())
     on('#btn-deselect', 'click', () => this.actions.select?.(null))
     on('#btn-new-session', 'click', () => this.actions.newConversation?.())
@@ -604,6 +605,10 @@ export class Hud {
     // often is how a HUD starts costing frames.
     this._cardSize = { w: card.offsetWidth, h: card.offsetHeight }
     this.$('#btn-open').disabled = thread.canOpen === false
+    // Only offered when there is something to dismiss. A third button on every card would
+    // crowd the two that are always worth having, and "Viewed" on a thread that is not asking
+    // for anything is a control with no effect.
+    this.$('#btn-viewed').hidden = !thread.unread
   }
 
   /**
@@ -972,6 +977,7 @@ const TEMPLATE = `
   <div class="progress"><i></i></div>
   <div class="pair">
     <button class="btn primary" id="btn-open" title="Open this thread in the harness it came from (Enter)">${ICON.open} Open</button>
+    <button class="btn" id="btn-viewed" title="Stop this thread asking for you until it moves on again (V)">${ICON.eye} Viewed</button>
     <button class="btn" id="btn-archive" title="Archive — this astronaut walks back to the ship (A)">${ICON.archive} Archive</button>
   </div>
 </div>
@@ -999,6 +1005,7 @@ const TEMPLATE = `
       <div>
         <div class="k"><span>Next needing you</span><kbd>N</kbd></div>
         <div class="k"><span>Open thread</span><kbd>Enter</kbd></div>
+        <div class="k"><span>Mark viewed</span><kbd>V</kbd></div>
         <div class="k"><span>Archive</span><kbd>A</kbd></div>
         <div class="k"><span>New conversation</span><kbd>C</kbd></div>
         <div class="k"><span>Orbit mode</span><kbd>O</kbd></div>

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -820,6 +820,66 @@ body {
   scrollbar-color: rgba(255, 255, 255, 0.16) transparent;
 }
 
+.side .hidden-block {
+  flex: none;
+  border-top: 1px solid var(--line);
+}
+
+.side .hidden-block[hidden] { display: none; }
+
+.side .hidden-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  margin: 0;
+  padding: 11px 15px 12px;
+  border: 0;
+  background: transparent;
+  color: var(--dim);
+  font: inherit;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  text-align: left;
+  cursor: pointer;
+}
+
+.side .hidden-toggle:hover { color: var(--text); }
+
+.side .hidden-toggle::after {
+  content: '';
+  width: 0;
+  height: 0;
+  border-left: 4px solid currentColor;
+  border-top: 3px solid transparent;
+  border-bottom: 3px solid transparent;
+  opacity: 0.7;
+  transition: transform 140ms ease;
+}
+
+.side .hidden-toggle[aria-expanded='true']::after { transform: rotate(90deg); }
+
+.side .hidden-projects {
+  padding: 0 9px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.side .hidden-projects[hidden] { display: none; }
+
+.side .hidden-repo { cursor: default; }
+.side .hidden-repo:hover { background: transparent; }
+.side .hidden-repo .n { opacity: 0.72; }
+
+.side .show-repo {
+  height: 28px;
+  padding: 0 10px;
+  font-size: 12px;
+  flex: none;
+}
+
 .side .repo {
   display: flex;
   align-items: center;

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -873,6 +873,10 @@ body {
 .side .hidden-repo:hover { background: transparent; }
 .side .hidden-repo .n { opacity: 0.72; }
 
+.thread-pop .actions #btn-viewed[hidden] {
+  display: none;
+}
+
 .side .folded-note .n {
   opacity: 0.6;
   font-style: italic;

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -873,6 +873,11 @@ body {
 .side .hidden-repo:hover { background: transparent; }
 .side .hidden-repo .n { opacity: 0.72; }
 
+.side .folded-note .n {
+  opacity: 0.6;
+  font-style: italic;
+}
+
 .side .show-repo {
   height: 28px;
   padding: 0 10px;

--- a/src/world/plots.js
+++ b/src/world/plots.js
@@ -158,7 +158,56 @@ function hexDistance(a, b) {
  * @param previous Map of id → cells from the last pass (or a saved colony file).
  * @returns Map of id → cells.
  */
+/**
+ * Is the colony one landmass?
+ *
+ * Every zone is a contiguous blob of its own, but nothing has ever guaranteed the *union* of
+ * them is — that held only because zones seed outward in spiral order from the middle, which
+ * happens to leave no gaps when everybody who was ever placed is still on the map.
+ *
+ * Take repos away and the guarantee goes with it. The survivors keep the cells they held in the
+ * bigger layout, which is the whole point of the stickiness, but if the zones between them have
+ * gone those cells are now islands floating in the sea. That is what folding away dormant repos
+ * does the first time it runs.
+ *
+ * The ship's cell counts as walkable here even though nobody may claim it: a colony that
+ * happens to wrap around the ship is not two colonies.
+ */
+function isConnected(out) {
+  const cells = new Map()
+  for (const [, list] of out) for (const c of list) cells.set(key(c.q, c.r), c)
+  if (cells.size < 2) return true
+  const ship = key(SHIP_CELL.q, SHIP_CELL.r)
+  const passable = new Set([...cells.keys(), ship])
+  const [start] = cells.keys()
+  const seen = new Set([start])
+  const queue = [cells.get(start)]
+  while (queue.length) {
+    const c = queue.pop()
+    for (const [dq, dr] of HEX_DIRS) {
+      const n = { q: c.q + dq, r: c.r + dr }
+      const k = key(n.q, n.r)
+      if (!passable.has(k) || seen.has(k)) continue
+      seen.add(k)
+      queue.push(n)
+    }
+  }
+  // The ship is a stepping stone, not a member: it does not have to be reached for the colony
+  // to be whole, and it does not count toward what has to be.
+  seen.delete(ship)
+  return seen.size === cells.size
+}
+
 export function allocateCells(projects, previous = new Map()) {
+  const laid = layOut(projects, previous)
+  // Remembering where a zone sat is worth a great deal, right up until it leaves the colony
+  // as scattered islands. Then the memory is describing a map that no longer exists, and
+  // starting over — compact, from the middle, the way a first run does it — is the lesser
+  // upheaval. It only happens when the alternative is visibly broken.
+  return isConnected(laid) ? laid : layOut(projects, new Map())
+}
+
+function layOut(projects, previous) {
   const reserved = key(SHIP_CELL.q, SHIP_CELL.r)
   const wanted = projects.map((p) => ({ id: p.id, want: cellsNeeded(p.size) }))
   const total = wanted.reduce((n, w) => n + w.want, 0)

--- a/src/world/sky.js
+++ b/src/world/sky.js
@@ -57,6 +57,15 @@ const SKY_FRAG = /* glsl */ `
 `
 
 /** Named times of day. The slider is continuous; these are just the good stops. */
+/**
+ * This machine's wall clock as a day fraction — 0 is midnight, 0.5 is noon, which is exactly
+ * what `timeOfDay` means. Local time on purpose: the point is that the colony's light matches
+ * the light out of your own window, so UTC would be the wrong answer nearly everywhere.
+ */
+export function systemTimeOfDay(now = new Date()) {
+  return (now.getHours() * 3600 + now.getMinutes() * 60 + now.getSeconds()) / 86400
+}
+
 export const TIMES = [
   { id: 'dawn', label: 'Dawn', value: 0.255 },
   { id: 'morning', label: 'Morning', value: 0.34 },
@@ -467,9 +476,19 @@ export class Sky {
     this.starUniforms.uTwinkle.value = elapsed
     this._refreshEnvironment()
 
+    // Following the clock beats cycling: both drive the same value, and a cycle running on
+    // top of it would just fight. Re-read every frame rather than on a timer — it is two
+    // divisions, and it means crossing midnight or the machine waking from sleep needs no
+    // special case.
+    if (this.settings.get('clockTime')) {
+      const t = systemTimeOfDay()
+      if (Math.abs(t - this.time) < 1e-5) return false
+      this.setTime(t)
+      return true // the caller re-syncs anything that keys off time
+    }
     if (this.settings.get('autoTime')) {
       this.setTime(this.time + dt / Math.max(20, this.settings.get('dayLength')))
-      return true // the caller re-syncs anything that keys off time
+      return true
     }
     return false
   }

--- a/test/harness.test.mjs
+++ b/test/harness.test.mjs
@@ -170,3 +170,74 @@ test('openInTerminal refuses anything not already resolved to absolute paths', a
   assert.equal((await openInTerminal([], '/tmp')).ok, false, 'empty argv')
   assert.equal((await openInTerminal(['/bin/ls', 123], '/tmp')).ok, false, 'non-string argument')
 })
+
+// ── Cursor, faked on disk ─────────────────────────────────────────────────────
+
+async function fakeCursor(dirName, records) {
+  const home = await fsp.mkdtemp(path.join(os.tmpdir(), 'cursor-fixture-'))
+  const dir = path.join(home, dirName, 'agent-transcripts', SESSION_ID)
+  await fsp.mkdir(dir, { recursive: true })
+  await fsp.writeFile(path.join(dir, `${SESSION_ID}.jsonl`), records.map((r) => JSON.stringify(r)).join('\n') + '\n')
+  return home
+}
+
+async function cursorWith(home) {
+  process.env.BOT_CROSSING_CURSOR_PROJECTS = home
+  const mod = await import(`../server/harnesses/cursor.mjs?${home}`)
+  return mod.default
+}
+
+const askedFor = (text) => ({ role: 'user', message: { content: [{ type: 'text', text }] } })
+
+test('a Cursor transcript yields a thread with the typed query as its title', async () => {
+  const home = await fakeCursor('tmp', [
+    askedFor('<timestamp>Tuesday, Sep 8, 2026, 4:08 PM (UTC-7)</timestamp>\n<user_query>\nwhat project is this?\n</user_query>'),
+    { role: 'assistant', message: { content: [{ type: 'text', text: 'It is…' }] } },
+    { type: 'turn_ended', status: 'success' },
+  ])
+  const h = await cursorWith(home)
+  assert.equal(await h.detect(), true)
+  const [t] = await h.scanThreads()
+  assert.equal(t.id, `cursor:${SESSION_ID}`)
+  // Cursor's own wrapper tags are scaffolding, not something a person typed.
+  assert.equal(t.title, 'what project is this?')
+  assert.equal(t.running, false, 'a closed turn is not running')
+  assert.equal(t.hasError, false)
+  await fsp.rm(home, { recursive: true, force: true })
+})
+
+test('a transcript from before turn_ended existed is not reported as mid-turn', async () => {
+  // The older corpus carries no markers at all. Reading "no marker" as "still working" would
+  // light up every historical thread on the map.
+  const home = await fakeCursor('tmp', [
+    askedFor('<user_query>old thread</user_query>'),
+    { role: 'assistant', message: { content: [{ type: 'text', text: 'done' }] } },
+  ])
+  const h = await cursorWith(home)
+  const [t] = await h.scanThreads()
+  assert.equal(t.running, false)
+  await fsp.rm(home, { recursive: true, force: true })
+})
+
+test('a failed turn is an error, and an open turn is running', async () => {
+  const home = await fakeCursor('tmp', [
+    askedFor('<user_query>do it</user_query>'),
+    { type: 'turn_ended', status: 'error' },
+  ])
+  const h = await cursorWith(home)
+  const [t] = await h.scanThreads()
+  assert.equal(t.hasError, true)
+  await fsp.rm(home, { recursive: true, force: true })
+})
+
+test('Cursor offers a folder link but never a per-thread one it cannot honour', async () => {
+  const home = await fakeCursor('tmp', [askedFor('<user_query>hi</user_query>')])
+  const h = await cursorWith(home)
+  assert.equal(h.openThread({ sessionId: SESSION_ID }).ok, false)
+  const opened = h.newSession('/tmp/some repo')
+  assert.equal(opened.ok, true)
+  assert.equal(schemeOf(opened.url), 'cursor')
+  assert.ok(opened.url.includes('%20'), 'a space in the path is escaped, not left raw')
+  assert.equal(h.newSession('relative/path').ok, false)
+  await fsp.rm(home, { recursive: true, force: true })
+})

--- a/test/harness.test.mjs
+++ b/test/harness.test.mjs
@@ -1,0 +1,172 @@
+/**
+ * The harness seam: what an adapter is allowed to hand back, and the two things the colony has
+ * historically got wrong about a thread — which repo it belongs to, and whether it is working.
+ *
+ * Fixture-driven. Nothing here reads a real harness, so it says the same thing on any machine.
+ */
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fsp from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
+import { HARNESSES } from '../server/harnesses/index.mjs'
+import codex from '../server/harnesses/codex.mjs'
+import claudeCode from '../server/harnesses/claude-code.mjs'
+import { readTail, findExecutable } from '../server/lib/fsutil.mjs'
+import { schemeOf, openInTerminal } from '../server/lib/xdg.mjs'
+
+// ── the contract ──────────────────────────────────────────────────────────────
+
+test('every registered harness implements the interface, and none of them can write', () => {
+  for (const h of HARNESSES) {
+    assert.match(h.id, /^[a-z0-9-]+$/, `${h.id} is not a kebab-case id`)
+    assert.equal(typeof h.name, 'string')
+    for (const fn of ['detect', 'scanThreads', 'openThread', 'newSession']) {
+      assert.equal(typeof h[fn], 'function', `${h.id} is missing ${fn}()`)
+    }
+    // The one rule the project will not bend on. An adapter that grows a write is a bug.
+    assert.equal(h.setArchived, undefined, `${h.id} must not write to its harness`)
+  }
+})
+
+test('harness ids are unique, and so are the id prefixes they hand out', () => {
+  const ids = HARNESSES.map((h) => h.id)
+  assert.equal(new Set(ids).size, ids.length)
+})
+
+// ── ids are prefixed, and refs from the page are not trusted ──────────────────
+
+test('a session id that merely stringifies to a UUID is refused', async () => {
+  // `RegExp.test` coerces, so an array holding a valid id passes the pattern and then travels on
+  // as an array. Both adapters check the type first.
+  const uuid = '2df3987c-02d3-405e-b8f5-da30e3835213'
+  assert.equal((await claudeCode.openThread({ cliSessionId: [uuid] })).ok, false)
+  assert.equal((await claudeCode.openThread({ desktopSessionId: { toString: () => `local_${uuid}` } })).ok, false)
+  assert.equal(codex.openThread({ sessionId: [uuid] }).ok, false)
+  assert.equal(codex.openThread({}).ok, false)
+  assert.equal(codex.openThread(null).ok, false)
+})
+
+test('codex opens through the registered scheme and prefixes its ids', () => {
+  const id = '019cc762-45a2-7112-89cd-cd345c17e834'
+  const opened = codex.openThread({ sessionId: id })
+  assert.equal(opened.ok, true)
+  assert.equal(schemeOf(opened.url), 'codex')
+  assert.equal(opened.url, `codex://threads/${id}`)
+})
+
+// ── a Codex install, faked on disk ────────────────────────────────────────────
+
+const line = (type, payload, timestamp = '2026-09-07T12:00:00.000Z') => JSON.stringify({ timestamp, type, payload })
+
+/** One id for every fixture, so a test can name it before the transcript exists. */
+const SESSION_ID = '019cc762-45a2-7112-89cd-cd345c17e834'
+
+async function fakeCodex(records) {
+  const home = await fsp.mkdtemp(path.join(os.tmpdir(), 'codex-fixture-'))
+  const day = path.join(home, 'sessions', '2026', '09', '07')
+  await fsp.mkdir(day, { recursive: true })
+  await fsp.writeFile(path.join(day, `rollout-2026-09-07T12-00-00-${SESSION_ID}.jsonl`), records.join('\n') + '\n')
+  return home
+}
+
+async function scanWith(home) {
+  process.env.CODEX_HOME = home
+  const mod = await import(`../server/harnesses/codex.mjs?${home}`)
+  return mod.default
+}
+
+test('a CLI-only Codex session is found with no database at all', async () => {
+  const home = await fakeCodex([
+    line('session_meta', { id: SESSION_ID, cwd: '/tmp/demo', git: { branch: 'main' } }),
+    line('turn_context', { model: 'gpt-5.3-codex', effort: 'high' }),
+    line('response_item', { type: 'message', role: 'user', content: [{ text: 'ship the thing' }] }),
+    line('event_msg', { type: 'task_complete' }),
+  ])
+  const h = await scanWith(home)
+  assert.equal(await h.detect(), true)
+  const [t] = await h.scanThreads()
+  assert.equal(t.id, `codex:${SESSION_ID}`, 'ids are prefixed')
+  assert.equal(t.project, 'demo')
+  assert.equal(t.model, 'gpt-5.3-codex')
+  assert.equal(t.effort, 'high')
+  assert.equal(t.gitBranch, 'main')
+  assert.equal(t.preview, 'ship the thing')
+  assert.ok(t.sizeBytes > 0, 'sizeBytes is transcript bytes, not a token count')
+  assert.equal(t.running, false)
+  await fsp.rm(home, { recursive: true, force: true })
+})
+
+test('an interrupted turn is not an error — escape must not redden an astronaut', async () => {
+  const home = await fakeCodex([
+    line('session_meta', { id: SESSION_ID, cwd: '/tmp/demo' }),
+    line('event_msg', { type: 'task_started' }),
+    line('event_msg', { type: 'turn_aborted' }),
+  ])
+  const h = await scanWith(home)
+  const [t] = await h.scanThreads()
+  assert.equal(t.hasError, false)
+  assert.equal(t.running, false, 'an aborted turn is not still running')
+  await fsp.rm(home, { recursive: true, force: true })
+})
+
+test('a task started long ago is not still running', async () => {
+  const home = await fakeCodex([
+    line('session_meta', { id: SESSION_ID, cwd: '/tmp/demo' }),
+    line('event_msg', { type: 'task_started' }),
+  ])
+  const day = path.join(home, 'sessions', '2026', '09', '07')
+  const [file] = await fsp.readdir(day)
+  const old = new Date(Date.now() - 6 * 60 * 60 * 1000)
+  await fsp.utimes(path.join(day, file), old, old)
+  const h = await scanWith(home)
+  const [t] = await h.scanThreads()
+  assert.equal(t.running, false, 'Codex writes nothing when killed, so the window has to bound it')
+  await fsp.rm(home, { recursive: true, force: true })
+})
+
+test('malformed records are skipped rather than throwing the scan away', async () => {
+  const home = await fakeCodex([
+    'not json at all',
+    '{"half": ',
+    line('session_meta', { id: SESSION_ID, cwd: '/tmp/demo' }),
+    line('response_item', { type: 'message', role: 'user', content: 'hello' }),
+  ])
+  const h = await scanWith(home)
+  const threads = await h.scanThreads()
+  assert.equal(threads.length, 1)
+  assert.equal(threads[0].preview, 'hello')
+  await fsp.rm(home, { recursive: true, force: true })
+})
+
+test('an absent Codex is simply not detected', async () => {
+  const home = await fsp.mkdtemp(path.join(os.tmpdir(), 'codex-empty-'))
+  const h = await scanWith(home)
+  assert.equal(await h.detect(), false)
+  assert.deepEqual(await h.scanThreads(), [])
+  await fsp.rm(home, { recursive: true, force: true })
+})
+
+// ── shared helpers ────────────────────────────────────────────────────────────
+
+test('readTail drops the partial line it lands in the middle of', async () => {
+  const f = path.join(await fsp.mkdtemp(path.join(os.tmpdir(), 'tail-')), 'x.jsonl')
+  await fsp.writeFile(f, 'first line\nsecond line\nthird line\n')
+  assert.equal(await readTail(f, 15), 'third line\n')
+  assert.equal(await readTail(f, 1000), 'first line\nsecond line\nthird line\n')
+})
+
+test('findExecutable refuses junk, and refuses a directory that sits on PATH', async () => {
+  assert.equal(await findExecutable(''), null)
+  assert.equal(await findExecutable(null), null)
+  assert.equal(await findExecutable('.'), null)
+  assert.equal(await findExecutable('definitely-not-a-real-binary-xyz'), null)
+})
+
+test('openInTerminal refuses anything not already resolved to absolute paths', async () => {
+  assert.equal((await openInTerminal(['ls'], '/tmp')).ok, false, 'relative argv[0]')
+  assert.equal((await openInTerminal(['/bin/ls'], 'relative')).ok, false, 'relative cwd')
+  assert.equal((await openInTerminal([], '/tmp')).ok, false, 'empty argv')
+  assert.equal((await openInTerminal(['/bin/ls', 123], '/tmp')).ok, false, 'non-string argument')
+})

--- a/test/state.test.mjs
+++ b/test/state.test.mjs
@@ -1,0 +1,136 @@
+/**
+ * The colony file: migration, and the merge that stops two tabs eating each other.
+ *
+ * These are the pieces where a mistake loses somebody's archive list silently, which is why they
+ * were made pure and testable rather than left inline.
+ */
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fsp from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import http from 'node:http'
+
+import { mergeState } from '../src/game/merge-state.js'
+
+// ── the three-way merge ───────────────────────────────────────────────────────
+
+test('an addition from each tab survives the merge', () => {
+  const out = mergeState({ archived: ['a'] }, { archived: ['a', 'mine'] }, { archived: ['a', 'theirs'] })
+  assert.deepEqual(out.archived.sort(), ['a', 'mine', 'theirs'])
+})
+
+test('a removal survives the merge — a plain union would resurrect it', () => {
+  const out = mergeState({ archived: ['t1'] }, { archived: [] }, { archived: ['t1', 't2'] })
+  assert.deepEqual(out.archived, ['t2'])
+})
+
+test('two tabs moving different zones both keep their move', () => {
+  const out = mergeState(
+    { plots: { a: [[0, 0]], b: [[1, 1]] } },
+    { plots: { a: [[9, 9]], b: [[1, 1]] } },
+    { plots: { a: [[0, 0]], b: [[7, 7]] } }
+  )
+  assert.deepEqual(out.plots, { a: [[9, 9]], b: [[7, 7]] })
+})
+
+test('a zone this tab never touched is left exactly as the other tab left it', () => {
+  // Rebuilt-but-identical arrays must not read as "changed here" — that is what would let a
+  // stale copy paste back over a zone somebody else moved.
+  const out = mergeState({ plots: { a: [[0, 0]] } }, { plots: { a: [[0, 0]] } }, { plots: { a: [[4, 4]] } })
+  assert.deepEqual(out.plots, { a: [[4, 4]] })
+})
+
+test('hiding a repo survives a conflicting save', () => {
+  assert.deepEqual(mergeState({ hiddenProjects: [] }, { hiddenProjects: ['x'] }, { hiddenProjects: [] }).hiddenProjects, ['x'])
+  assert.deepEqual(mergeState({ hiddenProjects: [] }, { hiddenProjects: [] }, { hiddenProjects: ['y'] }).hiddenProjects, ['y'])
+})
+
+test('settings are not merged field-wise — the last tab to touch a slider wins whole', () => {
+  const out = mergeState({ settings: { q: 1 } }, { settings: { q: 3 } }, { settings: { q: 2, planet: 'mars' } })
+  assert.deepEqual(out.settings, { q: 3 })
+})
+
+// ── the API, against a real socket ────────────────────────────────────────────
+
+async function withServer(run) {
+  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'bot-crossing-test-'))
+  process.env.BOT_CROSSING_DATA = dir
+  // Imported per-server so DATA_DIR is read fresh; the query string defeats the module cache.
+  const { apiMiddleware } = await import(`../server/api.mjs?${dir}`)
+  const server = http.createServer((req, res) => apiMiddleware(req, res, null))
+  await new Promise((r) => server.listen(0, '127.0.0.1', r))
+  const port = server.address().port
+  const call = (p, opts) =>
+    fetch(`http://127.0.0.1:${port}${p}`, {
+      headers: { Origin: `http://localhost:${port}`, 'Content-Type': 'application/json' },
+      ...opts,
+    })
+  try {
+    await run({ call, dir, put: (b) => call('/api/state', { method: 'PUT', body: JSON.stringify(b) }) })
+  } finally {
+    server.close()
+    await fsp.rm(dir, { recursive: true, force: true })
+  }
+}
+
+test('a v1 file has its bare ids prefixed on read, once', async () => {
+  await withServer(async ({ call, dir }) => {
+    const id = 'fe911daa-2393-4e29-8d36-6e37c328594c'
+    await fsp.writeFile(
+      path.join(dir, 'colony.json'),
+      JSON.stringify({ version: 1, archived: [id], archivedAt: { [id]: 5 }, updatedAt: 1 })
+    )
+    const state = await (await call('/api/state')).json()
+    assert.equal(state.version, 2)
+    assert.deepEqual(state.archived, [`claude-code:${id}`])
+    assert.deepEqual(Object.keys(state.archivedAt), [`claude-code:${id}`])
+  })
+})
+
+test('a stale save is refused with the disk state, not silently applied', async () => {
+  await withServer(async ({ call, put }) => {
+    const seed = await (await put({ archived: ['seed'] })).json()
+    assert.equal((await put({ archived: ['ok'], baseUpdatedAt: seed.updatedAt })).status, 200)
+    const stale = await put({ archived: ['lost'], baseUpdatedAt: seed.updatedAt })
+    assert.equal(stale.status, 409)
+    assert.deepEqual((await stale.json()).archived, ['ok'])
+    void call
+  })
+})
+
+test('a save with no base is allowed, so curl and a fresh install both work', async () => {
+  await withServer(async ({ put }) => {
+    assert.equal((await put({ archived: ['first'] })).status, 200)
+  })
+})
+
+test('simultaneous saves never 500 — one wins, the rest get a mergeable 409', async () => {
+  await withServer(async ({ call, put }) => {
+    const seed = await (await put({ archived: ['seed'] })).json()
+    const results = await Promise.all(
+      [1, 2, 3, 4, 5].map((i) => put({ archived: [`t${i}`], baseUpdatedAt: seed.updatedAt }))
+    )
+    const codes = results.map((r) => r.status)
+    assert.equal(codes.filter((c) => c === 200).length, 1, 'exactly one writer wins')
+    assert.equal(codes.filter((c) => c === 409).length, 4, 'the rest are told to merge')
+    assert.ok(!codes.some((c) => c >= 500), `no crashes, got ${codes}`)
+    void call
+  })
+})
+
+test('archiving is not a server endpoint any more — the colony owns that list', async () => {
+  await withServer(async ({ call }) => {
+    const res = await call('/api/archive', { method: 'POST', body: JSON.stringify({ id: 'x' }) })
+    assert.equal(res.status, 404)
+  })
+})
+
+test('a cross-origin write is refused even though the host is local', async () => {
+  await withServer(async ({ call }) => {
+    const res = await fetch(new URL('/api/state', `http://127.0.0.1:0`), { method: 'PUT' }).catch(() => null)
+    void res
+    const bad = await call('/api/state', { method: 'PUT', body: '{}', headers: { Origin: 'http://evil.com' } })
+    assert.equal(bad.status, 403)
+  })
+})

--- a/test/state.test.mjs
+++ b/test/state.test.mjs
@@ -134,3 +134,47 @@ test('a cross-origin write is refused even though the host is local', async () =
     assert.equal(bad.status, 403)
   })
 })
+
+// ── marking a thread viewed ───────────────────────────────────────────────────
+
+/**
+ * The rule `applyThreads` uses. Kept here as well because it is one line in the browser and
+ * the whole point of it is the *second* half: viewed is a timestamp, not a flag, so a thread
+ * that moves on afterwards starts asking again.
+ */
+const suppressUnread = (thread, viewedAt) => {
+  const at = viewedAt[thread.id]
+  return at && thread.lastActivityAt <= at ? { ...thread, unread: false } : thread
+}
+
+test('marking a thread viewed stops it asking', () => {
+  const t = { id: 'a', unread: true, lastActivityAt: 100 }
+  assert.equal(suppressUnread(t, { a: 200 }).unread, false)
+})
+
+test('a thread that moves on after you looked asks again', () => {
+  const t = { id: 'a', unread: true, lastActivityAt: 300 }
+  assert.equal(suppressUnread(t, { a: 200 }).unread, true, 'newer activity beats an older look')
+})
+
+test('viewing one thread says nothing about another', () => {
+  const t = { id: 'b', unread: true, lastActivityAt: 100 }
+  assert.equal(suppressUnread(t, { a: 200 }).unread, true)
+})
+
+test('viewedAt survives a merge, so a second tab cannot un-view a thread', () => {
+  const merged = mergeState({ viewedAt: {} }, { viewedAt: { a: 5 } }, { viewedAt: { b: 7 } })
+  assert.deepEqual(merged.viewedAt, { a: 5, b: 7 })
+})
+
+test('viewedAt is carried through the v1 migration with the ids it keys on', async () => {
+  await withServer(async ({ call, dir }) => {
+    const id = 'fe911daa-2393-4e29-8d36-6e37c328594c'
+    await fsp.writeFile(
+      path.join(dir, 'colony.json'),
+      JSON.stringify({ version: 1, viewedAt: { [id]: 42 }, updatedAt: 1 })
+    )
+    const state = await (await call('/api/state')).json()
+    assert.deepEqual(Object.keys(state.viewedAt), [`claude-code:${id}`])
+  })
+})


### PR DESCRIPTION
Implements the intent of thirteen open PRs in one branch. Several were widening the same seam in different directions, so this picks one shape for each and applies it consistently. Contributors are credited on the commits.

### Bot Crossing no longer writes to a harness

The job is to **read** your threads and **open** them where they live. Sending state back into a coding agent is not something this should be doing, and archiving was the one place it did.

It also never worked reliably. The flag landed on disk, but the desktop app serves from the copy of its records it loaded at launch — so a thread archived here stayed put in its own list until the app restarted, and got rewritten from memory the next time the app touched it. Holding that together took a re-assert on every scan, a `ps` sweep, and a "pending" state for the gap.

So archiving is now **inside Bot Crossing only** and does not touch the coding harness. The astronaut still walks back to the ship. Archiving in the harness's own app still sends it home too, because the scan reads that flag — that direction was always fine.

`data/colony.json` is the only file this project writes, anywhere. `setArchived` is gone from the adapter interface, and the scan no longer starts a subprocess at all.

### Harnesses
- **Codex** — reads both stores (SQLite thread index + rollout transcripts), opens through `codex://`
- **Cursor** — agent transcripts. Composer/sidebar threads are not read yet
- Adapters can report `diagnostic()` so a broken harness says why instead of looking healthy and contributing nothing

### Platform
- **Windows** — finds the Store (MSIX) install; fixes plot names showing as full absolute paths on any name collision
- **Linux** — opening a thread probes the URL scheme, then falls back to the harness CLI in a terminal

### Bugs
- "Running" means mid-turn, not just a live process
- Concurrent saves no longer 500 and lose the write
- Astronauts no longer pile up at the ramp on load
- The whole crew no longer vanishes when the agent count exceeds the instance buffers
- Zones can't end up as disconnected islands

### Features
- Hide a repo from the map; fold away repos quiet for three days (on by default)
- Mark a thread viewed so it stops asking (`V`)
- Live sky that follows the system clock

### Notes
- **Node 22.13+** required (`node:sqlite`)
- `colony.json` migrates v1→v2 on first read — thread ids are now prefixed (`claude-code:…`). One-way; back up the file if you want a way out
- `npm test` — 33 tests
- `DECISIONS.md` records what's settled and why

Closes #5, #8, #9, #10, #11, #12, #13, #14, #15, #16, #17, #18, #19

Not included: #7 (Hermes — throws on my machine, waiting on schema info)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
