### PR TITLE
Open: front the attached terminal window instead of importing into the desktop app

### DIFF
--- a/server/api.mjs
+++ b/server/api.mjs
@@ -4,6 +4,7 @@ import path from 'node:path'
 import { spawn } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 import { openInTerminal, schemeHasHandler, schemeOf } from './lib/xdg.mjs'
+import { focusWindowOfPid } from './lib/windows.mjs'
 import {
   defaultHarness,
   harnessStatus,
@@ -175,8 +176,15 @@ async function resolveFolder(folder) {
 }
 
 /**
- * Show a harness's answer to "open this" — `{ ok, url, command }` — and say truthfully whether
- * anything happened.
+ * Show a harness's answer to "open this" — `{ ok, url, command, pid }` — and say truthfully
+ * whether anything happened.
+ *
+ * A `pid` names a live process whose thread already has a window on this machine — a session
+ * running in a terminal right now. Fronting that window is tried before anything else, because
+ * the URL fallback for exactly these threads is `resume`, which imports the transcript into the
+ * desktop app as a second, untitled session. Only when no window can be found (the terminal is
+ * on another desktop, the process is detached, the walk found only the Claude app itself) does
+ * the URL run as before.
  *
  * macOS and Windows hand the URL to the opener exactly as before: a scheme the harness's app
  * registers is always answered there, so nothing is probed. Linux is the platform where the URL
@@ -193,6 +201,8 @@ async function resolveFolder(folder) {
 async function present(result) {
   // Only the reason reaches the page: a failure may still carry the adapter's command.
   if (!result || !result.ok) return { ok: false, error: result?.error || 'Nothing to open' }
+
+  if (result.pid && (await focusWindowOfPid(result.pid))) return { ok: true, focused: true }
 
   if (process.platform !== 'linux') {
     if (!result.url) return { ok: false, error: 'That harness has no deep link to open on this platform' }

--- a/server/harnesses/claude-code.mjs
+++ b/server/harnesses/claude-code.mjs
@@ -494,16 +494,49 @@ const CLI_DIRS = [
 const cliBinary = () => findExecutable('claude', CLI_DIRS)
 
 /**
+ * The pid of the live CLI process behind a session, if any. Same registry and same caveat as
+ * `scanLiveSessions`: files outlive their pids, so the pid is probed before it counts.
+ */
+async function liveSessionPid(sessionId) {
+  for (const file of await listFiles(CLI_LIVE, (n) => n.endsWith('.json'))) {
+    let record
+    try {
+      record = JSON.parse(await fsp.readFile(file, 'utf8'))
+    } catch {
+      continue
+    }
+    if (record.sessionId !== sessionId || !record.pid) continue
+    try {
+      process.kill(record.pid, 0)
+      return record.pid
+    } catch {
+      /* process is gone */
+    }
+  }
+  return 0
+}
+
+/**
  * Hands the thread back to Claude Code. `epitaxy/<local_…>` *navigates* the desktop app
  * to a thread it already has; `resume` *imports* the transcript, which spawns a second
  * untitled session and rewrites the .jsonl — so it is only ever the fallback for threads
  * the app has never seen. Ids are pattern-checked before they reach the opener.
+ *
+ * A terminal-started thread that is still running gets its live pid handed along too: it
+ * already has a window somewhere on this machine, and fronting that window is a better answer
+ * than `resume` importing the transcript into the desktop app as a second, untitled session.
+ * Whether and how to front it is the server's call — see `server/lib/windows.mjs`.
  */
 async function openThread(ref) {
   const { desktopSessionId, cliSessionId, cwd } = ref || {}
   let url = ''
   if (isDesktopId(desktopSessionId)) url = `claude://claude.ai/epitaxy/${desktopSessionId}`
   else if (isCliId(cliSessionId)) url = `claude://resume?session=${cliSessionId}`
+
+  // Only threads the desktop app has never seen: for the rest the deep link navigates to the
+  // tab the app already has, which is exactly the right window to front.
+  let pid = 0
+  if (!isDesktopId(desktopSessionId) && isCliId(cliSessionId)) pid = await liveSessionPid(cliSessionId)
 
   let command
   if (process.platform === 'linux' && isCliId(cliSessionId)) {
@@ -512,7 +545,7 @@ async function openThread(ref) {
   }
 
   if (!url && !command) return { ok: false, error: 'No openable session id on that thread' }
-  return { ok: true, url, command }
+  return { ok: true, url, command, pid }
 }
 
 /**

--- a/server/lib/windows.mjs
+++ b/server/lib/windows.mjs
@@ -1,0 +1,95 @@
+/**
+ * Windows desktop plumbing: put the window that hosts a given process in front.
+ *
+ * The sibling of `xdg.mjs`, for the same reason — a page of OS trivia with nothing to do with
+ * HTTP, and nothing in here knows about a particular harness. An adapter hands the server a pid;
+ * the server decides whether fronting its window is the right way to answer "open this".
+ *
+ * The pid itself has no window — it is a CLI process. The window belongs to whatever terminal is
+ * hosting it, which is some ancestor: the shell's parent is Windows Terminal, VS Code, an IDE.
+ * So the walk goes *up* the parent chain until a process with a real main window appears, and
+ * fronts that. The Claude desktop app is deliberately stepped over: a process hosted by the app
+ * itself is the app's to present, and the deep link does that better than raw window fronting.
+ */
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+
+/**
+ * Enumerating every process (`Get-CimInstance Win32_Process`) is the slow half, a second or two
+ * on a busy machine; the rest is instant. The budget covers that with room, because past it the
+ * caller falls back to the deep link — a worse answer than a fronted window, but never a hang.
+ */
+const FOCUS_TIMEOUT_MS = 8000
+
+/** How many parents to visit before concluding nothing on the chain owns a window. */
+const MAX_HOPS = 16
+
+/**
+ * `SetForegroundWindow` alone is refused when the caller is a background process — Windows
+ * reserves focus-stealing for whoever the user is interacting with. A transient Alt keypress
+ * (0xA4, down then up) is the documented-by-folklore exemption: a process that just sent input
+ * counts as interacting. Restore-first matters too: fronting a minimized window leaves it
+ * minimized, just "active" in the taskbar.
+ */
+const script = (pid) => `
+$ErrorActionPreference = 'SilentlyContinue'
+$parent = @{}
+foreach ($p in Get-CimInstance Win32_Process) { $parent[[int]$p.ProcessId] = [int]$p.ParentProcessId }
+Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+public static class BotCrossingFocus {
+  [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr h);
+  [DllImport("user32.dll")] public static extern bool ShowWindowAsync(IntPtr h, int cmd);
+  [DllImport("user32.dll")] public static extern bool IsIconic(IntPtr h);
+  [DllImport("user32.dll")] public static extern void keybd_event(byte key, byte scan, uint flags, UIntPtr extra);
+}
+'@
+$cur = ${pid}
+for ($i = 0; $i -lt ${MAX_HOPS} -and $cur -gt 0; $i++) {
+  $proc = Get-Process -Id $cur
+  if ($proc -and $proc.MainWindowHandle -ne [IntPtr]::Zero) {
+    # The first *windowed* ancestor decides. The Claude app means the thread is the app's own —
+    # its deep link presents it better; explorer is the chain's root, and fronting a stray File
+    # Explorer window would be plain wrong. Either way: stop, let the caller fall back.
+    if ($proc.ProcessName -eq 'claude' -or $proc.ProcessName -eq 'explorer') { exit 1 }
+    $h = $proc.MainWindowHandle
+    if ([BotCrossingFocus]::IsIconic($h)) { [BotCrossingFocus]::ShowWindowAsync($h, 9) | Out-Null }
+    [BotCrossingFocus]::keybd_event(0xA4, 0, 0, [UIntPtr]::Zero)
+    [BotCrossingFocus]::keybd_event(0xA4, 0, 2, [UIntPtr]::Zero)
+    [BotCrossingFocus]::SetForegroundWindow($h) | Out-Null
+    'focused'
+    exit 0
+  }
+  if (-not $parent.ContainsKey($cur)) { break }
+  $next = $parent[$cur]
+  if ($next -eq $cur) { break }
+  $cur = $next
+}
+exit 1
+`
+
+/**
+ * Front the window hosting `pid`. True only when a window was actually found and told to come
+ * forward; false covers everything else — wrong platform, a chain with no window on it (a
+ * detached process, or one hosted by the Claude desktop app), or PowerShell being unavailable.
+ * The caller treats false as "use the URL instead", so failing quietly is the whole contract.
+ */
+export async function focusWindowOfPid(pid) {
+  if (process.platform !== 'win32') return false
+  if (!Number.isInteger(pid) || pid <= 0) return false
+  try {
+    // -EncodedCommand sidesteps every quoting rule cmd and PowerShell disagree on.
+    const encoded = Buffer.from(script(pid), 'utf16le').toString('base64')
+    const { stdout } = await execFileAsync(
+      'powershell.exe',
+      ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-EncodedCommand', encoded],
+      { timeout: FOCUS_TIMEOUT_MS, windowsHide: true }
+    )
+    return stdout.includes('focused')
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
## What

When a thread was started from a terminal and its CLI process is still alive, clicking **open** now brings the terminal window that hosts it to the front, instead of falling through to `claude://resume` — which imports the transcript into the Claude desktop app as a second, untitled session.

## How

- **`server/harnesses/claude-code.mjs`**: for threads the desktop app has never seen, the adapter looks the session up in the live registry (`~/.claude/sessions`), probes the pid, and hands it along as `pid` on the open result. Threads with a desktop record are untouched — `epitaxy` already navigates to the tab the app has.
- **`server/lib/windows.mjs`** (new, sibling of `xdg.mjs`): `focusWindowOfPid(pid)` walks the process's parent chain to the first ancestor with a real main window — the CLI process itself has none; the window belongs to Windows Terminal, an IDE, or classic conhost — and fronts it (restore-if-minimized + the transient-Alt exemption so `SetForegroundWindow` is honoured from a background process). The walk stops deliberately at the Claude desktop app (its deep link presents the thread better) and at `explorer` (fronting a stray File Explorer window would be plain wrong); both fall back to the URL.
- **`server/api.mjs`**: `present()` tries the window first when a `pid` rides along, and only then hands the URL to the opener, exactly as before.

Windows-only for now — `focusWindowOfPid` returns `false` on other platforms, so behaviour there is unchanged. The same seam would take an AppleScript implementation for macOS.

## Tested

On Windows 11, against the live session registry on my machine:

- a thread running inside Windows Terminal → the WT window comes to the front ✔
- a thread running inside PhpStorm's terminal → PhpStorm comes to the front ✔
- a thread hosted by the Claude desktop app itself (chain: `claude → claude[window]`) → helper declines, deep link runs as before ✔
- `npm test`: 33/33 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)