### PR TITLE
claude-code: draw a thread's live subagents on the map

### DIFF
--- a/server/harnesses/README.md
+++ b/server/harnesses/README.md
@@ -96,6 +96,7 @@ what earns a repo its own zone, and `lastActivityAt` is what sorts the whole map
 | `sizeBytes` | number | Transcript size. **This is how finished a building looks**, on a log scale |
 | `source` | string | Free-form, for your own bookkeeping (the Claude adapter uses `desktop` / `cli`) |
 | `canOpen` | boolean | Whether this thread can be opened. The UI greys the button out |
+| `subagents` | array | Optional. Errands this thread has out *right now*: `{ id, task, lastActivityAt }`. Drawn as small companions at the parent's building — no zone, no badge, not counted. Omit it and nothing changes |
 | `ref` | object | **Opaque.** Whatever *you* need to find this thread again |
 
 ### About `ref`

--- a/server/harnesses/claude-code.mjs
+++ b/server/harnesses/claude-code.mjs
@@ -89,6 +89,21 @@ const HEAD_BYTES = 192 * 1024
 const ACTIVE_WINDOW_MS = 30 * 60 * 1000
 
 /**
+ * How long a subagent's transcript may sit untouched before its errand counts as abandoned.
+ * A subagent runs inside its parent's process, so the pid probe the rest of this file uses does
+ * not exist for it, and one that is thinking writes nothing for minutes at a time — at two or
+ * three minutes they blink out while still working.
+ */
+const SUBAGENT_WINDOW_MS = 10 * 60 * 1000
+
+/**
+ * A brief can be long: 36 of 147 transcripts on this machine open with more than 8 KB, the
+ * largest at 17 KB. `readHead` drops a trailing partial line, so a head that is too small yields
+ * nothing at all rather than a truncated task.
+ */
+const SUBAGENT_HEAD_BYTES = 64 * 1024
+
+/**
  * Every id this adapter hands out is prefixed. `server/harnesses/README.md` asks for ids unique
  * across harnesses, and while two UUIDs will not collide, the colony keys its archive list and
  * saved layout on this string — so it is worth being unambiguous rather than merely lucky.
@@ -267,6 +282,74 @@ async function scanLiveSessions() {
   return live
 }
 
+/** Briefs, kept until the file changes — the mtime cache `transcriptMeta` establishes. */
+const subagentCache = new Map()
+
+/** The prompt a parent handed its subagent, which is the only thing about an errand worth showing. */
+async function subagentTask(file, mtime) {
+  const cached = subagentCache.get(file)
+  if (cached && cached.mtime === mtime) return cached.task
+  let task = ''
+  // Not simply the first record, and sometimes not there at all: a forked subagent opens with a
+  // `fork-context-ref` and inherits its parent's context instead of being briefed, so it has no
+  // task text to find. Same test `readTranscriptMeta` puts to a thread's first prompt.
+  for (const record of jsonLines(await readHead(file, SUBAGENT_HEAD_BYTES).catch(() => ''))) {
+    if (record.type !== 'user' || !record.message) continue
+    const text = cleanPrompt(firstText(record.message.content))
+    if (text && !text.startsWith('<')) {
+      task = text
+      break
+    }
+  }
+  subagentCache.set(file, { mtime, task })
+  return task
+}
+
+/**
+ * The subagents a session has out right now, keyed by the session that sent them. Their
+ * transcripts live one level below the session's own, in
+ * `<project>/<sessionId>/subagents/agent-<id>.jsonl`.
+ *
+ * Only sessions with a live process are walked. Every other session on disk has subagent
+ * transcripts too, and all of that work would be thrown away: an errand cannot outlive the
+ * process running it.
+ */
+async function scanSubagents(livePending) {
+  const byParent = new Map()
+  const live = await livePending
+  if (!live.size) return byParent
+  const seen = new Set()
+  const cutoff = Date.now() - SUBAGENT_WINDOW_MS
+  for (const projectDir of await listDirs(CLI_PROJECTS)) {
+    for (const sessionDir of await listDirs(projectDir)) {
+      const parent = path.basename(sessionDir)
+      if (!live.has(parent)) continue
+      const dir = path.join(sessionDir, 'subagents')
+      for (const file of await listFiles(dir, (n) => n.endsWith('.jsonl'))) {
+        const stat = await fsp.stat(file).catch(() => null)
+        if (!stat || stat.mtimeMs < cutoff) continue
+        // A subagent that has handed its answer back is finished however recently it wrote —
+        // the same question `awaitingReply` asks of a thread, put to the errand's own transcript.
+        seen.add(file)
+        if (await awaitingReply(file)) continue
+        const out = byParent.get(parent) || []
+        out.push({
+          id: path.basename(file, '.jsonl'),
+          task: await subagentTask(file, stat.mtimeMs),
+          lastActivityAt: stat.mtimeMs,
+        })
+        byParent.set(parent, out)
+      }
+    }
+  }
+  // Errands are many and short-lived, so the cache is pruned to what this pass actually saw
+  // rather than growing for the life of the process the way the thread cache can afford to.
+  for (const file of subagentCache.keys()) {
+    if (!seen.has(file)) subagentCache.delete(file)
+  }
+  return byParent
+}
+
 /** Every thread the desktop app has a record for. */
 async function scanDesktopSessions() {
   const out = []
@@ -340,10 +423,14 @@ function toThread(t) {
 }
 
 async function scanThreads() {
-  const [desktop, transcripts, live] = await Promise.all([
+  // The subagent walk needs the live set, and waiting for it here would serialise scans the
+  // README says must never block — so it is handed the promise and waits on it itself.
+  const livePending = scanLiveSessions()
+  const [desktop, transcripts, live, subagents] = await Promise.all([
     scanDesktopSessions(),
     scanTranscripts(),
-    scanLiveSessions(),
+    livePending,
+    scanSubagents(livePending),
   ])
   const byId = new Map()
   const add = (thread) => {
@@ -476,6 +563,8 @@ async function scanThreads() {
     // A thread that handed the turn back wants you, whether or not the desktop app has ever seen
     // it — the only way a terminal-only thread can ask for anything at all.
     if (waiting) thread.unread = true
+    const errands = subagents.get(thread.cliSessionId)
+    if (errands) thread.subagents = errands
   }
   return threads.map(toThread)
 }

--- a/src/agents/astronauts.js
+++ b/src/agents/astronauts.js
@@ -40,6 +40,14 @@ const AGENT_LOOK = {
   leaving: { trim: 0x6f7f75, eye: [1.0, 1.0, 1.1] },
 }
 
+/** Small enough that a cluster of them reads as one thread's fan-out rather than as more threads. */
+const SUBAGENT_SIZE = 0.45
+/**
+ * One livery whatever the errand is doing. Deliberately not the gold of `celebrating`, which the
+ * colony spends on a merged PR — a fan-out is not a celebration.
+ */
+const SUBAGENT_LOOK = { trim: 0x7f6fc9, eye: [1.5, 1.2, 3.0] }
+
 const WALK_SPEED = 2.1
 const TURN_RATE = 7.5
 /**
@@ -512,6 +520,10 @@ export class Astronauts {
       id: entry.id,
       thread: entry.thread,
       status: entry.status,
+      subagent: Boolean(entry.subagent),
+      task: entry.task || '',
+      activeAt: entry.activeAt || 0,
+      size: entry.subagent ? SUBAGENT_SIZE : 1,
       site: entry.site ? entry.site.clone() : new THREE.Vector3(),
       // The thing being worked on, and where round it this astronaut is standing to do it.
       anchor: entry.anchor ? entry.anchor.clone() : null,
@@ -596,7 +608,8 @@ export class Astronauts {
 
   /** Status change → new behaviour, new trim, new eye colour. */
   _applyStatus(agent, status) {
-    const look = AGENT_LOOK[status] || AGENT_LOOK.idle
+    let look = AGENT_LOOK[status] || AGENT_LOOK.idle
+    if (agent.subagent) look = SUBAGENT_LOOK
     agent.trim.set(look.trim)
     agent.eye.setRGB(look.eye[0], look.eye[1], look.eye[2])
     agent.loop = FACE_LOOPS[status] || null
@@ -1168,7 +1181,7 @@ export class Astronauts {
       // agent than there are slots, which is exactly when the colony would empty.
       if (i >= this.capacity) break
       if (agent.state === 'gone') continue
-      const s = agent.scale
+      const s = agent.scale * (agent.size ?? 1)
       if (s <= 0.001) continue
 
       // Root transform for the whole character. The rig is authored at 2.2 units tall, so
@@ -1272,7 +1285,7 @@ export class Astronauts {
 
     for (const agent of this.agents) {
       if (agent.scale < 0.3 || agent.state === 'gone') continue
-      v.set(agent.pos.x, agent.pos.y + (this.headHeight || 0.75), agent.pos.z).project(camera)
+      v.set(agent.pos.x, agent.pos.y + (this.headHeight || 0.75) * (agent.size ?? 1), agent.pos.z).project(camera)
       if (v.z > 1) continue // behind the camera
       agent.screen.copy(v)
       const dx = (v.x - ndcX) * aspect
@@ -1328,6 +1341,7 @@ export class Astronauts {
   }
 
   setHover(agent) {
+    if (agent) this.hoverRing.scale.setScalar(agent.size ?? 1)
     this.hoverRing.visible = Boolean(agent)
     if (agent) this.hoverRing.position.set(agent.pos.x, agent.pos.y + 0.03, agent.pos.z)
   }
@@ -1346,7 +1360,7 @@ export class Astronauts {
         this.selectRing.position.set(a.pos.x, a.pos.y + 0.035, a.pos.z)
         this.selectRing.rotation.y = elapsed * 0.6
         const s = 1 + Math.sin(elapsed * 3) * 0.05
-        this.selectRing.scale.setScalar(s)
+        this.selectRing.scale.setScalar(s * (a.size ?? 1))
       }
     }
     if (this.hoverRing.visible) this.hoverRing.rotation.y = -elapsed * 0.4

--- a/src/game/colony.js
+++ b/src/game/colony.js
@@ -45,6 +45,11 @@ const STALE_MS = 3 * 24 * 60 * 60 * 1000
 const AGENT_RADIUS = 0.26
 /** Progress a live thread adds per second, so a working site visibly grows while you watch. */
 const LIVE_GROWTH = 0.004
+/**
+ * How many subagents one thread may show at once. A wide fan-out is a detail of how somebody
+ * split their work, not something the colony owes the map in full.
+ */
+const MAX_SUBAGENTS = 4
 /** How many zones' positions to remember, including repos with nothing running in them. */
 const LAYOUT_MEMORY = 80
 
@@ -317,6 +322,9 @@ export class Colony {
     }
 
     const roster = []
+    // Subagents ride at the end of the roster on purpose: `setRoster` truncates at `maxAgents`
+    // — 40 on the lowest preset — and an errand must never push a real thread off the map.
+    const entourage = []
     const seenBuildings = new Set()
     const stats = { agents: 0, projects: projects.length }
     for (const key of STATUS_ORDER) stats[key] = 0
@@ -343,17 +351,32 @@ export class Colony {
         const building = this._syncBuilding(thread, plot, i)
         seenBuildings.add(thread.id)
 
+        const site = this._workSite(plot, building, i)
         roster.push({
           id: thread.id,
           thread,
           status,
-          site: this._workSite(plot, building, i),
+          site,
           // Where the work actually is. A working astronaut circles it rather than standing
           // at one spot, so it needs the building, not just a place to stand near it.
           anchor: building.mesh.position.clone(),
           // Already on the colony's books, so it does not need an entrance.
           known: knownIds.has(thread.id),
         })
+
+        for (const sub of (thread.subagents || []).slice(0, MAX_SUBAGENTS)) {
+          entourage.push({
+            id: `${thread.id}/${sub.id}`,
+            thread,
+            status: 'working',
+            subagent: true,
+            task: sub.task,
+            activeAt: sub.lastActivityAt,
+            site,
+            anchor: building.mesh.position.clone(),
+            known: true,
+          })
+        }
       })
     }
 
@@ -368,7 +391,7 @@ export class Colony {
     this.activePlots = active
     this._rebuildNavigation()
     this.stats = { ...stats, done: stats.celebrating }
-    this.astronauts.setRoster(roster, this._world())
+    this.astronauts.setRoster([...roster, ...entourage], this._world())
     return this.stats
   }
 
@@ -753,6 +776,8 @@ export class Colony {
   }
 
   _badgeFor(agent) {
+    // An errand has no state of its own to report; its parent's badge already speaks for it.
+    if (agent.subagent) return BADGE.none
     if (agent.state === 'spawning') return BADGE.spawning
     if (agent.state === 'leaving') return BADGE.leaving
     // Badges only appear once an astronaut has actually reached its post — a stream of
@@ -768,6 +793,9 @@ export class Colony {
 
     for (const agent of this.astronauts.agents) {
       if (agent.scale < 0.5) continue
+      // Half-size bodies throwing full-size sparks read as a rendering fault, and the parent is
+      // already emitting for the same building.
+      if (agent.subagent) continue
       // What this one is standing on, which on a plot is the deck rather than the terrain
       // under it. Everything thrown off an astronaut has to land back on the same surface.
       const ground = agent.groundY || 0

--- a/src/main.js
+++ b/src/main.js
@@ -177,7 +177,7 @@ const actions = {
    * behaviour you actually want and the reason this is a timestamp rather than a flag.
    */
   markViewed: () => {
-    const thread = threads.find((t) => t.id === selectedId)
+    const thread = actionableThread()
     if (!thread) return
     state.viewedAt = { ...(state.viewedAt || {}), [thread.id]: Date.now() }
     queueSave()
@@ -223,7 +223,7 @@ const actions = {
   },
 
   openThread: async () => {
-    const thread = threads.find((t) => t.id === selectedId)
+    const thread = actionableThread()
     if (!thread) return
     try {
       await openThread(thread)
@@ -240,7 +240,7 @@ const actions = {
   // the astronaut walks back to the ship. The harness's own records are never touched — see
   // `reconcileArchived` in server/api.mjs for why that stopped being worth doing.
   archiveThread: () => {
-    const thread = threads.find((t) => t.id === selectedId)
+    const thread = actionableThread()
     if (!thread) return
     const foldedBefore = new Set(colony.dormantProjects || [])
     state.archived = [...new Set([...state.archived, thread.id])]
@@ -278,6 +278,20 @@ hud.setSideWidth(sideWidth())
 window.addEventListener('resize', () => hud.setSideWidth(sideWidth()))
 
 // ── selection ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * The thread the card's actions apply to, or null when a subagent is selected. An errand has no
+ * session of its own to open, archive or dismiss, and silently doing nothing is how a button
+ * teaches somebody that the whole card is broken.
+ */
+function actionableThread() {
+  const thread = threads.find((t) => t.id === selectedId)
+  if (thread) return thread
+  if (selectedId && colony.agentFor(selectedId)?.subagent) {
+    hud.toast('That is a subagent — select the thread that sent it')
+  }
+  return null
+}
 
 function select(id, { fly = false } = {}) {
   selectedId = id

--- a/src/ui/hud.js
+++ b/src/ui/hud.js
@@ -584,31 +584,46 @@ export class Hud {
     this.selected = { agent, thread }
     card.classList.add('on')
 
-    this.$('.thread-pop .title').textContent = thread.title || 'Untitled thread'
-    const status = STATUS_LABEL[agent.status] || agent.status
+    // An errand is not the thread it was sent from: it carries a brief instead of a title, and
+    // has no branch, model or progress of its own. Showing its parent's card here would say
+    // something true about the wrong astronaut.
+    const errand = Boolean(agent.subagent)
+    this.$('.thread-pop .title').textContent = errand
+      ? agent.task || 'Subagent'
+      : thread.title || 'Untitled thread'
+    const status = errand ? 'Subagent' : STATUS_LABEL[agent.status] || agent.status
     const meta = this.$('.thread-pop .meta')
     const bits = [
       `<span class="tag"><i class="swatch" style="background:${hex(agent.trim.getHex())}"></i>${escapeHtml(status)}</span>`,
     ]
-    // The repo is the panel's own heading now, so the card says what the *thread* is.
-    if (thread.worktree) bits.push(`<span class="tag">⑂ ${escapeHtml(thread.worktree)}</span>`)
-    if (thread.gitBranch) bits.push(`<span class="tag">${escapeHtml(thread.gitBranch)}</span>`)
-    if (thread.model) bits.push(`<span class="tag">${escapeHtml(shortModel(thread.model))}</span>`)
-    bits.push(`<span>${ago(thread.lastActivityAt)}</span>`)
+    if (errand) {
+      bits.push(`<span class="tag">${escapeHtml(thread.title || 'Untitled thread')}</span>`)
+      bits.push(`<span>${ago(agent.activeAt || thread.lastActivityAt)}</span>`)
+    } else {
+      // The repo is the panel's own heading now, so the card says what the *thread* is.
+      if (thread.worktree) bits.push(`<span class="tag">⑂ ${escapeHtml(thread.worktree)}</span>`)
+      if (thread.gitBranch) bits.push(`<span class="tag">${escapeHtml(thread.gitBranch)}</span>`)
+      if (thread.model) bits.push(`<span class="tag">${escapeHtml(shortModel(thread.model))}</span>`)
+      bits.push(`<span>${ago(thread.lastActivityAt)}</span>`)
+    }
     meta.innerHTML = bits.join('')
 
-    const pct = Math.round((this.actions.progressFor?.(thread.id) ?? 0) * 100)
+    const pct = errand ? 0 : Math.round((this.actions.progressFor?.(thread.id) ?? 0) * 100)
     this.$('.thread-pop .progress > i').style.width = `${pct}%`
     this.$('.thread-pop .progress > i').style.background = hex(agent.trim.getHex())
     // Measured once per selection rather than per frame: placing the card beside its
     // astronaut needs its size sixty times a second, and asking the layout for it that
     // often is how a HUD starts costing frames.
     this._cardSize = { w: card.offsetWidth, h: card.offsetHeight }
-    this.$('#btn-open').disabled = thread.canOpen === false
+    // Nothing here acts on an errand: there is no session to hand back, and archiving it would
+    // hide a thread nobody archived. Disabled rather than hidden, so the card does not resize
+    // as the selection moves between an astronaut and one of its subagents.
+    this.$('#btn-open').disabled = errand || thread.canOpen === false
+    this.$('#btn-archive').disabled = errand
     // Only offered when there is something to dismiss. A third button on every card would
     // crowd the two that are always worth having, and "Viewed" on a thread that is not asking
     // for anything is a control with no effect.
-    this.$('#btn-viewed').hidden = !thread.unread
+    this.$('#btn-viewed').hidden = errand || !thread.unread
   }
 
   /**

--- a/test/harness.test.mjs
+++ b/test/harness.test.mjs
@@ -148,6 +148,69 @@ test('an absent Codex is simply not detected', async () => {
   await fsp.rm(home, { recursive: true, force: true })
 })
 
+// ── subagents ─────────────────────────────────────────────────────────────────
+
+/**
+ * A Claude Code home with one live CLI session and one subagent under it. The pid is this
+ * process's own, which is the only pid a test can be sure is alive when the scan probes it.
+ */
+async function fakeClaude(errandRecords) {
+  const home = await fsp.mkdtemp(path.join(os.tmpdir(), 'claude-home-'))
+  const session = '11111111-2222-4333-8444-555555555555'
+  const project = path.join(home, '.claude', 'projects', '-tmp-demo')
+  await fsp.mkdir(path.join(project, session, 'subagents'), { recursive: true })
+  await fsp.mkdir(path.join(home, '.claude', 'sessions'), { recursive: true })
+  await fsp.writeFile(
+    path.join(project, `${session}.jsonl`),
+    `${JSON.stringify({ type: 'user', cwd: '/tmp/demo', message: { content: 'build the thing' } })}\n`
+  )
+  await fsp.writeFile(
+    path.join(home, '.claude', 'sessions', `${process.pid}.json`),
+    JSON.stringify({ pid: process.pid, sessionId: session, cwd: '/tmp/demo', status: 'busy' })
+  )
+  await fsp.writeFile(
+    path.join(project, session, 'subagents', 'agent-abc.jsonl'),
+    errandRecords.map((r) => `${JSON.stringify(r)}\n`).join('')
+  )
+  return home
+}
+
+async function claudeWith(home) {
+  process.env.HOME = home
+  const mod = await import(`../server/harnesses/claude-code.mjs?${home}`)
+  return mod.default
+}
+
+const midTurn = { type: 'assistant', message: { content: [{ type: 'tool_use' }], stop_reason: 'tool_use' } }
+
+test('a running subagent is reported with the brief it was given, however long that is', async () => {
+  const realHome = process.env.HOME
+  // Longer than any head this could reasonably read at once: a brief that is truncated away
+  // yields no task at all, because readHead drops the line it lands in the middle of.
+  const brief = `repair the raster pipeline ${'x'.repeat(20 * 1024)}`
+  const home = await fakeClaude([{ type: 'user', message: { content: brief } }, midTurn])
+  const h = await claudeWith(home)
+  const [thread] = await h.scanThreads()
+  assert.equal(thread.subagents?.length, 1)
+  assert.equal(thread.subagents[0].id, 'agent-abc')
+  assert.match(thread.subagents[0].task, /^repair the raster pipeline/)
+  process.env.HOME = realHome
+  await fsp.rm(home, { recursive: true, force: true })
+})
+
+test('a subagent that has handed its answer back is finished, however recently it wrote', async () => {
+  const realHome = process.env.HOME
+  const home = await fakeClaude([
+    { type: 'user', message: { content: 'summarise the diff' } },
+    { type: 'assistant', message: { content: [{ type: 'text', text: 'here it is' }], stop_reason: 'end_turn' } },
+  ])
+  const h = await claudeWith(home)
+  const [thread] = await h.scanThreads()
+  assert.equal(thread.subagents, undefined, 'a finished errand is not an astronaut on the map')
+  process.env.HOME = realHome
+  await fsp.rm(home, { recursive: true, force: true })
+})
+
 // ── shared helpers ────────────────────────────────────────────────────────────
 
 test('readTail drops the partial line it lands in the middle of', async () => {


### PR DESCRIPTION
Claude Code subagents run inside their parent's session and leave a transcript in
`<project>/<sessionId>/subagents/agent-<id>.jsonl`. Nothing on the map showed them, so a thread
that had fanned out to four agents looked exactly like one sitting still.

**What it does.** The adapter reports an optional `subagents` array on a thread —
`{ id, task, lastActivityAt }` — and the colony draws each as a half-height astronaut working the
parent's building: no building, no zone, no badge, in no statistic, capped at four. They ride at
the end of the roster because `setRoster` truncates at `maxAgents`, which is 40 on the lowest
preset — an errand must never push a real thread off the map.

Selecting one shows its brief and the thread that sent it, rather than rendering the parent's card
beside somebody else's astronaut. Open/Archive/Viewed are disabled there, and the keyboard
shortcuts say why instead of silently doing nothing.

**Liveness, with no pid to probe.** A subagent runs inside its parent's process, so the probe the
rest of the adapter uses does not exist for it. Two cheap tests instead: the transcript's mtime
inside a 10-minute window — at two or three minutes they blink out while still thinking — and
`awaitingReply` on the errand's own transcript, since one that has handed its answer back is
finished however recently it wrote. Only sessions with a live process are walked, briefs are cached
against mtime, and the cache is pruned to what each pass saw.

**Cost**, measured against my own store (146 subagent transcripts across 39 session directories):
`scanThreads()` 6.4 ms median with the walk against 3.3 ms without — **+3.1 ms on a 15 s poll**.
Cold first call +4.6 ms on ~70 ms, where the 70 ms is `transcriptMeta` and not this. Removing the
mtime gate so every brief is read triples the walk to 13.9 ms: that gate is the cost model rather
than an optimisation, which is why it carries a comment.

**Interface.** `subagents` is a new optional field, so the Thread table in
`server/harnesses/README.md` has a row for it. It is not a Claude Code concept: the Codex adapter
already filters `thread_spawn_edges` children with *"Threads a task spawned are not conversations
anybody had"* — that comment is this feature's premise, and Codex could fill the same field later
without a client change.

**Verified.** `npm test` green, 35 including two new fixtures: a running errand with a 20 KB brief
(a head too small returns nothing at all, because `readHead` drops the partial line it lands in),
and a finished errand that must not appear. Run against a real store for an afternoon with one to
four errands live at a time. No new dependencies, nothing new written to disk.

**Known limits, deliberately not fixed here.** A run aborted mid-turn still reads as working until
the window expires — 4 of 147 transcripts here. Separation and the pick radius still use full-size
constants, so a half-height errand holds a full helmet of air around it; that is astronaut physics
and a different change. And a *forked* subagent opens with `fork-context-ref` and inherits its
parent's context instead of being briefed, so it has no task text to show at all (6 of 147).
