### PR TITLE
Two fixes where the colony misrepresents a thread: a dropped `?` and an erased archive

### DIFF
--- a/src/agents/astronauts.js
+++ b/src/agents/astronauts.js
@@ -26,6 +26,11 @@ import { attachMatrixAt, decorateSkinned, frameFor } from './crew.js'
  * size these characters render.
  */
 
+/** Attention order for the roster clamp: an astronaut that wants something from you outranks
+ *  a quiet one for a rendering slot. Mirrors the status precedence in game/colony.js. */
+const URGENCY = { blocked: 0, waiting: 1, working: 2, celebrating: 3, spawning: 4, idle: 5, sleeping: 6, leaving: 7 }
+const URGENCY_RANK = (s) => (s in URGENCY ? URGENCY[s] : 9)
+
 const SUIT_TONES = [0xf3f1ec, 0xe8e4dc, 0xf7f4ee, 0xdfe4e8, 0xf1e9df]
 
 /** Trim + eye colour per behaviour. Eyes are pushed past 1.0 so the bloom pass catches them. */
@@ -471,7 +476,17 @@ export class Astronauts {
     // for them. Without this the clamp above would quietly drop whoever sorted last, which is
     // better than an empty planet but still not what the scan said.
     const leaving = this.agents.reduce((n, a) => n + (a.state === 'leaving' ? 1 : 0), 0)
-    const wanted = entries.slice(0, Math.max(1, cap - leaving))
+    // ...and whoever sorts last must not be the one astronaut holding a `?`. The clamp is a
+    // frame budget and stays, but it spends its slots on the crew that want something from
+    // you first: blocked, then waiting, then working, and the quiet ones last. Stable within
+    // a status, so a roster at the cap does not churn between polls, and placement is
+    // untouched because every entry carries its own site and anchor.
+    //
+    // Measured on a real colony: 151 live threads against a 90 cap, four of them unread. The
+    // panel read "4 need you" while pressing N answered "nobody is waiting on you right now",
+    // because all three waiting astronauts sorted past the slice and were never drawn.
+    const byUrgency = [...entries].sort((a, b) => URGENCY_RANK(a.status) - URGENCY_RANK(b.status))
+    const wanted = byUrgency.slice(0, Math.max(1, cap - leaving))
     const seen = new Set()
 
     // The ramp is one door and the ship is a solid obstacle around it, so an entrance is a

--- a/src/main.js
+++ b/src/main.js
@@ -48,6 +48,8 @@ const rig = new CameraRig(engine.camera, engine.canvas, settings)
 const colony = new Colony(engine.scene, settings, engine.camera, engine.renderer)
 
 let state = { archived: [], archivedAt: {}, opened: [], plots: {}, seen: {}, hiddenProjects: [], viewedAt: {} }
+/** Guards queueSave: nothing is written until fetchState() has replaced the empty state above. */
+let stateLoaded = false
 let threads = []
 /** Last legend built for the bottom bar, kept so the open zone's chip can light up between polls. */
 let legendProjects = []
@@ -666,6 +668,20 @@ async function poll() {
 }
 
 function queueSave() {
+  // Nothing may be written before the file has been read. `state` above starts with an EMPTY
+  // archive list and is replaced by fetchState() during boot; a save queued inside that window
+  // PUTs the empty list and erases every archive on disk.
+  //
+  // The optimistic-concurrency guard does not cover this, by design: `baseUpdatedAt` is 0 until
+  // adoptBase() runs, and the server treats a zero base as a first write and allows it. That is
+  // right for a fresh install and wrong for a tab that simply has not finished loading.
+  //
+  // The damage is invisible, which is what makes it worth a guard rather than a comment:
+  // reconcileArchived re-asserts every thread that ALSO carries isArchived in its harness's own
+  // records, so a wiped file comes back looking populated rather than empty. Measured twice in
+  // a row while archiving 49 threads — an archive list of 50 read back as 11, which is exactly
+  // the number with a Claude Code desktop record.
+  if (!stateLoaded) return
   clearTimeout(pendingSave)
   pendingSave = setTimeout(async () => {
     try {
@@ -689,6 +705,7 @@ async function boot() {
     fetchState()
       .then((s) => {
         state = s
+        stateLoaded = true
         // Before the first roster: zones come back to the ground they were on last time.
         colony.restoreLayout(state.plots)
         // And the settings, but only for a browser that has none of its own — an explicit
@@ -696,7 +713,11 @@ async function boot() {
         if (!hasStoredSettings() && state.settings) settings.applyAll(state.settings)
       })
       .catch(() => {
-        /* first run, or the file is gone — an empty colony state is a valid one */
+        // Not "first run, or the file is gone": the server answers a missing file with an
+        // empty state rather than an error, so a rejection means it could not be reached and
+        // we do not know what is on disk. Saves stay off for this session and say so, because
+        // an archive that silently fails to persist is worse than one that refuses.
+        hud.toast('Could not read the saved colony — archiving is off until you reload', 'err')
       }),
     settle(loadKit()),
     settle(loadCrew()),


### PR DESCRIPTION
Two independent bugs, both found while using Bot Crossing on a real colony — 304 threads across seven repos, Claude Code only. CONTRIBUTING says bug fixes are most welcome where "the colony misrepresents what a thread is actually doing", and both of these are exactly that.

They're separate commits and stand alone; take either.

---

### 1. The roster clamp drops the astronaut that wants you

`setRoster` already leaves room for agents walking back to the ship, and its comment names what's left over: it *"would quietly drop whoever sorted last, which is better than an empty planet but still not what the scan said."*

Whoever sorts last can be the one astronaut holding a `?`.

**Measured:** 151 live threads against a 90 clamp (the *high* preset), four of them unread. The panel read **"4 need you"** while pressing `N` answered **"nobody is waiting on you right now"**. Both were true about different things — the stat counts *threads*, `focusStatus` searches *rendered* agents — and all three genuinely-waiting astronauts sorted past the slice. They weren't hard to spot; they were never drawn.

The clamp stays, it's a frame budget. It now spends its slots on the crew that want something first: blocked → waiting → working → quiet. Sort is stable within a status so a roster at the cap doesn't churn between polls, and placement is untouched since each entry carries its own `site` and `anchor`.

### 2. A save during boot erases the archive list

`state` starts with an empty `archived: []` and is replaced by `fetchState()` during boot. `queueSave()` can fire inside that window and PUT the empty list over `colony.json`.

The optimistic-concurrency guard doesn't catch it, and I think by design: `baseUpdatedAt` is `0` until `adoptBase()` runs, and the PUT handler treats a zero base as a first write and allows it. Right for a fresh install; wrong for a tab that hasn't finished loading.

**What makes it worth a guard rather than a comment is that the damage is invisible.** `reconcileArchived` re-asserts every thread that also carries `isArchived` in its harness's own records, so a wiped file comes back looking *populated* rather than empty. Archiving 49 old threads, an archive list of **50 read back as 11** — twice in a row. Eleven is exactly the number of those threads holding a Claude Code desktop record. Without that detail it reads as "the archive didn't take" rather than "the page erased it".

I also changed the fetch's `catch`, which currently says *"first run, or the file is gone"*. The server answers a missing file with an empty state, never an error — so a rejection means it was unreachable and the file's contents are unknown. Saves stay off for that session and the user is told, because an archive that silently fails to persist is worse than one that refuses.

**Verified:** 50 archived → page opened → still 50. Before the guard, the identical sequence came back 11.

---

No new dependencies, no interface changes, both verified against a real Claude Code colony. Written with Claude Code (Opus 5) and marked `Co-Authored-By` on both commits — mentioning it since you were straight about using an agent for the first review pass, and it seemed fair to be straight back.

Entirely understood if these sit, or if you'd rather take the diagnosis and write the fix yourself.