### PR TITLE
Shared colonies: visit a teammate's colony read-only over the LAN

### DIFF
--- a/docs/superpowers/specs/2026-09-09-shared-colonies-design.md
+++ b/docs/superpowers/specs/2026-09-09-shared-colonies-design.md
@@ -1,0 +1,102 @@
+# Shared colonies over the intranet — design
+
+Approved 2026-09-09. Visiting model: **merged map** — a neighbour's repos appear as their own
+district on your map, read-only.
+
+## What it is
+
+Two Bot Crossing installs on one LAN can share their colonies. Sharing is off by default. When
+Chantal turns it on, her machine answers a read-only guest API; when Dimitri adds her as a
+neighbour, her repos rise as a named district ("Chantal") beside his own, her astronauts walking
+and building from her live status data. Nothing on her machine can be opened, archived or
+started from his map — not as a permission, but because the routes do not exist on the socket
+he talks to.
+
+## Components
+
+### 1. Guest listener — `server/guest.mjs`
+
+A second HTTP server, opened only while sharing is on, bound to `0.0.0.0:5275`
+(`BOT_CROSSING_GUEST_PORT` overrides). It serves exactly:
+
+- `GET /guest/info` → `{ app: 'bot-crossing', name, version, instanceId }`
+- `GET /guest/threads` → the same scan the owner sees, minus anything actionable: `ref` is
+  stripped, `canOpen` forced false. Transcript paths and pids never leave the adapter anyway.
+
+No static files, no other routes — action endpoints are absent by construction, which is the
+whole security story. The owner's own UI stays on `127.0.0.1:5274`, unreachable from the LAN.
+
+### 2. Discovery — `server/discovery.mjs`
+
+UDP on port 5276 (`BOT_CROSSING_DISCOVERY_PORT`).
+
+- **Announce** (only while sharing): broadcast `{ v: 1, app: 'bot-crossing', name, guestPort,
+  instanceId }` every 15 s, and once immediately on enable.
+- **Listen** (always): collect announcements into a peers list `{ name, host, guestPort,
+  lastSeen }`, expiring after 60 s. Own announcements are recognised by `instanceId` (random
+  per boot) and dropped.
+
+Broadcast does not cross subnets; that is what manual adding is for.
+
+### 3. Neighbours — `server/neighbors.mjs`
+
+Configured neighbours live in `colony.json` under `network.neighbors: [{ name, host, port }]`,
+alongside `network.share: boolean` and `network.colonyName: string`. The page manages them
+through the existing `PUT /api/state` flow; the server watches that write and starts/stops the
+guest listener and announcer to match.
+
+Each poll of `/api/threads` triggers a background refresh per neighbour — `GET
+http://host:port/guest/threads` with a 2 s abort — and merges the **cached** last-good answer,
+so a slow or dead neighbour never delays the owner's own map. Guest threads are tagged:
+
+- `id` → `guest:<host>:<id>` (can never collide with a local id)
+- `colony: <name>`, `canOpen: false`, no `ref`
+
+The merged payload also carries `colonies: [{ name, host, online }]` so the page can dim an
+offline district instead of dropping it.
+
+New read endpoint: `GET /api/neighbors` → `{ configured: [...with online flags],
+discovered: [...from UDP, minus already-configured] }`.
+
+### 4. Map — merged districts
+
+Each neighbour gets a **landing beacon**: an anchor cell at a bearing derived from the colony
+name, placed beyond the owner's own zones. A guest repo's zone seeds from that beacon the way
+local zones seed from the ship, so a neighbour's repos cluster into a recognisable district
+rather than interleaving. A name banner floats over the district; guest plots carry the
+neighbour's accent. Offline: the district stays (layout is remembered in `colony.json` like any
+zone) and dims with an offline badge.
+
+### 5. Read-only in the UI
+
+Guest threads and plots show their info on click, but open / archive / new-conversation actions
+are absent for them (`canOpen` false, no `ref`, and the zone deck's "new conversation" is
+hidden for guest districts). The server refuses actions on `guest:`-prefixed ids regardless.
+
+### 6. Settings
+
+In the S-panel, a Network section: colony name (default: OS username), share toggle (default
+off), configured neighbours with online dots and remove, discovered neighbours with an add
+button, manual host:port entry.
+
+## Testing
+
+- Unit: guest listener allowlist (action routes 404 on the guest socket; `ref` stripped),
+  neighbour merge tagging (prefix, `canOpen`, collision safety), discovery parse/expiry.
+- End-to-end on one machine: a second instance with its own `BOT_CROSSING_DATA` dir and ports
+  plays Chantal; verify her district renders, actions are refused, and unplugging her (killing
+  the instance) dims the district.
+
+## Out of scope (deliberately)
+
+- Fetching a neighbour's own zone layout (`/guest/state`): the merged map lays guest zones out
+  itself, so the endpoint is not built.
+- Transitive sharing (seeing Chantal's neighbours), auth/allowlists beyond the LAN boundary,
+  TLS: the trust model is "same intranet, opt-in, read-only socket".
+- macOS/Linux parity concerns: everything here is plain Node networking, platform-neutral.
+
+## Practical notes
+
+- Both machines need this build; sharing must be switched on by its owner.
+- Windows Firewall will ask once, per machine, to allow node inbound on private networks
+  (guest port 5275/TCP and discovery 5276/UDP).

--- a/docs/superpowers/specs/2026-09-09-shared-colonies-design.md
+++ b/docs/superpowers/specs/2026-09-09-shared-colonies-design.md
@@ -91,8 +91,22 @@ button, manual host:port entry.
 
 - Fetching a neighbour's own zone layout (`/guest/state`): the merged map lays guest zones out
   itself, so the endpoint is not built.
-- Transitive sharing (seeing Chantal's neighbours), auth/allowlists beyond the LAN boundary,
-  TLS: the trust model is "same intranet, opt-in, read-only socket".
+- Transitive sharing (seeing Chantal's neighbours) and TLS: the trust model is "same intranet,
+  opt-in, read-only, mutual-add".
+
+## Amendment 2026-09-09: opt-in allowlist and origin check
+
+Two tightenings landed after the first cut, both after review:
+
+- **Per-session opt-in** (`network.shared`): sharing exposes only the sessions and repos on an
+  allowlist, empty by default, so "share on" never means "share everything". Toggled by a
+  "Share with others" button on a repo and a "Share" button on a session; enforced in the guest
+  `getThreads` filter.
+- **Origin check** (`server/guest.mjs`): the guest listener answers only loopback and the hosts
+  the owner has added as neighbours, so a shared session is readable by the colleagues you chose
+  rather than by the whole LAN. This makes visiting **mutual**: to be visited, add the visitor.
+  Hosts added by name rather than IP will not match a raw remote address; discovery adds by IP,
+  which is the path that matters.
 - macOS/Linux parity concerns: everything here is plain Node networking, platform-neutral.
 
 ## Practical notes

--- a/install/Install Bot Crossing.cmd
+++ b/install/Install Bot Crossing.cmd
@@ -1,0 +1,7 @@
+@echo off
+REM Double-click this to install (or update) Bot Crossing on this PC.
+REM It sets up Node, builds the app, and makes it open when you log in.
+cd /d "%~dp0"
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0install-bot-crossing.ps1" %*
+echo.
+pause

--- a/install/README.md
+++ b/install/README.md
@@ -3,6 +3,11 @@
 One installer does everything on a Windows PC — for a brand-new machine **and** for
 updating one that already has Bot Crossing. It needs no admin rights for the app itself.
 
+> **Already have a clone you work in?** Do not run this installer — it installs a *second*
+> copy under `%LOCALAPPDATA%\BotCrossing` with its own autostart, and both would fight over
+> port 5274. Just `git pull` in the clone you already have; the installer is for a machine
+> with nothing on it yet.
+
 ## The easy way
 
 1. Copy this whole `install` folder to the PC (a USB stick or a network share is fine).

--- a/install/README.md
+++ b/install/README.md
@@ -1,0 +1,65 @@
+# Installing Bot Crossing (shared-colonies build)
+
+One installer does everything on a Windows PC — for a brand-new machine **and** for
+updating one that already has Bot Crossing. It needs no admin rights for the app itself.
+
+## The easy way
+
+1. Copy this whole `install` folder to the PC (a USB stick or a network share is fine).
+2. Double-click **`Install Bot Crossing.cmd`**.
+3. Wait — it fetches Node if needed, downloads and builds the app, and sets it to open
+   when you log in. When it finishes, the colony opens by itself.
+
+That's the whole thing for a colleague. Their own name (their Windows username) becomes
+their colony name; **sharing starts off**, so nothing leaves their machine until they turn
+it on in **Settings (S) → Shared colonies**.
+
+## Turning on sharing, and visiting each other
+
+- **To let others visit you:** open Settings → Shared colonies → *Share on the network*.
+- **To visit someone:** in that same panel, either pick a colony under *Found on your
+  network*, or type their PC's name/IP and port `5275`. Their colony appears as its own
+  district on your map — **read-only**: you see their astronauts, you can't touch their threads.
+
+The first time you turn sharing on, Windows may pop up a firewall prompt for `node` — allow
+it on **Private** networks. (Running the installer as administrator adds that rule for you.)
+
+## Options (for the person setting it up)
+
+Run from a PowerShell window instead of double-clicking to pass options:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File install-bot-crossing.ps1 -Share -Monitor 2
+```
+
+| Option | What it does |
+|---|---|
+| `-Share` | Turn sharing on right away (default: off). |
+| `-Monitor <n>` | Open the colony on monitor *n*, counted left to right (default: primary). |
+| `-InstallDir <path>` | Where to install (default: `%LOCALAPPDATA%\BotCrossing`). |
+| `-Branch <name>` | Which branch to build (default: `shared-colonies`). |
+| `-NoAutostart` | Install without the log-in autostart entry. |
+| `-NoLaunch` | Don't open the colony when the install finishes. |
+
+## Updating later
+
+Run the installer again — it pulls the newest code, rebuilds, and keeps your colony,
+your settings and your neighbour list. (For Chantal, or anyone who had the older Bot
+Crossing: just run this installer once; it gives a clean managed install with the shared
+build. The old copy can be deleted.)
+
+## What it sets up
+
+- A portable **Node 22** under the install folder, only if the PC has nothing new enough
+  — your system stays untouched.
+- The app under `…\BotCrossing\bot-crossing`, built and ready.
+- A **login autostart** entry (per-user) that opens the colony fullscreen in its own window.
+- Firewall rules for the guest port (**TCP 5275**) and discovery (**UDP 5276**) — added
+  automatically when the installer runs as admin, printed for you to paste if not.
+
+## Removing it
+
+- Delete `bot-crossing.vbs` from your Startup folder
+  (`Win+R` → `shell:startup`).
+- Delete the install folder (`%LOCALAPPDATA%\BotCrossing`).
+- If you added them: remove the two "Bot Crossing" firewall rules.

--- a/install/README.md
+++ b/install/README.md
@@ -27,7 +27,19 @@ it on in **Settings (S) → Shared colonies**.
   district on your map — **read-only**: you see their astronauts, you can't touch their threads.
 
 The first time you turn sharing on, Windows may pop up a firewall prompt for `node` — allow
-it on **Private** networks. (Running the installer as administrator adds that rule for you.)
+it. (Running the installer as administrator adds the rule for you.) The rule is opened on all
+network profiles, which is safe here: the colony only ever answers colleagues you have added,
+so an open port is not an open door.
+
+### Over a VPN (incl. FortiClient)
+
+Auto-discovery does not cross a VPN — add each other **by IP**. Find your VPN IP with
+`ipconfig` (the VPN adapter's address). It only works if the VPN lets the two machines reach
+each other directly (`ping <their VPN IP>` succeeds); many corporate SSL-VPNs block
+client-to-client by default, which their IT would have to allow for TCP 5275. If a colleague
+can reach you but is still refused, their address arrived looking different than the one you
+added (VPN NAT) — the real one shows up under **Settings → Shared colonies → "Tried to visit
+you"**, one click to add.
 
 ## Options (for the person setting it up)
 

--- a/install/install-bot-crossing.ps1
+++ b/install/install-bot-crossing.ps1
@@ -203,6 +203,9 @@ if (-not $NoAutostart) {
 }
 
 # -- 6. Firewall (best effort) ------------------------------------------------
+# Opened on ALL profiles (profile=any), not just private, so sharing also works over a VPN
+# whose adapter Windows classifies as public/domain. Safe here: the guest listener answers only
+# the colleagues the owner has added (an app-level origin check), so an open port is not open access.
 function Test-Admin {
   $id = [Security.Principal.WindowsIdentity]::GetCurrent()
   (New-Object Security.Principal.WindowsPrincipal($id)).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
@@ -211,17 +214,17 @@ if (Test-Admin) {
   try {
     netsh advfirewall firewall delete rule name="Bot Crossing guest" | Out-Null 2>&1
     netsh advfirewall firewall delete rule name="Bot Crossing discovery" | Out-Null 2>&1
-    netsh advfirewall firewall add rule name="Bot Crossing guest" dir=in action=allow protocol=TCP localport=5275 profile=private | Out-Null
-    netsh advfirewall firewall add rule name="Bot Crossing discovery" dir=in action=allow protocol=UDP localport=5276 profile=private | Out-Null
-    Ok "Firewall opened for sharing (TCP 5275, UDP 5276, private networks)"
+    netsh advfirewall firewall add rule name="Bot Crossing guest" dir=in action=allow protocol=TCP localport=5275 profile=any | Out-Null
+    netsh advfirewall firewall add rule name="Bot Crossing discovery" dir=in action=allow protocol=UDP localport=5276 profile=any | Out-Null
+    Ok "Firewall opened for sharing (TCP 5275, UDP 5276, all networks)"
   } catch {
     Warn "Could not add firewall rules automatically."
   }
 } else {
   Warn "Not running as admin - sharing needs the firewall opened once."
   Warn "If teammates cannot see this colony, run these in an elevated PowerShell:"
-  Write-Host '      netsh advfirewall firewall add rule name="Bot Crossing guest" dir=in action=allow protocol=TCP localport=5275 profile=private' -ForegroundColor DarkGray
-  Write-Host '      netsh advfirewall firewall add rule name="Bot Crossing discovery" dir=in action=allow protocol=UDP localport=5276 profile=private' -ForegroundColor DarkGray
+  Write-Host '      netsh advfirewall firewall add rule name="Bot Crossing guest" dir=in action=allow protocol=TCP localport=5275 profile=any' -ForegroundColor DarkGray
+  Write-Host '      netsh advfirewall firewall add rule name="Bot Crossing discovery" dir=in action=allow protocol=UDP localport=5276 profile=any' -ForegroundColor DarkGray
 }
 
 # -- 7. Launch ----------------------------------------------------------------

--- a/install/install-bot-crossing.ps1
+++ b/install/install-bot-crossing.ps1
@@ -1,0 +1,235 @@
+<#
+  Bot Crossing - one-shot installer for Windows (shared-colonies build).
+
+  Fresh install and update in one: sets up a portable Node 22 if the machine has
+  none new enough, fetches the code, builds it, installs an autostart entry that
+  opens the colony fullscreen in its own window, and opens the firewall for the
+  guest + discovery ports so teammates can visit.
+
+  No admin rights are needed for the app itself - Node, the code and the autostart
+  entry all live under the current user. Only the firewall rule wants elevation,
+  and the script says so and carries on if it cannot add one.
+
+  Usage (from a PowerShell window):
+      powershell -ExecutionPolicy Bypass -File install-bot-crossing.ps1
+
+  Options:
+      -InstallDir <path>   Where to put everything      (default: %LOCALAPPDATA%\BotCrossing)
+      -Branch <name>       Which branch to build        (default: shared-colonies)
+      -Monitor <n>         Which monitor to open on, 1-based left-to-right (default: primary)
+      -Share               Turn sharing on out of the box (default: off - you toggle it in-app)
+      -NoAutostart         Install without the login autostart entry
+      -NoLaunch            Do not open the colony when the install finishes
+#>
+
+param(
+  [string]$InstallDir = (Join-Path $env:LOCALAPPDATA 'BotCrossing'),
+  [string]$Branch = 'shared-colonies',
+  [int]$Monitor = 0,
+  [switch]$Share,
+  [switch]$NoAutostart,
+  [switch]$NoLaunch
+)
+
+$ErrorActionPreference = 'Stop'
+$RepoUrl = 'https://github.com/dimitrihilverda/bot-crossing.git'
+$RepoZip = "https://github.com/dimitrihilverda/bot-crossing/archive/refs/heads/$Branch.zip"
+$NodeVersion = '22.23.2'
+$RepoDir = Join-Path $InstallDir 'bot-crossing'
+
+function Say([string]$m) { Write-Host "  $m" -ForegroundColor Cyan }
+function Ok([string]$m) { Write-Host "  $m" -ForegroundColor Green }
+function Warn([string]$m) { Write-Host "  $m" -ForegroundColor Yellow }
+
+Write-Host "`nBot Crossing installer" -ForegroundColor White
+Write-Host "----------------------`n"
+New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+
+# -- 1. Node 22+ --------------------------------------------------------------
+function Test-Node([string]$exe) {
+  try {
+    $v = & $exe --version 2>$null
+    if ($v -match 'v(\d+)\.') { return [int]$Matches[1] -ge 22 }
+  } catch {}
+  return $false
+}
+
+$NodeExe = ''
+# Prefer a portable Node we installed on a previous run, then whatever is on PATH.
+$portable = Join-Path $InstallDir "node\node.exe"
+if ((Test-Path $portable) -and (Test-Node $portable)) { $NodeExe = $portable }
+elseif (Test-Node 'node') { $NodeExe = (Get-Command node).Source }
+
+if (-not $NodeExe) {
+  Say "No Node 22+ found - fetching a portable copy (no admin needed)..."
+  $arch = if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') { 'arm64' } else { 'x64' }
+  $zipName = "node-v$NodeVersion-win-$arch"
+  $zipUrl = "https://nodejs.org/dist/v$NodeVersion/$zipName.zip"
+  $zipPath = Join-Path $env:TEMP "$zipName.zip"
+  Invoke-WebRequest -Uri $zipUrl -OutFile $zipPath -UseBasicParsing
+  $nodeParent = Join-Path $InstallDir 'node-tmp'
+  if (Test-Path $nodeParent) { Remove-Item $nodeParent -Recurse -Force }
+  Expand-Archive -Path $zipPath -DestinationPath $nodeParent -Force
+  $extracted = Join-Path $nodeParent $zipName
+  $nodeFinal = Join-Path $InstallDir 'node'
+  if (Test-Path $nodeFinal) { Remove-Item $nodeFinal -Recurse -Force }
+  Move-Item $extracted $nodeFinal
+  Remove-Item $nodeParent -Recurse -Force
+  Remove-Item $zipPath -Force
+  $NodeExe = Join-Path $nodeFinal 'node.exe'
+  Ok "Node $NodeVersion ($arch) installed under $nodeFinal"
+} else {
+  Ok "Using Node at $NodeExe"
+}
+
+$NodeDir = Split-Path $NodeExe
+$NpmCli = Join-Path $NodeDir 'node_modules\npm\bin\npm-cli.js'
+function Npm([string[]]$npmArgs) {
+  & $NodeExe $NpmCli @npmArgs
+  if ($LASTEXITCODE -ne 0) { throw "npm $($npmArgs -join ' ') failed" }
+}
+
+# -- 2. The code --------------------------------------------------------------
+$gitOk = $false
+try { git --version | Out-Null; $gitOk = $true } catch {}
+
+if ($gitOk) {
+  if (Test-Path (Join-Path $RepoDir '.git')) {
+    Say "Updating the existing checkout..."
+    git -C $RepoDir fetch --depth 1 origin $Branch 2>$null
+    git -C $RepoDir checkout $Branch 2>$null
+    git -C $RepoDir reset --hard "origin/$Branch" 2>$null
+  } else {
+    Say "Cloning Bot Crossing ($Branch)..."
+    if (Test-Path $RepoDir) { Remove-Item $RepoDir -Recurse -Force }
+    git clone --depth 1 --branch $Branch $RepoUrl $RepoDir
+  }
+} else {
+  Say "Git not found - downloading a source snapshot instead..."
+  $zip = Join-Path $env:TEMP "bot-crossing-$Branch.zip"
+  Invoke-WebRequest -Uri $RepoZip -OutFile $zip -UseBasicParsing
+  $tmp = Join-Path $env:TEMP "bc-src"
+  if (Test-Path $tmp) { Remove-Item $tmp -Recurse -Force }
+  Expand-Archive -Path $zip -DestinationPath $tmp -Force
+  $inner = Get-ChildItem $tmp -Directory | Select-Object -First 1
+  if (Test-Path $RepoDir) { Remove-Item $RepoDir -Recurse -Force }
+  Move-Item $inner.FullName $RepoDir
+  Remove-Item $tmp -Recurse -Force
+  Remove-Item $zip -Force
+  Warn "Installed from a snapshot - re-run this installer to update (or install Git)."
+}
+Ok "Code is in $RepoDir"
+
+# -- 3. Build -----------------------------------------------------------------
+Push-Location $RepoDir
+try {
+  Say "Installing dependencies..."
+  Npm @('install', '--no-audit', '--no-fund')
+  Say "Building..."
+  Npm @('run', 'build')
+  Ok "Build complete"
+} finally {
+  Pop-Location
+}
+
+# -- 4. Colony name + sharing default -----------------------------------------
+$dataDir = Join-Path $RepoDir 'data'
+New-Item -ItemType Directory -Force -Path $dataDir | Out-Null
+$colonyFile = Join-Path $dataDir 'colony.json'
+$state = if (Test-Path $colonyFile) { Get-Content $colonyFile -Raw | ConvertFrom-Json } else { [pscustomobject]@{ version = 2 } }
+if (-not $state.PSObject.Properties['network']) {
+  $state | Add-Member -NotePropertyName network -NotePropertyValue ([pscustomobject]@{ colonyName = $env:USERNAME; share = [bool]$Share; neighbors = @() })
+} else {
+  if (-not $state.network.colonyName) { $state.network.colonyName = $env:USERNAME }
+  if ($Share) { $state.network.share = $true }
+}
+($state | ConvertTo-Json -Depth 12) | Set-Content -Path $colonyFile -Encoding UTF8
+Ok ("Colony name: {0}   Sharing: {1}" -f $state.network.colonyName, $(if ($state.network.share) { 'on' } else { 'off (toggle it in Settings -> Shared colonies)' }))
+
+# -- 5. Autostart + launcher --------------------------------------------------
+$startupScript = Join-Path $InstallDir 'start-bot-crossing.ps1'
+@"
+# Bot Crossing launcher - starts the server hidden and opens it fullscreen.
+`$node    = '$NodeExe'
+`$project = '$RepoDir'
+`$url     = 'http://127.0.0.1:5274'
+`$edge    = 'C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe'
+`$chrome  = 'C:\Program Files\Google\Chrome\Application\chrome.exe'
+`$profile = Join-Path `$project 'startup\browser-profile'
+`$targetMonitor = $Monitor  # 0 = primary, else 1-based left-to-right
+
+Add-Type -AssemblyName System.Windows.Forms
+`$screens = [System.Windows.Forms.Screen]::AllScreens
+if (`$targetMonitor -ge 1 -and `$targetMonitor -le `$screens.Count) {
+  `$t = (`$screens | Sort-Object { `$_.Bounds.X })[`$targetMonitor - 1]
+} else {
+  `$t = [System.Windows.Forms.Screen]::PrimaryScreen
+}
+`$x = `$t.Bounds.X; `$y = `$t.Bounds.Y; `$w = `$t.Bounds.Width; `$h = `$t.Bounds.Height
+
+`$listening = Test-NetConnection -ComputerName 127.0.0.1 -Port 5274 -InformationLevel Quiet -WarningAction SilentlyContinue
+if (-not `$listening) {
+  Start-Process -FilePath `$node -ArgumentList 'server/serve.mjs' -WorkingDirectory `$project -WindowStyle Hidden
+  for (`$i = 0; `$i -lt 60; `$i++) {
+    Start-Sleep -Milliseconds 500
+    if (Test-NetConnection -ComputerName 127.0.0.1 -Port 5274 -InformationLevel Quiet -WarningAction SilentlyContinue) { break }
+  }
+}
+
+`$browser = if (Test-Path `$edge) { `$edge } elseif (Test-Path `$chrome) { `$chrome } else { `$null }
+if (`$browser) {
+  Start-Process -FilePath `$browser -ArgumentList @(
+    "--app=`$url", "--user-data-dir=`$profile",
+    "--window-position=`$x,`$y", "--window-size=`$w,`$h",
+    '--start-fullscreen', '--no-first-run', '--no-default-browser-check'
+  )
+} else {
+  Start-Process `$url  # no Chromium browser found - open in the default browser
+}
+"@ | Set-Content -Path $startupScript -Encoding UTF8
+
+$vbs = Join-Path $InstallDir 'bot-crossing.vbs'
+@"
+Set shell = CreateObject("WScript.Shell")
+shell.Run "powershell -NoProfile -ExecutionPolicy Bypass -File ""$startupScript""", 0, False
+"@ | Set-Content -Path $vbs -Encoding ASCII
+
+if (-not $NoAutostart) {
+  $startupDir = [Environment]::GetFolderPath('Startup')
+  Copy-Item $vbs (Join-Path $startupDir 'bot-crossing.vbs') -Force
+  Ok "Autostart installed - Bot Crossing will open when you log in"
+} else {
+  Warn "Autostart skipped. Launch it any time with: $vbs"
+}
+
+# -- 6. Firewall (best effort) ------------------------------------------------
+function Test-Admin {
+  $id = [Security.Principal.WindowsIdentity]::GetCurrent()
+  (New-Object Security.Principal.WindowsPrincipal($id)).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+if (Test-Admin) {
+  try {
+    netsh advfirewall firewall delete rule name="Bot Crossing guest" | Out-Null 2>&1
+    netsh advfirewall firewall delete rule name="Bot Crossing discovery" | Out-Null 2>&1
+    netsh advfirewall firewall add rule name="Bot Crossing guest" dir=in action=allow protocol=TCP localport=5275 profile=private | Out-Null
+    netsh advfirewall firewall add rule name="Bot Crossing discovery" dir=in action=allow protocol=UDP localport=5276 profile=private | Out-Null
+    Ok "Firewall opened for sharing (TCP 5275, UDP 5276, private networks)"
+  } catch {
+    Warn "Could not add firewall rules automatically."
+  }
+} else {
+  Warn "Not running as admin - sharing needs the firewall opened once."
+  Warn "If teammates cannot see this colony, run these in an elevated PowerShell:"
+  Write-Host '      netsh advfirewall firewall add rule name="Bot Crossing guest" dir=in action=allow protocol=TCP localport=5275 profile=private' -ForegroundColor DarkGray
+  Write-Host '      netsh advfirewall firewall add rule name="Bot Crossing discovery" dir=in action=allow protocol=UDP localport=5276 profile=private' -ForegroundColor DarkGray
+}
+
+# -- 7. Launch ----------------------------------------------------------------
+Write-Host ""
+Ok "Done."
+if (-not $NoLaunch) {
+  Say "Opening Bot Crossing..."
+  & wscript $vbs
+}
+Write-Host "`nVisit a teammate: open Settings (S) -> Shared colonies. Turn sharing on to let"
+Write-Host "others visit you; add or pick a discovered colony to visit theirs (read-only).`n"

--- a/server/api.mjs
+++ b/server/api.mjs
@@ -438,10 +438,34 @@ function applyNetwork(network) {
   }
 }
 
+/**
+ * Keep the network sockets alive without a human toggling anything.
+ *
+ * Sleep, a Wi-Fi drop or an IP change can leave the guest listener or the discovery socket
+ * dead — and before this the only cure was switching sharing off and on, on *both* machines,
+ * because the sharer's socket had quietly died. This tick re-asserts the intended state every
+ * `RECONCILE_MS`: it rebinds discovery, heals a dropped guest listener, and re-announces, all
+ * idempotent so a healthy machine does nothing. The visitor side already recovers on its own —
+ * its neighbour poll retries every few seconds — so once the sharer's socket is back, the
+ * district returns without anyone touching a switch.
+ */
+const RECONCILE_MS = 15 * 1000
+function reconcileNetwork() {
+  if (!currentNetwork) return
+  discovery.listen() // no-op if the socket is up; rebinds if it dropped
+  if (currentNetwork.share) {
+    if (guest.needsHeal) guest.start()
+    discovery.setAnnounce(true, { name: currentNetwork.colonyName, guestPort: guest.port })
+  }
+}
+
 /** Boot wiring: read the file once, start listening for peers, honour a stored share=on. */
 export async function initNetwork() {
   discovery.listen()
   applyNetwork((await readState()).network)
+  clearInterval(reconcileNetwork._timer)
+  reconcileNetwork._timer = setInterval(reconcileNetwork, RECONCILE_MS)
+  reconcileNetwork._timer.unref?.()
 }
 
 /** Connect-style middleware: handles /api/*, passes everything else through. */

--- a/server/api.mjs
+++ b/server/api.mjs
@@ -1,4 +1,5 @@
 import fsp from 'node:fs/promises'
+import net from 'node:net'
 import os from 'node:os'
 import path from 'node:path'
 import { spawn } from 'node:child_process'
@@ -450,11 +451,38 @@ function applyNetwork(network) {
  * district returns without anyone touching a switch.
  */
 const RECONCILE_MS = 15 * 1000
-function reconcileNetwork() {
+
+/**
+ * Actually connect to a local TCP port, briefly, to prove it still accepts connections.
+ * `server.listening` lies after the machine sleeps — the socket claims to be up while nothing
+ * reaches it — so the only honest check is to open a connection and see if it lands. Resolves
+ * true on connect, false on error or timeout.
+ */
+function probePort(port, timeout = 1000) {
+  return new Promise((resolve) => {
+    const socket = net.connect({ host: '127.0.0.1', port })
+    let done = false
+    const finish = (ok) => {
+      if (done) return
+      done = true
+      socket.destroy()
+      resolve(ok)
+    }
+    socket.setTimeout(timeout)
+    socket.once('connect', () => finish(true))
+    socket.once('timeout', () => finish(false))
+    socket.once('error', () => finish(false))
+  })
+}
+
+async function reconcileNetwork() {
   if (!currentNetwork) return
   discovery.listen() // no-op if the socket is up; rebinds if it dropped
   if (currentNetwork.share) {
+    // A dropped listener heals; a listener that only *looks* alive (post-sleep) is caught by
+    // probing the port for real and force-restarting when nothing answers.
     if (guest.needsHeal) guest.start()
+    else if (guest.running && !(await probePort(guest.port))) guest.restart()
     discovery.setAnnounce(true, { name: currentNetwork.colonyName, guestPort: guest.port })
   }
 }

--- a/server/api.mjs
+++ b/server/api.mjs
@@ -5,6 +5,9 @@ import { spawn } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 import { openInTerminal, schemeHasHandler, schemeOf } from './lib/xdg.mjs'
 import { focusWindowOfPid } from './lib/windows.mjs'
+import { GuestServer, GUEST_PORT } from './guest.mjs'
+import { Discovery, INSTANCE_ID } from './discovery.mjs'
+import { Neighbors, cleanNeighbor } from './neighbors.mjs'
 import {
   defaultHarness,
   harnessStatus,
@@ -58,11 +61,34 @@ const emptyState = () => ({
   hiddenProjects: [],
   viewedAt: {},
   settings: null,
+  network: emptyNetwork(),
   updatedAt: 0,
 })
 
 const asObject = (v) => (v && typeof v === 'object' && !Array.isArray(v) ? v : {})
 const asArray = (v) => (Array.isArray(v) ? v : [])
+
+/** Sharing off, nobody added, named after whoever is logged in — the state of a fresh install. */
+function emptyNetwork() {
+  let name = ''
+  try {
+    name = os.userInfo().username
+  } catch {
+    name = os.hostname()
+  }
+  return { colonyName: name || 'colony', share: false, neighbors: [] }
+}
+
+/** The network block as the file is allowed to describe it — bad entries fall out, not in. */
+function cleanNetwork(raw) {
+  const base = emptyNetwork()
+  const net = asObject(raw)
+  return {
+    colonyName: String(net.colonyName || base.colonyName).slice(0, 80),
+    share: net.share === true,
+    neighbors: asArray(net.neighbors).map(cleanNeighbor).filter(Boolean),
+  }
+}
 
 async function readState() {
   try {
@@ -77,6 +103,7 @@ async function readState() {
       hiddenProjects: asArray(raw.hiddenProjects).map(String).filter(Boolean),
       viewedAt: asObject(raw.viewedAt),
       settings: raw.settings && typeof raw.settings === 'object' ? raw.settings : null,
+      network: cleanNetwork(raw.network),
       updatedAt: Number(raw.updatedAt) || 0,
     }
   } catch {
@@ -112,6 +139,7 @@ async function writeState(next) {
     hiddenProjects: asArray(next.hiddenProjects).map(String).filter(Boolean),
     viewedAt: asObject(next.viewedAt),
     settings: next.settings && typeof next.settings === 'object' ? next.settings : null,
+    network: cleanNetwork(next.network),
     updatedAt: Date.now(),
   }
   await fsp.mkdir(DATA_DIR, { recursive: true })
@@ -362,6 +390,44 @@ function readJsonBody(req, limit = 4 * 1024 * 1024) {
   })
 }
 
+// ── shared colonies ─────────────────────────────────────────────────────────────────────
+
+const neighbors = new Neighbors()
+const discovery = new Discovery()
+const guest = new GuestServer({
+  instanceId: INSTANCE_ID,
+  getName: () => currentNetwork.colonyName,
+  // Guests see the colony as its owner curates it: the same scan, with the same archived
+  // flags applied, minus anything actionable (the guest server strips that itself).
+  getThreads: async () => reconcileArchived(await scanThreads()),
+})
+
+let currentNetwork = emptyNetwork()
+
+/**
+ * Make the machinery match the colony file. Called at boot and again after every state
+ * write, so the settings panel's toggle is the only switch there is — no restart, no second
+ * source of truth. Everything here is idempotent: applying the same network twice starts
+ * nothing twice.
+ */
+function applyNetwork(network) {
+  currentNetwork = network
+  neighbors.setConfigured(network.neighbors)
+  if (network.share) {
+    guest.start()
+    discovery.setAnnounce(true, { name: network.colonyName, guestPort: guest.port })
+  } else {
+    guest.stop()
+    discovery.setAnnounce(false)
+  }
+}
+
+/** Boot wiring: read the file once, start listening for peers, honour a stored share=on. */
+export async function initNetwork() {
+  discovery.listen()
+  applyNetwork((await readState()).network)
+}
+
 /** Connect-style middleware: handles /api/*, passes everything else through. */
 export async function apiMiddleware(req, res, next) {
   const url = new URL(req.url, 'http://localhost')
@@ -377,7 +443,31 @@ export async function apiMiddleware(req, res, next) {
       // A harness that is present but cannot read its own store says so here, rather than
       // appearing healthy in the list while quietly contributing nothing.
       const warnings = (await harnessStatus()).filter((h) => h.detected && h.error).map((h) => h.error)
-      return send(res, 200, { threads, scannedAt: Date.now(), warnings })
+      // Neighbours ride along from cache — refreshed in the background, never awaited, so
+      // somebody else's sleeping laptop cannot slow this machine's own map down.
+      neighbors.refresh()
+      const visiting = neighbors.merged()
+      return send(res, 200, {
+        threads: [...threads, ...visiting.threads],
+        colonies: visiting.colonies,
+        scannedAt: Date.now(),
+        warnings,
+      })
+    }
+
+    if (url.pathname === '/api/neighbors' && req.method === 'GET') {
+      const configured = new Set(currentNetwork.neighbors.map((n) => `${n.host}:${n.port}`))
+      const discovered = discovery
+        .peers()
+        .filter((p) => !configured.has(`${p.host}:${p.guestPort}`))
+        .map((p) => ({ name: p.name, host: p.host, port: p.guestPort }))
+      return send(res, 200, {
+        network: currentNetwork,
+        colonies: neighbors.merged().colonies,
+        discovered,
+        sharing: guest.running,
+        guestPort: guest.port,
+      })
     }
 
     if (url.pathname === '/api/harnesses' && req.method === 'GET') {
@@ -411,7 +501,11 @@ export async function apiMiddleware(req, res, next) {
       return serialise(async () => {
         const current = await readState()
         if (base && current.updatedAt !== base) return send(res, 409, current)
-        return send(res, 200, await writeState(body))
+        const written = await writeState(body)
+        // The settings panel's network switches live in this same file, so a save is also
+        // the moment sharing starts or stops and the neighbour list changes.
+        applyNetwork(written.network)
+        return send(res, 200, written)
       })
     }
 

--- a/server/api.mjs
+++ b/server/api.mjs
@@ -529,10 +529,16 @@ export async function apiMiddleware(req, res, next) {
         .peers()
         .filter((p) => !configured.has(`${p.host}:${p.guestPort}`))
         .map((p) => ({ name: p.name, host: p.host, port: p.guestPort }))
+      // Strangers who tried to read us but are not on the list — the answer to "I added their
+      // IP but they still can't get in" when a VPN presents a different address than expected.
+      const refused = guest.running
+        ? guest.recentRefused().filter((r) => !configured.has(`${r.host}:${guest.port}`))
+        : []
       return send(res, 200, {
         network: currentNetwork,
         colonies: neighbors.merged().colonies,
         discovered,
+        refused,
         sharing: guest.running,
         guestPort: guest.port,
       })

--- a/server/api.mjs
+++ b/server/api.mjs
@@ -76,10 +76,16 @@ function emptyNetwork() {
   } catch {
     name = os.hostname()
   }
-  return { colonyName: name || 'colony', share: false, neighbors: [] }
+  return { colonyName: name || 'colony', share: false, neighbors: [], shared: [] }
 }
 
-/** The network block as the file is allowed to describe it — bad entries fall out, not in. */
+/**
+ * The network block as the file is allowed to describe it — bad entries fall out, not in.
+ *
+ * `shared` is the opt-in allowlist: the ids of sessions, and the names of repos, that this
+ * colony hands out to visitors. Empty means nothing is shared even when `share` is on, which
+ * is the safe default — a session is never exposed until it is named here.
+ */
 function cleanNetwork(raw) {
   const base = emptyNetwork()
   const net = asObject(raw)
@@ -87,6 +93,7 @@ function cleanNetwork(raw) {
     colonyName: String(net.colonyName || base.colonyName).slice(0, 80),
     share: net.share === true,
     neighbors: asArray(net.neighbors).map(cleanNeighbor).filter(Boolean),
+    shared: [...new Set(asArray(net.shared).map(String).filter(Boolean))].slice(0, 2000),
   }
 }
 
@@ -397,9 +404,15 @@ const discovery = new Discovery()
 const guest = new GuestServer({
   instanceId: INSTANCE_ID,
   getName: () => currentNetwork.colonyName,
-  // Guests see the colony as its owner curates it: the same scan, with the same archived
-  // flags applied, minus anything actionable (the guest server strips that itself).
-  getThreads: async () => reconcileArchived(await scanThreads()),
+  // Guests see only what the owner opted to share: the same scan, archived flags applied,
+  // then filtered to the allowlist — by session id or by repo name — before anything leaves.
+  // An empty allowlist shares nothing, which is the whole point of opt-in.
+  getThreads: async () => {
+    const all = await reconcileArchived(await scanThreads())
+    const shared = new Set(currentNetwork.shared || [])
+    if (!shared.size) return []
+    return all.filter((t) => shared.has(t.id) || shared.has(t.project))
+  },
 })
 
 let currentNetwork = emptyNetwork()

--- a/server/api.mjs
+++ b/server/api.mjs
@@ -404,6 +404,9 @@ const discovery = new Discovery()
 const guest = new GuestServer({
   instanceId: INSTANCE_ID,
   getName: () => currentNetwork.colonyName,
+  // Only the colleagues this colony has added may read it — mutual add, so sharing is never
+  // readable by the whole LAN. Read fresh per request so adding someone takes effect at once.
+  getAllowedHosts: () => (currentNetwork.neighbors || []).map((n) => n.host),
   // Guests see only what the owner opted to share: the same scan, archived flags applied,
   // then filtered to the allowlist — by session id or by repo name — before anything leaves.
   // An empty allowlist shares nothing, which is the whole point of opt-in.

--- a/server/api.mjs
+++ b/server/api.mjs
@@ -4,6 +4,7 @@ import path from 'node:path'
 import { spawn } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 import { openInTerminal, schemeHasHandler, schemeOf } from './lib/xdg.mjs'
+import { focusWindowOfPid } from './lib/windows.mjs'
 import {
   defaultHarness,
   harnessStatus,
@@ -175,8 +176,15 @@ async function resolveFolder(folder) {
 }
 
 /**
- * Show a harness's answer to "open this" — `{ ok, url, command }` — and say truthfully whether
- * anything happened.
+ * Show a harness's answer to "open this" — `{ ok, url, command, pid }` — and say truthfully
+ * whether anything happened.
+ *
+ * A `pid` names a live process whose thread already has a window on this machine — a session
+ * running in a terminal right now. Fronting that window is tried before anything else, because
+ * the URL fallback for exactly these threads is `resume`, which imports the transcript into the
+ * desktop app as a second, untitled session. Only when no window can be found (the terminal is
+ * on another desktop, the process is detached, the walk found only the Claude app itself) does
+ * the URL run as before.
  *
  * macOS and Windows hand the URL to the opener exactly as before: a scheme the harness's app
  * registers is always answered there, so nothing is probed. Linux is the platform where the URL
@@ -193,6 +201,8 @@ async function resolveFolder(folder) {
 async function present(result) {
   // Only the reason reaches the page: a failure may still carry the adapter's command.
   if (!result || !result.ok) return { ok: false, error: result?.error || 'Nothing to open' }
+
+  if (result.pid && (await focusWindowOfPid(result.pid))) return { ok: true, focused: true }
 
   if (process.platform !== 'linux') {
     if (!result.url) return { ok: false, error: 'That harness has no deep link to open on this platform' }

--- a/server/discovery.mjs
+++ b/server/discovery.mjs
@@ -43,11 +43,22 @@ export class Discovery {
    * and where the OS still refuses, discovery is simply absent — manual adding still works,
    * so this never takes the server down.
    */
+  /** True when the listening socket is up. The reconcile tick rebinds it if it ever drops. */
+  get healthy() {
+    return Boolean(this._socket)
+  }
+
   listen() {
     if (this._socket) return
     const socket = dgram.createSocket({ type: 'udp4', reuseAddr: true })
     socket.on('error', () => {
-      socket.close()
+      // Sleep or a network change can drop the socket. Null it so the next reconcile rebinds,
+      // rather than leaving discovery silently dead until the app restarts.
+      try {
+        socket.close()
+      } catch {
+        /* already closing */
+      }
       if (this._socket === socket) this._socket = null
     })
     socket.on('message', (buf, rinfo) => this._onMessage(buf, rinfo))

--- a/server/discovery.mjs
+++ b/server/discovery.mjs
@@ -1,0 +1,127 @@
+/**
+ * Finding each other on the LAN: a UDP heartbeat, nothing more.
+ *
+ * Every instance listens; only an instance whose owner turned sharing on speaks. An
+ * announcement is one small JSON datagram to the broadcast address, repeated every
+ * ANNOUNCE_MS, saying "a Bot Crossing named X answers guests on port Y here". Listeners
+ * collect them into a peers list that expires quietly — three missed heartbeats and you are
+ * no longer on it.
+ *
+ * Broadcast does not cross subnets, and that is accepted rather than fought: mDNS proper
+ * would buy multi-subnet discovery at the cost of a dependency and a protocol, and the
+ * neighbour you cannot discover can always be added by hand. This file is the "it just shows
+ * up" half of that pair, not a guarantee.
+ *
+ * Own announcements come back on the same socket (broadcast is broadcast) and are recognised
+ * by `instanceId` — random per boot — rather than by address, because "which of my addresses
+ * did this arrive from" is exactly the kind of question with six wrong answers.
+ */
+import dgram from 'node:dgram'
+import crypto from 'node:crypto'
+
+export const DISCOVERY_PORT = Number(process.env.BOT_CROSSING_DISCOVERY_PORT) || 5276
+const ANNOUNCE_MS = 15 * 1000
+const PEER_TTL_MS = 50 * 1000
+
+/** One id per boot, shared by discovery and the guest API so a peer can be matched to itself. */
+export const INSTANCE_ID = crypto.randomUUID()
+
+export class Discovery {
+  constructor({ port = DISCOVERY_PORT, instanceId = INSTANCE_ID } = {}) {
+    this.port = port
+    this.instanceId = instanceId
+    /** host → { name, host, guestPort, lastSeen } */
+    this._peers = new Map()
+    this._socket = null
+    this._announcer = null
+    this._announce = null
+  }
+
+  /**
+   * Start collecting announcements. Safe to call on a machine where another instance holds
+   * the port already (the end-to-end test runs two on one box): `reuseAddr` lets both bind,
+   * and where the OS still refuses, discovery is simply absent — manual adding still works,
+   * so this never takes the server down.
+   */
+  listen() {
+    if (this._socket) return
+    const socket = dgram.createSocket({ type: 'udp4', reuseAddr: true })
+    socket.on('error', () => {
+      socket.close()
+      if (this._socket === socket) this._socket = null
+    })
+    socket.on('message', (buf, rinfo) => this._onMessage(buf, rinfo))
+    socket.bind(this.port, () => {
+      try {
+        socket.setBroadcast(true)
+      } catch {
+        /* sending is optional; listening already works */
+      }
+    })
+    this._socket = socket
+  }
+
+  _onMessage(buf, rinfo) {
+    let msg
+    try {
+      msg = JSON.parse(buf.toString('utf8'))
+    } catch {
+      return
+    }
+    if (!msg || msg.app !== 'bot-crossing' || msg.v !== 1) return
+    if (msg.instanceId === this.instanceId) return // our own echo
+    const guestPort = Number(msg.guestPort)
+    if (!Number.isInteger(guestPort) || guestPort <= 0 || guestPort > 65535) return
+    const name = String(msg.name || '').slice(0, 80).trim()
+    if (!name) return
+    this._peers.set(`${rinfo.address}:${guestPort}`, {
+      name,
+      host: rinfo.address,
+      guestPort,
+      lastSeen: Date.now(),
+    })
+  }
+
+  /** Everybody heard from recently. Expiry happens on read — nothing to tick over. */
+  peers() {
+    const now = Date.now()
+    const out = []
+    for (const [key, peer] of this._peers) {
+      if (now - peer.lastSeen > PEER_TTL_MS) this._peers.delete(key)
+      else out.push(peer)
+    }
+    return out
+  }
+
+  /** Start or stop announcing. Called whenever the owner toggles sharing or renames. */
+  setAnnounce(enabled, { name, guestPort } = {}) {
+    clearInterval(this._announcer)
+    this._announcer = null
+    this._announce = null
+    if (!enabled) return
+    this._announce = JSON.stringify({
+      v: 1,
+      app: 'bot-crossing',
+      name: String(name || 'colony').slice(0, 80),
+      guestPort,
+      instanceId: this.instanceId,
+    })
+    const beat = () => this._send()
+    this._announcer = setInterval(beat, ANNOUNCE_MS)
+    // Unref'd so a test that forgets to stop announcing still lets the process exit.
+    this._announcer.unref?.()
+    beat() // the first heartbeat should not wait 15 seconds
+  }
+
+  _send() {
+    if (!this._socket || !this._announce) return
+    const buf = Buffer.from(this._announce, 'utf8')
+    this._socket.send(buf, 0, buf.length, this.port, '255.255.255.255', () => {})
+  }
+
+  close() {
+    this.setAnnounce(false)
+    this._socket?.close()
+    this._socket = null
+  }
+}

--- a/server/guest.mjs
+++ b/server/guest.mjs
@@ -66,25 +66,53 @@ export class GuestServer {
     this.getThreads = getThreads
     this.getAllowedHosts = getAllowedHosts || (() => [])
     this._server = null
+    /** True between start() and stop(): the listener is *meant* to be up, so heal it if it dies. */
+    this._wantOn = false
+    this._healTimer = null
   }
 
   get running() {
-    return Boolean(this._server)
+    return Boolean(this._server && this._server.listening)
   }
 
   start() {
+    this._wantOn = true
     if (this._server) return
     const server = http.createServer((req, res) => this._handle(req, res))
     server.on('error', () => {
-      // The port being taken (a second instance, another app) must not take the colony down;
-      // sharing is just off until the owner toggles it again.
+      // A dead listener must not take the colony down — but it must not stay dead either.
+      // Sleep, a network change or a transient bind failure can drop it, and before this the
+      // only cure was the owner toggling sharing off and on. Now it heals itself.
       if (this._server === server) this._server = null
+      this._scheduleHeal()
+    })
+    server.on('close', () => {
+      if (this._server === server) this._server = null
+      if (this._wantOn) this._scheduleHeal()
     })
     server.listen(this.port, '0.0.0.0')
     this._server = server
   }
 
+  /** Bring the listener back a moment after it dropped, as long as it is still meant to be up. */
+  _scheduleHeal() {
+    if (!this._wantOn || this._healTimer) return
+    this._healTimer = setTimeout(() => {
+      this._healTimer = null
+      if (this._wantOn && !this._server) this.start()
+    }, 3000)
+    this._healTimer.unref?.()
+  }
+
+  /** True while sharing is meant to be on but the socket is not currently listening. */
+  get needsHeal() {
+    return this._wantOn && !this.running
+  }
+
   stop() {
+    this._wantOn = false
+    clearTimeout(this._healTimer)
+    this._healTimer = null
     this._server?.close()
     this._server = null
   }

--- a/server/guest.mjs
+++ b/server/guest.mjs
@@ -22,18 +22,49 @@ export function guestThread(thread) {
   return { ...rest, canOpen: false }
 }
 
+/**
+ * A socket address as a bare IPv4/IPv6 string, comparable to what a neighbour is added as.
+ * Node reports IPv4 clients over a dual-stack socket as `::ffff:192.168.0.5`, so the mapping
+ * prefix is stripped; loopback arrives as `::1` or `127.0.0.1`.
+ */
+export function normalizeIp(addr) {
+  if (!addr) return ''
+  let ip = String(addr)
+  if (ip.startsWith('::ffff:')) ip = ip.slice(7)
+  return ip
+}
+
+const isLoopback = (ip) => ip === '127.0.0.1' || ip === '::1' || ip.startsWith('127.')
+
+/**
+ * May this address read the colony? Loopback always (local page, tests), otherwise only the
+ * hosts the owner has added as neighbours — so "shared" means "shared with the colleagues I
+ * chose", not "readable by the whole LAN". Hosts added by name rather than IP will not match a
+ * raw address; discovery adds by IP, which is the path that matters.
+ */
+export function hostAllowed(remoteAddr, allowedHosts) {
+  const ip = normalizeIp(remoteAddr)
+  if (!ip) return false
+  if (isLoopback(ip)) return true
+  return (allowedHosts || []).some((h) => normalizeIp(h) === ip)
+}
+
 export class GuestServer {
   /**
    * @param getName    () → the colony's display name, read fresh per request so a rename
    *                   never needs a listener restart.
    * @param getThreads async () → the same scan the owner's page gets.
+   * @param getAllowedHosts () → the IPs allowed to read this colony: the hosts of the
+   *                   neighbours the owner has added. Loopback is always allowed. Read fresh
+   *                   per request, so adding a colleague takes effect without a restart.
    */
-  constructor({ port = GUEST_PORT, instanceId, version = '', getName, getThreads }) {
+  constructor({ port = GUEST_PORT, instanceId, version = '', getName, getThreads, getAllowedHosts }) {
     this.port = port
     this.instanceId = instanceId
     this.version = version
     this.getName = getName
     this.getThreads = getThreads
+    this.getAllowedHosts = getAllowedHosts || (() => [])
     this._server = null
   }
 
@@ -63,6 +94,11 @@ export class GuestServer {
       const json = JSON.stringify(body)
       res.writeHead(status, { 'Content-Type': 'application/json; charset=utf-8' })
       res.end(json)
+    }
+    // Who is asking, before what they asked. A host that is not a configured neighbour gets
+    // 403 and never learns whether anything is shared — the allowlist is not even consulted.
+    if (!hostAllowed(req.socket?.remoteAddress, this.getAllowedHosts())) {
+      return send(403, { error: 'This colony only answers colleagues it has added' })
     }
     if (req.method !== 'GET') return send(405, { error: 'The guest API is read-only' })
     const url = new URL(req.url, 'http://guest')

--- a/server/guest.mjs
+++ b/server/guest.mjs
@@ -69,6 +69,13 @@ export class GuestServer {
     /** True between start() and stop(): the listener is *meant* to be up, so heal it if it dies. */
     this._wantOn = false
     this._healTimer = null
+    /**
+     * IP -> last time a host we do NOT know tried to read us. This is the answer to \"I added
+     * their IP but they still can't see me\": over a NAT'ing VPN (FortiClient among them) the
+     * address the socket sees is not always the one the colleague added, and this surfaces the
+     * real one so it can be added with a click. Bounded and short-lived — a debugging aid, not a log.
+     */
+    this._refused = new Map()
   }
 
   get running() {
@@ -129,6 +136,23 @@ export class GuestServer {
     if (wanted) this.start()
   }
 
+  /** Record a stranger's IP, and forget the oldest once the list of them grows past a handful. */
+  _noteRefused(ip) {
+    this._refused.set(ip, Date.now())
+    while (this._refused.size > 12) this._refused.delete(this._refused.keys().next().value)
+  }
+
+  /** Strangers seen in the last few minutes — the page offers these as one-click adds. */
+  recentRefused(windowMs = 5 * 60 * 1000) {
+    const now = Date.now()
+    const out = []
+    for (const [ip, at] of this._refused) {
+      if (now - at > windowMs) this._refused.delete(ip)
+      else out.push({ host: ip, lastSeen: at })
+    }
+    return out
+  }
+
   async _handle(req, res) {
     const send = (status, body) => {
       const json = JSON.stringify(body)
@@ -138,6 +162,8 @@ export class GuestServer {
     // Who is asking, before what they asked. A host that is not a configured neighbour gets
     // 403 and never learns whether anything is shared — the allowlist is not even consulted.
     if (!hostAllowed(req.socket?.remoteAddress, this.getAllowedHosts())) {
+      const ip = normalizeIp(req.socket?.remoteAddress)
+      if (ip && !isLoopback(ip)) this._noteRefused(ip)
       return send(403, { error: 'This colony only answers colleagues it has added' })
     }
     if (req.method !== 'GET') return send(405, { error: 'The guest API is read-only' })

--- a/server/guest.mjs
+++ b/server/guest.mjs
@@ -117,6 +117,18 @@ export class GuestServer {
     this._server = null
   }
 
+  /**
+   * Tear the listener down and stand it back up, keeping `_wantOn`. Unlike waiting for the
+   * heal timer, this is unconditional — the caller has decided the socket is no good even if
+   * it still claims to be listening, which is exactly the state a socket can be left in after
+   * the machine sleeps: `listening` is true, but nothing actually reaches it.
+   */
+  restart() {
+    const wanted = this._wantOn
+    this.stop()
+    if (wanted) this.start()
+  }
+
   async _handle(req, res) {
     const send = (status, body) => {
       const json = JSON.stringify(body)

--- a/server/guest.mjs
+++ b/server/guest.mjs
@@ -1,0 +1,89 @@
+/**
+ * The guest API: what a neighbour on the LAN is allowed to see, and the whole of it.
+ *
+ * A second, separate HTTP server, opened only while sharing is on. Read-only is not a
+ * permission check here — it is the shape of the socket. The routes are `/guest/info` and
+ * `/guest/threads`, both GET; open, archive, new-session and the colony file simply do not
+ * exist on this listener, so there is nothing for a hostile LAN peer to even probe. The
+ * owner's own UI keeps living on 127.0.0.1, unreachable from outside.
+ *
+ * What leaves through here is also stripped: `ref` carries harness session ids and `canOpen`
+ * invites a click, and a guest can use neither. Everything else on a thread — title, project,
+ * status, timestamps — is exactly what the owner sees, which is what "visiting a colony"
+ * means.
+ */
+import http from 'node:http'
+
+export const GUEST_PORT = Number(process.env.BOT_CROSSING_GUEST_PORT) || 5275
+
+/** A thread as a guest may see it: nothing actionable, nothing that names a local file. */
+export function guestThread(thread) {
+  const { ref, transcriptFile, ...rest } = thread
+  return { ...rest, canOpen: false }
+}
+
+export class GuestServer {
+  /**
+   * @param getName    () → the colony's display name, read fresh per request so a rename
+   *                   never needs a listener restart.
+   * @param getThreads async () → the same scan the owner's page gets.
+   */
+  constructor({ port = GUEST_PORT, instanceId, version = '', getName, getThreads }) {
+    this.port = port
+    this.instanceId = instanceId
+    this.version = version
+    this.getName = getName
+    this.getThreads = getThreads
+    this._server = null
+  }
+
+  get running() {
+    return Boolean(this._server)
+  }
+
+  start() {
+    if (this._server) return
+    const server = http.createServer((req, res) => this._handle(req, res))
+    server.on('error', () => {
+      // The port being taken (a second instance, another app) must not take the colony down;
+      // sharing is just off until the owner toggles it again.
+      if (this._server === server) this._server = null
+    })
+    server.listen(this.port, '0.0.0.0')
+    this._server = server
+  }
+
+  stop() {
+    this._server?.close()
+    this._server = null
+  }
+
+  async _handle(req, res) {
+    const send = (status, body) => {
+      const json = JSON.stringify(body)
+      res.writeHead(status, { 'Content-Type': 'application/json; charset=utf-8' })
+      res.end(json)
+    }
+    if (req.method !== 'GET') return send(405, { error: 'The guest API is read-only' })
+    const url = new URL(req.url, 'http://guest')
+
+    try {
+      if (url.pathname === '/guest/info') {
+        return send(200, {
+          app: 'bot-crossing',
+          v: 1,
+          name: this.getName(),
+          version: this.version,
+          instanceId: this.instanceId,
+        })
+      }
+      if (url.pathname === '/guest/threads') {
+        const threads = await this.getThreads()
+        return send(200, { name: this.getName(), threads: threads.map(guestThread), scannedAt: Date.now() })
+      }
+      return send(404, { error: 'Not found' })
+    } catch (err) {
+      return send(500, { error: String(err && err.message ? err.message : err) })
+    }
+  }
+}

--- a/server/harnesses/claude-code.mjs
+++ b/server/harnesses/claude-code.mjs
@@ -494,16 +494,49 @@ const CLI_DIRS = [
 const cliBinary = () => findExecutable('claude', CLI_DIRS)
 
 /**
+ * The pid of the live CLI process behind a session, if any. Same registry and same caveat as
+ * `scanLiveSessions`: files outlive their pids, so the pid is probed before it counts.
+ */
+async function liveSessionPid(sessionId) {
+  for (const file of await listFiles(CLI_LIVE, (n) => n.endsWith('.json'))) {
+    let record
+    try {
+      record = JSON.parse(await fsp.readFile(file, 'utf8'))
+    } catch {
+      continue
+    }
+    if (record.sessionId !== sessionId || !record.pid) continue
+    try {
+      process.kill(record.pid, 0)
+      return record.pid
+    } catch {
+      /* process is gone */
+    }
+  }
+  return 0
+}
+
+/**
  * Hands the thread back to Claude Code. `epitaxy/<local_…>` *navigates* the desktop app
  * to a thread it already has; `resume` *imports* the transcript, which spawns a second
  * untitled session and rewrites the .jsonl — so it is only ever the fallback for threads
  * the app has never seen. Ids are pattern-checked before they reach the opener.
+ *
+ * A terminal-started thread that is still running gets its live pid handed along too: it
+ * already has a window somewhere on this machine, and fronting that window is a better answer
+ * than `resume` importing the transcript into the desktop app as a second, untitled session.
+ * Whether and how to front it is the server's call — see `server/lib/windows.mjs`.
  */
 async function openThread(ref) {
   const { desktopSessionId, cliSessionId, cwd } = ref || {}
   let url = ''
   if (isDesktopId(desktopSessionId)) url = `claude://claude.ai/epitaxy/${desktopSessionId}`
   else if (isCliId(cliSessionId)) url = `claude://resume?session=${cliSessionId}`
+
+  // Only threads the desktop app has never seen: for the rest the deep link navigates to the
+  // tab the app already has, which is exactly the right window to front.
+  let pid = 0
+  if (!isDesktopId(desktopSessionId) && isCliId(cliSessionId)) pid = await liveSessionPid(cliSessionId)
 
   let command
   if (process.platform === 'linux' && isCliId(cliSessionId)) {
@@ -512,7 +545,7 @@ async function openThread(ref) {
   }
 
   if (!url && !command) return { ok: false, error: 'No openable session id on that thread' }
-  return { ok: true, url, command }
+  return { ok: true, url, command, pid }
 }
 
 /**

--- a/server/lib/windows.mjs
+++ b/server/lib/windows.mjs
@@ -1,0 +1,95 @@
+/**
+ * Windows desktop plumbing: put the window that hosts a given process in front.
+ *
+ * The sibling of `xdg.mjs`, for the same reason — a page of OS trivia with nothing to do with
+ * HTTP, and nothing in here knows about a particular harness. An adapter hands the server a pid;
+ * the server decides whether fronting its window is the right way to answer "open this".
+ *
+ * The pid itself has no window — it is a CLI process. The window belongs to whatever terminal is
+ * hosting it, which is some ancestor: the shell's parent is Windows Terminal, VS Code, an IDE.
+ * So the walk goes *up* the parent chain until a process with a real main window appears, and
+ * fronts that. The Claude desktop app is deliberately stepped over: a process hosted by the app
+ * itself is the app's to present, and the deep link does that better than raw window fronting.
+ */
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+
+/**
+ * Enumerating every process (`Get-CimInstance Win32_Process`) is the slow half, a second or two
+ * on a busy machine; the rest is instant. The budget covers that with room, because past it the
+ * caller falls back to the deep link — a worse answer than a fronted window, but never a hang.
+ */
+const FOCUS_TIMEOUT_MS = 8000
+
+/** How many parents to visit before concluding nothing on the chain owns a window. */
+const MAX_HOPS = 16
+
+/**
+ * `SetForegroundWindow` alone is refused when the caller is a background process — Windows
+ * reserves focus-stealing for whoever the user is interacting with. A transient Alt keypress
+ * (0xA4, down then up) is the documented-by-folklore exemption: a process that just sent input
+ * counts as interacting. Restore-first matters too: fronting a minimized window leaves it
+ * minimized, just "active" in the taskbar.
+ */
+const script = (pid) => `
+$ErrorActionPreference = 'SilentlyContinue'
+$parent = @{}
+foreach ($p in Get-CimInstance Win32_Process) { $parent[[int]$p.ProcessId] = [int]$p.ParentProcessId }
+Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+public static class BotCrossingFocus {
+  [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr h);
+  [DllImport("user32.dll")] public static extern bool ShowWindowAsync(IntPtr h, int cmd);
+  [DllImport("user32.dll")] public static extern bool IsIconic(IntPtr h);
+  [DllImport("user32.dll")] public static extern void keybd_event(byte key, byte scan, uint flags, UIntPtr extra);
+}
+'@
+$cur = ${pid}
+for ($i = 0; $i -lt ${MAX_HOPS} -and $cur -gt 0; $i++) {
+  $proc = Get-Process -Id $cur
+  if ($proc -and $proc.MainWindowHandle -ne [IntPtr]::Zero) {
+    # The first *windowed* ancestor decides. The Claude app means the thread is the app's own —
+    # its deep link presents it better; explorer is the chain's root, and fronting a stray File
+    # Explorer window would be plain wrong. Either way: stop, let the caller fall back.
+    if ($proc.ProcessName -eq 'claude' -or $proc.ProcessName -eq 'explorer') { exit 1 }
+    $h = $proc.MainWindowHandle
+    if ([BotCrossingFocus]::IsIconic($h)) { [BotCrossingFocus]::ShowWindowAsync($h, 9) | Out-Null }
+    [BotCrossingFocus]::keybd_event(0xA4, 0, 0, [UIntPtr]::Zero)
+    [BotCrossingFocus]::keybd_event(0xA4, 0, 2, [UIntPtr]::Zero)
+    [BotCrossingFocus]::SetForegroundWindow($h) | Out-Null
+    'focused'
+    exit 0
+  }
+  if (-not $parent.ContainsKey($cur)) { break }
+  $next = $parent[$cur]
+  if ($next -eq $cur) { break }
+  $cur = $next
+}
+exit 1
+`
+
+/**
+ * Front the window hosting `pid`. True only when a window was actually found and told to come
+ * forward; false covers everything else — wrong platform, a chain with no window on it (a
+ * detached process, or one hosted by the Claude desktop app), or PowerShell being unavailable.
+ * The caller treats false as "use the URL instead", so failing quietly is the whole contract.
+ */
+export async function focusWindowOfPid(pid) {
+  if (process.platform !== 'win32') return false
+  if (!Number.isInteger(pid) || pid <= 0) return false
+  try {
+    // -EncodedCommand sidesteps every quoting rule cmd and PowerShell disagree on.
+    const encoded = Buffer.from(script(pid), 'utf16le').toString('base64')
+    const { stdout } = await execFileAsync(
+      'powershell.exe',
+      ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-EncodedCommand', encoded],
+      { timeout: FOCUS_TIMEOUT_MS, windowsHide: true }
+    )
+    return stdout.includes('focused')
+  } catch {
+    return false
+  }
+}

--- a/server/neighbors.mjs
+++ b/server/neighbors.mjs
@@ -1,0 +1,109 @@
+/**
+ * The visiting half: fetch a neighbour's guest API and fold their threads into ours.
+ *
+ * The owner's own map must never wait on somebody else's machine, so this is built around a
+ * cache. `/api/threads` merges whatever each neighbour answered *last time* and kicks off a
+ * refresh in the background; a neighbour that is slow, asleep or unplugged costs nothing but
+ * a stale district and an `online: false` flag. The page decides what offline looks like.
+ *
+ * Tagging is where collisions go to die. A guest thread's id is prefixed with the neighbour's
+ * address, so two machines that both know a repo called `wra` — or that both scanned the very
+ * same session id — can never merge into one astronaut. The project is prefixed with the
+ * colony's display name for the same reason, and because the plot label that falls out of it
+ * ("Chantal · wra") is exactly the sign the district needed anyway.
+ */
+
+const FETCH_TIMEOUT_MS = 2000
+/** How long a cached answer is considered fresh enough not to re-ask. */
+const REFRESH_MS = 10 * 1000
+/** Announce a neighbour as offline only after this long without a good answer. */
+const OFFLINE_MS = 45 * 1000
+
+const keyOf = (n) => `${n.host}:${n.port}`
+
+/** A configured neighbour as the colony file is allowed to describe one. */
+export function cleanNeighbor(raw) {
+  const host = String(raw?.host || '').trim()
+  const port = Number(raw?.port) || 0
+  if (!host || !/^[\w.:\-]+$/.test(host)) return null
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) return null
+  return { name: String(raw?.name || host).slice(0, 80), host, port }
+}
+
+export class Neighbors {
+  constructor() {
+    this.configured = []
+    /** key → { threads, name, fetchedAt, okAt, inflight } */
+    this._cache = new Map()
+  }
+
+  setConfigured(list) {
+    this.configured = (Array.isArray(list) ? list : []).map(cleanNeighbor).filter(Boolean)
+    const keep = new Set(this.configured.map(keyOf))
+    for (const key of this._cache.keys()) if (!keep.has(key)) this._cache.delete(key)
+  }
+
+  /** Kick stale entries into refreshing. Returns nothing; the merge reads the cache. */
+  refresh() {
+    const now = Date.now()
+    for (const neighbor of this.configured) {
+      const key = keyOf(neighbor)
+      const entry = this._cache.get(key) || { threads: [], name: neighbor.name, fetchedAt: 0, okAt: 0 }
+      this._cache.set(key, entry)
+      if (entry.inflight || now - entry.fetchedAt < REFRESH_MS) continue
+      entry.inflight = true
+      entry.fetchedAt = now
+      this._fetch(neighbor, entry).finally(() => {
+        entry.inflight = false
+      })
+    }
+  }
+
+  async _fetch(neighbor, entry) {
+    try {
+      const res = await fetch(`http://${neighbor.host}:${neighbor.port}/guest/threads`, {
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      })
+      if (!res.ok) return
+      const body = await res.json()
+      if (!Array.isArray(body?.threads)) return
+      entry.threads = body.threads
+      // The neighbour knows its own name best — a rename on her side lands here on its own.
+      entry.name = String(body.name || neighbor.name).slice(0, 80)
+      entry.okAt = Date.now()
+    } catch {
+      /* offline, slow, or not a guest API — the cache and the okAt stamp already say so */
+    }
+  }
+
+  /**
+   * Everything the neighbours contribute right now: their threads, tagged beyond any chance
+   * of colliding with a local id or plot, and a per-colony roster the page uses for banners
+   * and the settings list.
+   */
+  merged() {
+    const now = Date.now()
+    const threads = []
+    const colonies = []
+    for (const neighbor of this.configured) {
+      const key = keyOf(neighbor)
+      const entry = this._cache.get(key)
+      const name = entry?.name || neighbor.name
+      const online = Boolean(entry && now - entry.okAt < OFFLINE_MS)
+      colonies.push({ key, name, host: neighbor.host, port: neighbor.port, online })
+      for (const t of entry?.threads || []) {
+        threads.push({
+          ...t,
+          id: `guest:${key}:${t.id}`,
+          project: `${name} · ${t.project || 'unknown'}`,
+          colony: name,
+          colonyKey: key,
+          colonyOnline: online,
+          canOpen: false,
+          ref: undefined,
+        })
+      }
+    }
+    return { threads, colonies }
+  }
+}

--- a/server/serve.mjs
+++ b/server/serve.mjs
@@ -2,7 +2,7 @@ import http from 'node:http'
 import fsp from 'node:fs/promises'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { apiMiddleware } from './api.mjs'
+import { apiMiddleware, initNetwork } from './api.mjs'
 
 const here = path.dirname(fileURLToPath(import.meta.url))
 const DIST = path.join(here, '..', 'dist')
@@ -60,4 +60,9 @@ const server = http.createServer(async (req, res) => {
 
 server.listen(PORT, HOST, () => {
   console.log(`Bot Crossing → http://${HOST}:${PORT}`)
+})
+
+// Shared colonies: start listening for neighbours, and resume sharing if it was left on.
+initNetwork().catch(() => {
+  /* a machine that cannot open the sockets still gets its own colony */
 })

--- a/src/game/api.js
+++ b/src/game/api.js
@@ -92,3 +92,10 @@ export const openThread = (thread) => post('/api/open', { harness: thread.harnes
 export const newSession = (folder, harness) => post('/api/new-session', { folder, harness })
 
 export const revealFolder = (folder) => post('/api/reveal', { folder })
+
+/**
+ * The state of shared colonies: the machine's own network config, whichever neighbours are
+ * currently reachable, and any not-yet-added colonies discovered on the LAN. Read fresh
+ * whenever the settings panel opens — it changes as machines come and go.
+ */
+export const fetchNeighbors = () => req('/api/neighbors')

--- a/src/game/colony.js
+++ b/src/game/colony.js
@@ -5,6 +5,7 @@ import {
   Plot,
   allocateCells,
   colonyAnchor,
+  cellWorld,
   shipPosition,
   createLabel,
   createBanner,
@@ -428,7 +429,11 @@ export class Colony {
       if (!cells?.length) return
       const visiting = colonyOf.get(name)
       const accent = this._pickAccent(name)
-      const plot = new Plot({ id: name, name, index, cells, accent })
+      // Sit the slab on the terrain under its root cell. Near the ship that is ~0; a visiting
+      // district anchored far out lands on whatever the ground does there, instead of floating.
+      const root = cellWorld(cells[0].q, cells[0].r)
+      const groundY = terrainHeight(root.x, root.z, this.planet)
+      const plot = new Plot({ id: name, name, index, cells, accent, groundY })
       plot.signature = wanted.get(name)
       // A visiting colony's plot carries its colony so the district can be banner-labelled and
       // dimmed together, and so a click knows the repo is read-only.
@@ -440,7 +445,7 @@ export class Colony {
       // the colony name, so the plate need only say which repo.
       const labelText = visiting ? name.replace(`${visiting.colony} · `, '') : name
       const label = createLabel(labelText, accent)
-      label.position.set(plot.labelAnchor.x, 3.2, plot.labelAnchor.z)
+      label.position.set(plot.labelAnchor.x, plot.groundY + 3.2, plot.labelAnchor.z)
       plot.label = label
       this.labelGroup.add(label)
     })
@@ -458,9 +463,12 @@ export class Colony {
     if (this.scatterGroup && this._plotFootprint() !== this._scatterFootprint) this._buildScatter()
     // Which hex cells are decked. Ground height is asked for once per moving agent per
     // frame, so it wants to be a lookup rather than a scan over every plot's every tile.
-    this.deckedCells = new Set()
+    // Cell → the deck's top height there, so the crew stands on a sunk district's deck rather
+    // than at a flat 0.45. Near the ship groundY is ~0, so this is the old DECK_TOP everywhere
+    // that mattered before districts existed.
+    this.deckedCells = new Map()
     for (const plot of this.plotOrder) {
-      for (const cell of plot.cells) this.deckedCells.add(`${cell.q},${cell.r}`)
+      for (const cell of plot.cells) this.deckedCells.set(`${cell.q},${cell.r}`, plot.groundY + DECK_TOP)
     }
     this._syncLabels()
   }
@@ -494,11 +502,13 @@ export class Colony {
       }
       let cx = 0
       let cz = 0
+      let cy = 0
       for (const plot of plots) {
         cx += plot.middle.x
         cz += plot.middle.z
+        cy += plot.groundY
       }
-      banner.position.set(cx / plots.length, 5.0, cz / plots.length)
+      banner.position.set(cx / plots.length, cy / plots.length + 5.0, cz / plots.length)
       banner.userData.online = plots.every((p) => p.colonyOnline !== false)
     }
   }
@@ -521,7 +531,8 @@ export class Colony {
 
   groundAt(x, z) {
     const cell = worldToHex(x, z)
-    if (this.deckedCells?.has(`${cell.q},${cell.r}`)) return DECK_TOP
+    const deck = this.deckedCells?.get(`${cell.q},${cell.r}`)
+    if (deck !== undefined) return deck
     return terrainHeight(x, z, this.planet)
   }
 

--- a/src/game/colony.js
+++ b/src/game/colony.js
@@ -4,8 +4,10 @@ import { Sky } from '../world/sky.js'
 import {
   Plot,
   allocateCells,
+  colonyAnchor,
   shipPosition,
   createLabel,
+  createBanner,
   hashString,
   worldToHex,
   DECK_TOP,
@@ -122,6 +124,8 @@ export class Colony {
 
     this.plots = new Map()
     this.plotOrder = []
+    /** colony name → floating district banner, for visiting colonies only. */
+    this.colonyBanners = new Map()
     /**
      * Where every zone sits, kept across polls *and* across the departures of the threads
      * that made it: a repo whose last session you archive comes back to the same ground
@@ -269,11 +273,18 @@ export class Colony {
 
     // Group by repo, biggest project first so the busiest work lands nearest the middle.
     const byProject = new Map()
+    // Which visiting colony a project belongs to, if any — read off the guest threads, whose
+    // project name the server already prefixed with the colony's. A home repo has no entry.
+    const projectColony = new Map()
     for (const thread of live) {
       const key = thread.project || 'unknown'
       if (!byProject.has(key)) byProject.set(key, [])
       byProject.get(key).push(thread)
+      if (thread.colony && !projectColony.has(key)) {
+        projectColony.set(key, { colony: thread.colony, online: thread.colonyOnline !== false })
+      }
     }
+    this.projectColony = projectColony
     /**
      * Repos where nothing has stirred in days, folded away on request.
      *
@@ -376,8 +387,14 @@ export class Colony {
     // The previous layout is an input, so a zone only moves when its own footprint changes
     // — never because a different repo gained or lost a thread. `plotCells` carries it
     // between polls, and the colony file carries it between sessions.
+    const colonyOf = this.projectColony || new Map()
     const layout = allocateCells(
-      projects.map(([name, list]) => ({ id: name, size: list.length })),
+      projects.map(([name, list]) => {
+        const visiting = colonyOf.get(name)
+        // A visiting colony's repos anchor to that colony's district out past the home zones,
+        // so they cluster together and read as somebody else's settlement.
+        return { id: name, size: list.length, anchor: visiting ? colonyAnchor(visiting.colony) : null }
+      }),
       this.plotCells
     )
     // Remembered, not replaced: a project that has just lost its last thread keeps its
@@ -409,19 +426,34 @@ export class Colony {
       if (this.plots.has(name)) return
       const cells = layout.get(name)
       if (!cells?.length) return
+      const visiting = colonyOf.get(name)
       const accent = this._pickAccent(name)
       const plot = new Plot({ id: name, name, index, cells, accent })
       plot.signature = wanted.get(name)
+      // A visiting colony's plot carries its colony so the district can be banner-labelled and
+      // dimmed together, and so a click knows the repo is read-only.
+      plot.colony = visiting ? visiting.colony : ''
       this.plots.set(name, plot)
       this.plotGroup.add(plot.group)
 
-      const label = createLabel(name, accent)
+      // Guest plots drop the colony prefix from their own plate — the district banner carries
+      // the colony name, so the plate need only say which repo.
+      const labelText = visiting ? name.replace(`${visiting.colony} · `, '') : name
+      const label = createLabel(labelText, accent)
       label.position.set(plot.labelAnchor.x, 3.2, plot.labelAnchor.z)
       plot.label = label
       this.labelGroup.add(label)
     })
 
+    // Keep the online/offline flag current on plots that already existed — a colony going
+    // offline must dim its district without rebuilding every plot in it.
+    for (const [name, plot] of this.plots) {
+      if (!plot.colony) continue
+      plot.colonyOnline = colonyOf.get(name)?.online !== false
+    }
+
     this.plotOrder = [...this.plots.values()]
+    this._syncColonyBanners()
     // Zones that just moved, appeared or grew are zones the scatter does not know about.
     if (this.scatterGroup && this._plotFootprint() !== this._scatterFootprint) this._buildScatter()
     // Which hex cells are decked. Ground height is asked for once per moving agent per
@@ -431,6 +463,44 @@ export class Colony {
       for (const cell of plot.cells) this.deckedCells.add(`${cell.q},${cell.r}`)
     }
     this._syncLabels()
+  }
+
+  /**
+   * One banner floating over each visiting colony's cluster of plots. Positioned at the
+   * centroid of that colony's zones, so it recentres on its own as the district grows or
+   * shrinks, and rebuilt only when the set of colonies on the map changes.
+   */
+  _syncColonyBanners() {
+    const groups = new Map()
+    for (const plot of this.plotOrder) {
+      if (!plot.colony) continue
+      if (!groups.has(plot.colony)) groups.set(plot.colony, [])
+      groups.get(plot.colony).push(plot)
+    }
+    // Retire banners for colonies that have left the map entirely.
+    for (const [name, banner] of this.colonyBanners) {
+      if (groups.has(name)) continue
+      this.labelGroup.remove(banner)
+      banner.userData.dispose?.()
+      this.colonyBanners.delete(name)
+    }
+    for (const [name, plots] of groups) {
+      let banner = this.colonyBanners.get(name)
+      if (!banner) {
+        // Accent taken from the district's first plot, so the banner glyph matches its zones.
+        banner = createBanner(name, plots[0].accent)
+        this.colonyBanners.set(name, banner)
+        this.labelGroup.add(banner)
+      }
+      let cx = 0
+      let cz = 0
+      for (const plot of plots) {
+        cx += plot.middle.x
+        cz += plot.middle.z
+      }
+      banner.position.set(cx / plots.length, 5.0, cz / plots.length)
+      banner.userData.online = plots.every((p) => p.colonyOnline !== false)
+    }
   }
 
   /**
@@ -661,6 +731,15 @@ export class Colony {
       const next = THREE.MathUtils.damp(label.material.opacity, wanted, 9, dt)
       label.material.opacity = next
       label.visible = next > 0.01
+    }
+    // District banners stay up whenever their colony is on the map — they are the sign you
+    // read to know whose settlement you are looking at. An offline colony's banner dims
+    // rather than vanishing, so a sleeping machine reads as "away", not "gone".
+    for (const banner of this.colonyBanners.values()) {
+      const wanted = this.uiVisible ? (banner.userData.online ? 1 : 0.4) : 0
+      const next = THREE.MathUtils.damp(banner.material.opacity, wanted, 9, dt)
+      banner.material.opacity = next
+      banner.visible = next > 0.01
     }
   }
 

--- a/src/game/merge-state.js
+++ b/src/game/merge-state.js
@@ -127,5 +127,9 @@ export function mergeState(base, local, remote) {
     hiddenProjects: mergeSet(b.hiddenProjects, l.hiddenProjects, r.hiddenProjects),
     viewedAt: mergeMap(b.viewedAt, l.viewedAt, r.viewedAt),
     settings: l.settings && typeof l.settings === 'object' ? l.settings : r.settings ?? null,
+    // Network config is this machine's own — sharing, its colony name, the neighbours it
+    // visits. Like `settings`, local wins whole: two tabs are the same person on one machine,
+    // and field-wise merging could leave sharing half-toggled between them.
+    network: l.network && typeof l.network === 'object' ? l.network : r.network ?? null,
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -52,9 +52,31 @@ let state = { archived: [], archivedAt: {}, opened: [], plots: {}, seen: {}, hid
 
 /** The machine's own network block, always a well-formed object for the settings panel. */
 function network() {
-  if (!state.network || typeof state.network !== 'object') state.network = { colonyName: '', share: false, neighbors: [] }
+  if (!state.network || typeof state.network !== 'object') state.network = { colonyName: '', share: false, neighbors: [], shared: [] }
   if (!Array.isArray(state.network.neighbors)) state.network.neighbors = []
+  if (!Array.isArray(state.network.shared)) state.network.shared = []
   return state.network
+}
+
+/** The opt-in allowlist as a Set: session ids and repo names this colony hands to visitors. */
+function sharedSet() {
+  return new Set(network().shared)
+}
+
+/** Is this thread exposed to visitors — directly, or because its whole repo is shared? */
+function threadShared(thread) {
+  if (!thread) return false
+  const s = sharedSet()
+  return s.has(thread.id) || s.has(thread.project)
+}
+
+/** Add or remove one entry (a session id or a repo name) from the allowlist. */
+function toggleShared(key) {
+  const s = sharedSet()
+  if (s.has(key)) s.delete(key)
+  else s.add(key)
+  patchNetwork({ shared: [...s] })
+  applyThreads(threads)
 }
 
 /** Write a change to the network block and let the server pick it up on the save. */
@@ -304,6 +326,25 @@ const actions = {
   // ── shared colonies ────────────────────────────────────────────────────────────────
   /** The machine's own network config, for the settings panel to render. */
   getNetwork: () => ({ ...network() }),
+  /** Is this colony sharing at all — the switch that makes the share controls worth showing. */
+  sharingOn: () => Boolean(network().share),
+  /** How much is actually exposed right now: repos on the list, and live sessions it adds up to. */
+  sharedSummary: () => {
+    const s = sharedSet()
+    const repos = [...s].filter((k) => colony.plots.has(k) || threads.some((t) => t.project === k))
+    const exposed = threads.filter((t) => !t.colony && (s.has(t.id) || s.has(t.project))).length
+    return { repos: repos.length, exposed }
+  },
+  /** Whether a repo is on the allowlist by its own name. */
+  isRepoShared: (name) => sharedSet().has(name),
+  /** How a session is shared: 'repo' (via its whole repo), 'session' (on its own), or ''. */
+  sessionShareState: (id) => {
+    const thread = threads.find((t) => t.id === id)
+    if (!thread) return ''
+    if (sharedSet().has(thread.project)) return 'repo'
+    if (sharedSet().has(thread.id)) return 'session'
+    return ''
+  },
   /** Fold the live neighbour/discovery view together with the saved config. */
   fetchNeighbors: () => fetchNeighbors(),
   setShare: (on) => patchNetwork({ share: Boolean(on) }),
@@ -316,6 +357,26 @@ const actions = {
   },
   removeNeighbor: (host, port) => {
     patchNetwork({ neighbors: network().neighbors.filter((n) => !(n.host === host && n.port === port)) })
+  },
+
+  /** Toggle whether one repo, with all its sessions present and future, is shared. */
+  toggleShareRepo: (name) => {
+    if (!name) return
+    const wasShared = sharedSet().has(name)
+    toggleShared(name)
+    hud.toast(wasShared ? `${name} is no longer shared` : `Sharing ${name} with the network`)
+  },
+  /** Toggle whether one session is shared. Independent of its repo's own switch. */
+  toggleShareSession: (id) => {
+    const thread = threads.find((t) => t.id === id)
+    if (!thread) return
+    if (sharedSet().has(thread.project)) {
+      hud.toast(`This session is already shared — ${thread.project} is shared as a whole repo`)
+      return
+    }
+    const wasShared = sharedSet().has(id)
+    toggleShared(id)
+    hud.toast(wasShared ? 'Session no longer shared' : 'Sharing this session with the network')
   },
 
   // The card's bar is about the *thread*, not about how much of its building has risen —
@@ -431,6 +492,7 @@ function syncProject() {
     return
   }
   const now = Date.now()
+  const repoShared = sharedSet().has(plot.name)
   const list = [...colony.threads.values()]
     .filter((thread) => thread.project === plot.name)
     .map((thread) => ({
@@ -439,6 +501,8 @@ function syncProject() {
       worktree: thread.worktree,
       lastActivityAt: thread.lastActivityAt,
       status: statusFor(thread, now),
+      // Marked in the row so you can see at a glance what leaves this machine.
+      shared: repoShared || sharedSet().has(thread.id),
     }))
     // Whoever wants something first, then most recently touched — the same order of
     // importance the badges use above their heads.
@@ -455,6 +519,9 @@ function syncProject() {
     colony: plot.colony || '',
     colonyOnline: plot.colonyOnline !== false,
     path: plot.colony ? '' : pathForProject(plot.name),
+    // Only your own repos can be shared, and only worth offering while sharing is on.
+    sharing: !plot.colony && Boolean(network().share),
+    repoShared,
     threads: list,
     selectedId,
   })

--- a/src/main.js
+++ b/src/main.js
@@ -16,6 +16,7 @@ import {
   openThread,
   newSession,
   revealFolder,
+  fetchNeighbors,
 } from './game/api.js'
 import { hideProject, hiddenCatalog, unhideProject } from './game/hidden-projects.js'
 
@@ -47,7 +48,22 @@ const engine = new Engine(settings).mount(app)
 const rig = new CameraRig(engine.camera, engine.canvas, settings)
 const colony = new Colony(engine.scene, settings, engine.camera, engine.renderer)
 
-let state = { archived: [], archivedAt: {}, opened: [], plots: {}, seen: {}, hiddenProjects: [], viewedAt: {} }
+let state = { archived: [], archivedAt: {}, opened: [], plots: {}, seen: {}, hiddenProjects: [], viewedAt: {}, network: null }
+
+/** The machine's own network block, always a well-formed object for the settings panel. */
+function network() {
+  if (!state.network || typeof state.network !== 'object') state.network = { colonyName: '', share: false, neighbors: [] }
+  if (!Array.isArray(state.network.neighbors)) state.network.neighbors = []
+  return state.network
+}
+
+/** Write a change to the network block and let the server pick it up on the save. */
+function patchNetwork(patch) {
+  state.network = { ...network(), ...patch }
+  queueSave()
+  // Sharing or a new neighbour changes what the next scan returns, so pull one in soon.
+  setTimeout(poll, 600)
+}
 let threads = []
 /** Last legend built for the bottom bar, kept so the open zone's chip can light up between polls. */
 let legendProjects = []
@@ -141,6 +157,13 @@ const actions = {
    */
   newConversation: async () => {
     const name = selectedProject
+    // A visiting district's repo is on another machine — there is no folder here to root a
+    // new thread in, and starting one is the owner's to do, not a visitor's.
+    const plot = name && colony.plots.get(name)
+    if (plot?.colony) {
+      hud.toast(`You are visiting ${plot.colony}'s colony — new threads are hers to start`)
+      return
+    }
     const folder = name && pathForProject(name)
     if (!folder) {
       hud.toast('No folder on disk for that project', 'err')
@@ -179,6 +202,9 @@ const actions = {
   markViewed: () => {
     const thread = threads.find((t) => t.id === selectedId)
     if (!thread) return
+    // Unread on a visiting thread is her bookkeeping, not yours: marking it viewed here would
+    // record a timestamp against an id that only means something on her machine.
+    if (thread.colony) return
     state.viewedAt = { ...(state.viewedAt || {}), [thread.id]: Date.now() }
     queueSave()
     applyThreads(threads)
@@ -225,6 +251,12 @@ const actions = {
   openThread: async () => {
     const thread = threads.find((t) => t.id === selectedId)
     if (!thread) return
+    // A visiting colony's thread is on another machine — there is nothing here to open, and
+    // the harness deep link would resolve to your own session ids, not hers.
+    if (thread.colony) {
+      hud.toast(`This thread lives on ${thread.colony}'s machine — you are visiting, read-only`)
+      return
+    }
     try {
       await openThread(thread)
       colony.astronauts.celebrate(thread.id)
@@ -242,6 +274,12 @@ const actions = {
   archiveThread: () => {
     const thread = threads.find((t) => t.id === selectedId)
     if (!thread) return
+    // Archiving is retiring a thread from *your* colony. A visitor's thread is not yours to
+    // retire — it belongs to her map, and would walk straight back on the next poll anyway.
+    if (thread.colony) {
+      hud.toast(`${thread.colony}'s threads are read-only here — nothing to archive`)
+      return
+    }
     const foldedBefore = new Set(colony.dormantProjects || [])
     state.archived = [...new Set([...state.archived, thread.id])]
     state.archivedAt = { ...state.archivedAt, [thread.id]: Date.now() }
@@ -262,6 +300,23 @@ const actions = {
   },
 
   uiVisibility: (visible) => colony.setUiVisible(visible),
+
+  // ── shared colonies ────────────────────────────────────────────────────────────────
+  /** The machine's own network config, for the settings panel to render. */
+  getNetwork: () => ({ ...network() }),
+  /** Fold the live neighbour/discovery view together with the saved config. */
+  fetchNeighbors: () => fetchNeighbors(),
+  setShare: (on) => patchNetwork({ share: Boolean(on) }),
+  setColonyName: (name) => patchNetwork({ colonyName: String(name || '').slice(0, 80) }),
+  addNeighbor: ({ name, host, port }) => {
+    const clean = { name: String(name || host || '').slice(0, 80), host: String(host || '').trim(), port: Number(port) || 0 }
+    if (!clean.host || !clean.port) return
+    const neighbors = network().neighbors.filter((n) => !(n.host === clean.host && n.port === clean.port))
+    patchNetwork({ neighbors: [...neighbors, clean] })
+  },
+  removeNeighbor: (host, port) => {
+    patchNetwork({ neighbors: network().neighbors.filter((n) => !(n.host === host && n.port === port)) })
+  },
 
   // The card's bar is about the *thread*, not about how much of its building has risen —
   // those were the same number while construction was drawn by burying the structure.
@@ -393,9 +448,13 @@ function syncProject() {
     })
 
   hud.setProject({
-    name: plot.name,
+    name: plot.colony ? plot.name.replace(`${plot.colony} · `, '') : plot.name,
     accent: plot.accent,
-    path: pathForProject(plot.name),
+    // A visiting district's folder is on another machine, so there is nothing local to open,
+    // reveal or copy — the panel reads as read-only and its action buttons go quiet.
+    colony: plot.colony || '',
+    colonyOnline: plot.colonyOnline !== false,
+    path: plot.colony ? '' : pathForProject(plot.name),
     threads: list,
     selectedId,
   })

--- a/src/main.js
+++ b/src/main.js
@@ -749,7 +749,12 @@ function applyThreads(list) {
   legendProjects = colony.plotOrder
     .map((plot) => ({
       name: plot.name,
+      // A visiting repo's list row drops the "Colony · " prefix — its colony is the section
+      // heading above it, so the row need only name the repo.
+      label: plot.colony ? plot.name.replace(`${plot.colony} · `, '') : plot.name,
       accent: plot.accent,
+      colony: plot.colony || '',
+      colonyOnline: plot.colonyOnline !== false,
       count: list.filter((t) => !t.archived && !archivedSet.has(t.id) && t.project === plot.name).length,
       urgent: colony.urgentPlots?.has(plot.id) ?? false,
     }))

--- a/src/ui/hud.js
+++ b/src/ui/hud.js
@@ -44,6 +44,8 @@ const ICON = {
   copy: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"/><path d="M5 15H4a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v1"/></svg>`,
   locate: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"><circle cx="12" cy="12" r="3"/><circle cx="12" cy="12" r="7.6"/><path d="M12 1.8v2.6M12 19.6v2.6M1.8 12h2.6M19.6 12h2.6"/></svg>`,
   orbit: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><circle cx="12" cy="12" r="4"/><ellipse cx="12" cy="12" rx="10.2" ry="4.6" transform="rotate(-24 12 12)"/><circle cx="21" cy="8.2" r="1.5" fill="currentColor" stroke="none"/></svg>`,
+  // A broadcast mast — sharing with the network.
+  share: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"><circle cx="12" cy="12" r="2"/><path d="M12 14v6M8.5 8.5a5 5 0 0 0 0 7M15.5 8.5a5 5 0 0 1 0 7M6 6a8 8 0 0 0 0 12M18 6a8 8 0 0 1 0 12"/></svg>`,
 }
 
 const STAT_DEFS = [
@@ -275,6 +277,7 @@ export class Hud {
          <div class="label"><span>Share on the network</span><span class="hint net-share-hint">Off — nobody can see this colony.</span></div>
          <button class="toggle net-share" role="switch" type="button"></button>
        </div>
+       <p class="net-count" hidden></p>
        <div class="net-block">
          <div class="net-head">Neighbours</div>
          <div class="net-list net-configured"></div>
@@ -327,6 +330,20 @@ export class Hud {
     g.querySelector('.net-share-hint').textContent = cfg.share
       ? 'On — teammates on your network can visit this colony.'
       : 'Off — nobody can see this colony.'
+
+    // What is actually exposed, so "sharing" never quietly means "sharing everything" or
+    // "sharing nothing". Only shown while sharing is on.
+    const countEl = g.querySelector('.net-count')
+    const summary = this.actions.sharedSummary?.() || { repos: 0, exposed: 0 }
+    countEl.hidden = !cfg.share
+    if (cfg.share) {
+      countEl.innerHTML =
+        summary.exposed === 0
+          ? 'Nothing shared yet — open a repo and press <b>Share with others</b>, or select a session and press <b>Share</b>.'
+          : `Sharing <b>${summary.exposed}</b> session${summary.exposed === 1 ? '' : 's'}` +
+            (summary.repos ? ` across <b>${summary.repos}</b> repo${summary.repos === 1 ? '' : 's'}` : '') +
+            '.'
+    }
 
     let live = { colonies: [], discovered: [] }
     try {
@@ -492,11 +509,13 @@ export class Hud {
     on('#btn-open', 'click', () => this.actions.openThread?.())
     on('#btn-viewed', 'click', () => this.actions.markViewed?.())
     on('#btn-archive', 'click', () => this.actions.archiveThread?.())
+    on('#btn-share-session', 'click', () => this.selected && this.actions.toggleShareSession?.(this.selected.thread.id))
     on('#btn-deselect', 'click', () => this.actions.select?.(null))
     on('#btn-new-session', 'click', () => this.actions.newConversation?.())
     on('#btn-reveal', 'click', () => this.actions.revealProject?.())
     on('#btn-copy-path', 'click', () => this.actions.copyProjectPath?.())
     on('#btn-hide-project', 'click', () => this.actions.hideProject?.())
+    on('#btn-share-repo', 'click', () => this.actions.toggleShareRepo?.(this.project?.name))
     on('#btn-hidden-toggle', 'click', () => this.toggleHiddenList())
     on('#btn-locate', 'click', () => this.actions.focusProject?.(this.project?.name))
     on('#btn-close-project', 'click', () => this.actions.closeProject?.())
@@ -664,6 +683,14 @@ export class Hud {
     this.$('#btn-reveal').disabled = visiting || !project.path
     this.$('#btn-copy-path').disabled = visiting || !project.path
     this.$('#btn-hide-project').hidden = visiting
+    // Share is offered on your own repos, only while sharing is on. Its label flips to say
+    // what the click will do, and the button lights up while the repo is being shared.
+    const shareBtn = this.$('#btn-share-repo')
+    shareBtn.hidden = !project.sharing
+    shareBtn.classList.toggle('on', Boolean(project.repoShared))
+    shareBtn.innerHTML = project.repoShared
+      ? `${ICON.share} Stop sharing`
+      : `${ICON.share} Share with others`
 
     const n = project.threads.length
     const waiting = project.threads.filter((t) => t.status === 'waiting' || t.status === 'blocked').length
@@ -684,6 +711,7 @@ export class Hud {
       b.innerHTML =
         '<i class="pip"></i>' +
         `<span class="t">${escapeHtml(t.title || 'Untitled thread')}</span>` +
+        (t.shared ? `<span class="shared-mark" title="Shared with the network">${ICON.share}</span>` : '') +
         `<span class="when">${ago(t.lastActivityAt)}</span>` +
         (t.worktree ? `<span class="wt">⑂ ${escapeHtml(t.worktree)}</span>` : '')
       b.addEventListener('click', () => this.actions.focusThread?.(t.id))
@@ -762,6 +790,19 @@ export class Hud {
     // crowd the two that are always worth having, and "Viewed" on a thread that is not asking
     // for anything is a control with no effect.
     this.$('#btn-viewed').hidden = visiting || !thread.unread
+    // Share is offered on your own sessions while sharing is on. When the whole repo is
+    // shared the per-session switch is redundant, so it reads as a locked-on state instead.
+    const shareState = visiting ? '' : this.actions.sessionShareState?.(thread.id) || ''
+    const shareBtn = this.$('#btn-share-session')
+    shareBtn.hidden = visiting || !this.actions.sharingOn?.()
+    shareBtn.classList.toggle('on', shareState !== '')
+    shareBtn.disabled = shareState === 'repo'
+    shareBtn.innerHTML =
+      shareState === 'repo'
+        ? `${ICON.share} Shared (repo)`
+        : shareState === 'session'
+          ? `${ICON.share} Stop sharing`
+          : `${ICON.share} Share`
   }
 
   /**
@@ -1102,6 +1143,7 @@ const TEMPLATE = `
           <button class="btn" id="btn-reveal" title="Show this folder in ${FILE_MANAGER}">${ICON.folder} ${FILE_MANAGER}</button>
           <button class="btn" id="btn-copy-path" title="Copy the folder path">${ICON.copy} Copy path</button>
         </div>
+        <button class="btn" id="btn-share-repo" title="Share this repo — every session in it becomes visible to colonies visiting you" hidden>${ICON.share} Share with others</button>
         <button class="btn" id="btn-hide-project" title="Hide this repo from the colony — does not archive its threads">${ICON.eyeOff} Hide from colony</button>
       </div>
       <div class="threads-head"></div>
@@ -1138,6 +1180,7 @@ const TEMPLATE = `
   <div class="pair">
     <button class="btn primary" id="btn-open" title="Open this thread in the harness it came from (Enter)">${ICON.open} Open</button>
     <button class="btn" id="btn-viewed" title="Stop this thread asking for you until it moves on again (V)">${ICON.eye} Viewed</button>
+    <button class="btn" id="btn-share-session" title="Share this one session with the network" hidden>${ICON.share} Share</button>
     <button class="btn" id="btn-archive" title="Archive — this astronaut walks back to the ship (A)">${ICON.archive} Archive</button>
   </div>
 </div>

--- a/src/ui/hud.js
+++ b/src/ui/hud.js
@@ -553,7 +553,7 @@ export class Hud {
    */
   setLegend(projects, activeName = null, hidden = [], folded = []) {
     const signature =
-      projects.map((p) => `${p.name}:${p.count}:${p.accent}:${p.urgent ? 1 : 0}`).join('|') +
+      projects.map((p) => `${p.name}:${p.count}:${p.accent}:${p.urgent ? 1 : 0}:${p.colony || ''}:${p.colonyOnline}`).join('|') +
       `~${activeName}~` +
       hidden.map((p) => `${p.name}:${p.count}`).join('|') +
       `~${folded.length}`
@@ -562,21 +562,50 @@ export class Hud {
 
     const wrap = this.$('.projects')
     wrap.innerHTML = ''
-    for (const p of projects) {
+
+    const repoButton = (p) => {
       const b = document.createElement('button')
       b.type = 'button'
       b.className = 'repo'
-      b.title = `${p.count} thread${p.count === 1 ? '' : 's'} in ${p.name}`
+      b.title = `${p.count} thread${p.count === 1 ? '' : 's'} in ${p.label || p.name}`
       b.setAttribute('aria-pressed', String(p.name === activeName))
       b.innerHTML =
         `<i class="swatch" style="background:${hex(p.accent)};color:${hex(p.accent)}"></i>` +
-        `<span class="n">${escapeHtml(p.name)}</span>` +
+        `<span class="n">${escapeHtml(p.label || p.name)}</span>` +
         (p.urgent ? '<i class="alarm"></i>' : '') +
         `<span class="count">${p.count}</span>`
       b.addEventListener('click', () => this.actions.pickProject?.(p.name))
-      wrap.appendChild(b)
+      return b
     }
-    this.$('.sec-head span').textContent = `${projects.length} repo${projects.length === 1 ? '' : 's'}`
+
+    // Your own repos first; each visiting colony is its own labelled section below, so it is
+    // always clear whose world a repo belongs to.
+    const home = projects.filter((p) => !p.colony)
+    const byColony = new Map()
+    for (const p of projects) {
+      if (!p.colony) continue
+      if (!byColony.has(p.colony)) byColony.set(p.colony, [])
+      byColony.get(p.colony).push(p)
+    }
+
+    for (const p of home) wrap.appendChild(repoButton(p))
+
+    for (const [colony, repos] of byColony) {
+      const head = document.createElement('div')
+      head.className = 'colony-head'
+      const online = repos.every((r) => r.colonyOnline)
+      head.innerHTML =
+        `<i class="net-dot ${online ? 'on' : 'off'}"></i>` +
+        `<span class="colony-name">${escapeHtml(colony)}</span>` +
+        `<span class="colony-tag">visiting${online ? '' : ' · away'}</span>`
+      wrap.appendChild(head)
+      for (const p of repos) wrap.appendChild(repoButton(p))
+    }
+
+    const colonyCount = byColony.size
+    this.$('.sec-head span').textContent =
+      `${home.length} repo${home.length === 1 ? '' : 's'}` +
+      (colonyCount ? ` · ${colonyCount} visiting` : '')
 
     // The hidden list is its own block at the foot of the sidebar: collapsed by default, because
     // the whole point of hiding a repo is not to look at it.

--- a/src/ui/hud.js
+++ b/src/ui/hud.js
@@ -286,6 +286,11 @@ export class Hud {
          <div class="net-head">Found on your network</div>
          <div class="net-list net-discovered"></div>
        </div>
+       <div class="net-block net-refused-block" hidden>
+         <div class="net-head">Tried to visit you</div>
+         <p class="note">A colleague reached your colony from an address you have not added — over a VPN this can differ from the one they expect. Add it to let them in.</p>
+         <div class="net-list net-refused"></div>
+       </div>
        <div class="net-add">
          <input class="net-host text-input" type="text" spellcheck="false" placeholder="hostname or IP">
          <input class="net-port text-input" type="text" spellcheck="false" inputmode="numeric" placeholder="5275">
@@ -396,6 +401,31 @@ export class Hud {
         this._refreshNetwork()
       })
       dlist.appendChild(row)
+    }
+
+    // Strangers the guest socket turned away — the click adds them at the guest port so a
+    // colleague blocked by a VPN's unexpected source address can be let in on sight.
+    const refused = (live.refused || []).filter(
+      (r) => !neighbors.some((n) => n.host === r.host)
+    )
+    const rblock = g.querySelector('.net-refused-block')
+    rblock.hidden = refused.length === 0
+    const rlist = g.querySelector('.net-refused')
+    rlist.innerHTML = ''
+    const guestPort = live.guestPort || 5275
+    for (const r of refused) {
+      const row = document.createElement('div')
+      row.className = 'net-item'
+      row.innerHTML =
+        `<i class="net-dot off"></i>` +
+        `<span class="net-item-name">${escapeHtml(r.host)}</span>` +
+        `<span class="net-item-addr">turned away</span>` +
+        `<button class="btn net-add-one">Add</button>`
+      row.querySelector('.net-add-one').addEventListener('click', () => {
+        this.actions.addNeighbor?.({ name: r.host, host: r.host, port: guestPort })
+        this._refreshNetwork()
+      })
+      rlist.appendChild(row)
     }
   }
 

--- a/src/ui/hud.js
+++ b/src/ui/hud.js
@@ -250,6 +250,136 @@ export class Hud {
       this._toggle('Show FPS', 'showFps')
     )
     body.appendChild(view)
+
+    this._buildNetwork(body)
+  }
+
+  /**
+   * Shared colonies. Unlike everything above it, this section is not backed by `Settings`
+   * (per-browser render preferences) but by the colony file's `network` block and a live
+   * poll of the LAN — so it manages its own DOM and refreshes itself whenever the panel
+   * opens, rather than riding the `controls` sync.
+   */
+  _buildNetwork(body) {
+    if (!this.actions.getNetwork) return
+    const g = group('Shared colonies')
+    g.classList.add('network')
+    g.insertAdjacentHTML(
+      'beforeend',
+      `<p class="note">Share this machine's colony on your intranet, and visit your teammates'. Visiting is always read-only — you see their astronauts, you cannot touch their threads.</p>
+       <div class="row">
+         <div class="label"><span>Colony name</span><span class="hint">How you appear to others.</span></div>
+         <input class="net-name text-input" type="text" maxlength="80" spellcheck="false" placeholder="colony">
+       </div>
+       <div class="row">
+         <div class="label"><span>Share on the network</span><span class="hint net-share-hint">Off — nobody can see this colony.</span></div>
+         <button class="toggle net-share" role="switch" type="button"></button>
+       </div>
+       <div class="net-block">
+         <div class="net-head">Neighbours</div>
+         <div class="net-list net-configured"></div>
+       </div>
+       <div class="net-block net-discovered-block" hidden>
+         <div class="net-head">Found on your network</div>
+         <div class="net-list net-discovered"></div>
+       </div>
+       <div class="net-add">
+         <input class="net-host text-input" type="text" spellcheck="false" placeholder="hostname or IP">
+         <input class="net-port text-input" type="text" spellcheck="false" inputmode="numeric" placeholder="5275">
+         <button class="btn net-add-btn" type="button">Add</button>
+       </div>`
+    )
+    body.appendChild(g)
+
+    const name = g.querySelector('.net-name')
+    name.addEventListener('change', () => this.actions.setColonyName?.(name.value.trim()))
+    g.querySelector('.net-share').addEventListener('click', () => {
+      const now = Boolean(this.actions.getNetwork?.().share)
+      this.actions.setShare?.(!now)
+      this._refreshNetwork()
+    })
+    const host = g.querySelector('.net-host')
+    const port = g.querySelector('.net-port')
+    const add = () => {
+      const h = host.value.trim()
+      const p = Number(port.value.trim()) || 5275
+      if (!h) return
+      this.actions.addNeighbor?.({ name: h, host: h, port: p })
+      host.value = ''
+      port.value = ''
+      this._refreshNetwork()
+    }
+    g.querySelector('.net-add-btn').addEventListener('click', add)
+    port.addEventListener('keydown', (e) => e.key === 'Enter' && add())
+    host.addEventListener('keydown', (e) => e.key === 'Enter' && add())
+    this._net = g
+  }
+
+  /** Repaint the network section from the saved config and a fresh look at the LAN. */
+  async _refreshNetwork() {
+    const g = this._net
+    if (!g) return
+    const cfg = this.actions.getNetwork?.() || { colonyName: '', share: false, neighbors: [] }
+    const nameInput = g.querySelector('.net-name')
+    if (document.activeElement !== nameInput) nameInput.value = cfg.colonyName || ''
+    const share = g.querySelector('.net-share')
+    share.setAttribute('aria-checked', String(Boolean(cfg.share)))
+    g.querySelector('.net-share-hint').textContent = cfg.share
+      ? 'On — teammates on your network can visit this colony.'
+      : 'Off — nobody can see this colony.'
+
+    let live = { colonies: [], discovered: [] }
+    try {
+      live = await this.actions.fetchNeighbors?.()
+    } catch {
+      /* server not reachable or feature off — the saved list still renders */
+    }
+    const online = new Map((live.colonies || []).map((c) => [`${c.host}:${c.port}`, c]))
+
+    const configured = g.querySelector('.net-configured')
+    configured.innerHTML = ''
+    const neighbors = cfg.neighbors || []
+    if (!neighbors.length) {
+      configured.innerHTML = `<div class="net-empty">None yet. Add one below, or pick a discovered colony.</div>`
+    }
+    for (const n of neighbors) {
+      const state = online.get(`${n.host}:${n.port}`)
+      const on = Boolean(state?.online)
+      const row = document.createElement('div')
+      row.className = 'net-item'
+      row.innerHTML =
+        `<i class="net-dot ${on ? 'on' : 'off'}" title="${on ? 'Online' : 'Offline'}"></i>` +
+        `<span class="net-item-name">${escapeHtml(state?.name || n.name || n.host)}</span>` +
+        `<span class="net-item-addr">${escapeHtml(n.host)}:${n.port}</span>` +
+        `<button class="btn icon ghost net-remove" title="Stop visiting">${ICON.close}</button>`
+      row.querySelector('.net-remove').addEventListener('click', () => {
+        this.actions.removeNeighbor?.(n.host, n.port)
+        this._refreshNetwork()
+      })
+      configured.appendChild(row)
+    }
+
+    const discovered = (live.discovered || []).filter(
+      (d) => !neighbors.some((n) => n.host === d.host && n.port === d.port)
+    )
+    const dblock = g.querySelector('.net-discovered-block')
+    dblock.hidden = discovered.length === 0
+    const dlist = g.querySelector('.net-discovered')
+    dlist.innerHTML = ''
+    for (const d of discovered) {
+      const row = document.createElement('div')
+      row.className = 'net-item'
+      row.innerHTML =
+        `<i class="net-dot on"></i>` +
+        `<span class="net-item-name">${escapeHtml(d.name || d.host)}</span>` +
+        `<span class="net-item-addr">${escapeHtml(d.host)}:${d.port}</span>` +
+        `<button class="btn net-add-one">Add</button>`
+      row.querySelector('.net-add-one').addEventListener('click', () => {
+        this.actions.addNeighbor?.({ name: d.name, host: d.host, port: d.port })
+        this._refreshNetwork()
+      })
+      dlist.appendChild(row)
+    }
   }
 
   _row(label, hint) {
@@ -506,10 +636,12 @@ export class Hud {
     // The minute is part of the signature because `ago()` is: without it a repo where
     // nothing is happening keeps whatever "4m ago" it was first drawn with, for as long as
     // you leave the panel open.
+    const visiting = Boolean(project.colony)
     const signature =
-      `${project.name}~${project.path}~${project.accent}~${project.selectedId}~${Math.floor(Date.now() / 60000)}~` +
+      `${project.name}~${project.path}~${project.accent}~${project.selectedId}~${project.colony}~${project.colonyOnline}~${Math.floor(Date.now() / 60000)}~` +
       project.threads.map((t) => `${t.id}:${t.status}:${t.title}:${t.lastActivityAt}`).join('|')
     panel.classList.add('drilled')
+    panel.classList.toggle('visiting', visiting)
     if (this._last.project === signature) return
     this._last.project = signature
 
@@ -518,12 +650,20 @@ export class Hud {
     swatch.style.color = hex(project.accent) // the halo is `currentColor`
     this.$('.side .name').textContent = project.name
     const path = this.$('.side .path')
-    path.textContent = project.path ? shortPath(project.path) : 'folder unknown'
-    path.title = project.path || ''
-    // Nothing to open a new thread in, and nothing to reveal, without a folder on disk.
-    this.$('#btn-new-session').disabled = !project.path
-    this.$('#btn-reveal').disabled = !project.path
-    this.$('#btn-copy-path').disabled = !project.path
+    // A visiting district names its colony where a home repo names its folder.
+    if (visiting) {
+      path.textContent = `◈ on ${project.colony}'s colony${project.colonyOnline ? '' : ' · away'}`
+      path.title = `A repo on ${project.colony}'s machine — read-only`
+    } else {
+      path.textContent = project.path ? shortPath(project.path) : 'folder unknown'
+      path.title = project.path || ''
+    }
+    // A visiting district has no folder on this machine: opening a thread, revealing or
+    // copying a path all reach for something that is not here, so they are switched off.
+    this.$('#btn-new-session').disabled = visiting || !project.path
+    this.$('#btn-reveal').disabled = visiting || !project.path
+    this.$('#btn-copy-path').disabled = visiting || !project.path
+    this.$('#btn-hide-project').hidden = visiting
 
     const n = project.threads.length
     const waiting = project.threads.filter((t) => t.status === 'waiting' || t.status === 'blocked').length
@@ -590,6 +730,13 @@ export class Hud {
     const bits = [
       `<span class="tag"><i class="swatch" style="background:${hex(agent.trim.getHex())}"></i>${escapeHtml(status)}</span>`,
     ]
+    // A visiting colony's thread wears its origin, so it is never mistaken for one of yours —
+    // and the card's actions are pared back to match, since none of them can reach her machine.
+    if (thread.colony) {
+      bits.push(
+        `<span class="tag visiting" title="On ${escapeHtml(thread.colony)}'s colony — read-only${thread.colonyOnline === false ? ', currently offline' : ''}">◈ ${escapeHtml(thread.colony)}${thread.colonyOnline === false ? ' · away' : ''}</span>`
+      )
+    }
     // The repo is the panel's own heading now, so the card says what the *thread* is.
     if (thread.worktree) bits.push(`<span class="tag">⑂ ${escapeHtml(thread.worktree)}</span>`)
     if (thread.gitBranch) bits.push(`<span class="tag">${escapeHtml(thread.gitBranch)}</span>`)
@@ -605,10 +752,16 @@ export class Hud {
     // often is how a HUD starts costing frames.
     this._cardSize = { w: card.offsetWidth, h: card.offsetHeight }
     this.$('#btn-open').disabled = thread.canOpen === false
+    // A visiting thread lives on somebody else's machine: opening, archiving and marking it
+    // viewed all reach for records that are not yours, so the card drops those controls
+    // entirely and leaves only what you came to do — look.
+    const visiting = Boolean(thread.colony)
+    this.$('#btn-open').hidden = visiting
+    this.$('#btn-archive').hidden = visiting
     // Only offered when there is something to dismiss. A third button on every card would
     // crowd the two that are always worth having, and "Viewed" on a thread that is not asking
     // for anything is a control with no effect.
-    this.$('#btn-viewed').hidden = !thread.unread
+    this.$('#btn-viewed').hidden = visiting || !thread.unread
   }
 
   /**
@@ -761,6 +914,13 @@ export class Hud {
     this.$('#btn-settings').setAttribute('aria-pressed', String(open))
     // Both live in the same slot on the right; the sidebar steps aside rather than hides.
     this.$('.side').classList.toggle('shifted', open)
+    // The network section is live — neighbours come and go on the LAN — so it refreshes while
+    // the panel is open and stops the moment it closes.
+    clearInterval(this._netTimer)
+    if (open && this._net) {
+      this._refreshNetwork()
+      this._netTimer = setInterval(() => this._refreshNetwork(), 5000)
+    }
   }
 
   toggleHelp(force) {

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1552,6 +1552,35 @@ kbd {
 /* Same story for the astronaut card: open, archive and viewed are gone for a visitor. */
 .thread-pop #btn-open[hidden],
 .thread-pop #btn-archive[hidden],
-.thread-pop #btn-viewed[hidden] {
+.thread-pop #btn-viewed[hidden],
+.thread-pop #btn-share-session[hidden],
+#btn-share-repo[hidden] {
   display: none !important;
 }
+
+/* A share button that is currently sharing lights up in the network teal. */
+.btn.on {
+  color: #bff3ec;
+  border-color: rgba(47, 212, 196, 0.5);
+  background: rgba(47, 212, 196, 0.14);
+}
+.btn.on svg { color: var(--teal); }
+
+/* The little broadcast mark on a shared session's row in the repo list. */
+.side .threads .thread .shared-mark {
+  display: inline-flex;
+  align-items: center;
+  color: var(--teal);
+  margin-left: 4px;
+}
+.side .threads .thread .shared-mark svg {
+  width: 13px;
+  height: 13px;
+}
+
+.group.network .net-count {
+  margin: 10px 0 0;
+  font-size: 11.5px;
+  color: var(--dim);
+}
+.group.network .net-count b { color: var(--teal); font-weight: 600; }

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1584,3 +1584,36 @@ kbd {
   color: var(--dim);
 }
 .group.network .net-count b { color: var(--teal); font-weight: 600; }
+
+/* A visiting colony's own section in the repo list — a heading that separates whose world
+   is whose, with an online dot and a quiet "visiting" tag. */
+.projects .colony-head {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin: 12px 0 4px;
+  padding: 5px 8px 4px;
+  border-top: 1px solid var(--line);
+}
+.projects .colony-head .colony-name {
+  font-size: 12px;
+  font-weight: 650;
+  letter-spacing: 0.02em;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.projects .colony-head .colony-tag {
+  margin-left: auto;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: var(--teal);
+  text-transform: uppercase;
+}
+.projects .colony-head .net-dot {
+  width: 7px;
+  height: 7px;
+  flex: none;
+}

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1418,3 +1418,140 @@ kbd {
   }
 }
 .bot-crossing-canvas { cursor: grab; }
+
+/* ── shared colonies ──────────────────────────────────────────────────────── */
+.group.network .note {
+  margin: 0 0 10px;
+  font-size: 11.5px;
+  line-height: 1.4;
+  color: var(--dim);
+}
+
+.text-input {
+  height: 30px;
+  padding: 0 10px;
+  border-radius: 9px;
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text);
+  font-size: 13px;
+  font-family: inherit;
+  outline: none;
+  min-width: 0;
+}
+.text-input:focus {
+  border-color: var(--teal);
+}
+.group.network .net-name {
+  width: 150px;
+  flex: none;
+}
+
+.net-block {
+  margin-top: 12px;
+}
+.net-head {
+  font-size: 11px;
+  font-weight: 650;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--dim);
+  margin-bottom: 6px;
+}
+.net-empty {
+  font-size: 12px;
+  color: var(--dim);
+  padding: 4px 0;
+}
+
+.net-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 0;
+}
+.net-item-name {
+  font-size: 13px;
+  font-weight: 550;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.net-item-addr {
+  font-size: 11px;
+  color: var(--dim);
+  margin-left: auto;
+  white-space: nowrap;
+}
+.net-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex: none;
+}
+.net-dot.on {
+  background: var(--teal);
+  box-shadow: 0 0 6px var(--teal);
+}
+.net-dot.off {
+  background: rgba(255, 255, 255, 0.22);
+}
+.net-item .btn.icon {
+  width: 24px;
+  min-width: 24px;
+  height: 24px;
+  flex: none;
+}
+.net-item .net-add-one {
+  padding: 3px 10px;
+  font-size: 12px;
+  flex: none;
+}
+
+.net-add {
+  display: flex;
+  gap: 6px;
+  margin-top: 12px;
+}
+.net-add .net-host {
+  flex: 1;
+}
+.net-add .net-port {
+  width: 58px;
+  flex: none;
+  text-align: center;
+}
+.net-add .net-add-btn {
+  flex: none;
+  padding: 0 14px;
+}
+
+/* a visiting thread's origin tag, and the read-only district panel */
+.thread-pop .tag.visiting {
+  background: rgba(47, 212, 196, 0.16);
+  color: #bff3ec;
+}
+.side.visiting .who .name::after {
+  content: '◈ visiting';
+  margin-left: 8px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: var(--teal);
+  vertical-align: middle;
+}
+/* A visiting district is read-only: none of the repo actions reach another machine, so the
+   whole action row is dropped and the thread list stands on its own. `hidden`/`disabled` in
+   JS is not enough — the `.btn` class sets `display`, which beats the `hidden` attribute. */
+.side.visiting #btn-new-session,
+.side.visiting #btn-reveal,
+.side.visiting #btn-copy-path,
+.side.visiting #btn-hide-project {
+  display: none !important;
+}
+/* Same story for the astronaut card: open, archive and viewed are gone for a visitor. */
+.thread-pop #btn-open[hidden],
+.thread-pop #btn-archive[hidden],
+.thread-pop #btn-viewed[hidden] {
+  display: none !important;
+}

--- a/src/world/plots.js
+++ b/src/world/plots.js
@@ -83,6 +83,11 @@ function hexToWorld(q, r, size = CELL) {
   return { x: size * 1.5 * q, z: size * Math.sqrt(3) * (r + q / 2) }
 }
 
+/** The world XZ of a cell's centre — so the colony can sample terrain height under a plot. */
+export function cellWorld(q, r) {
+  return hexToWorld(q, r)
+}
+
 /**
  * The inverse: which cell a world point falls in. Exact rather than nearest-centre, because
  * it decides whether something is standing on a plot's raised deck or on bare ground, and a
@@ -134,7 +139,7 @@ const cellsNeeded = (threadCount) =>
  * deliberate: a district you walk to reads as somebody else's settlement, not as your own
  * colony growing a lobe.
  */
-const ANCHOR_RING = 7
+const ANCHOR_RING = 5
 export function colonyAnchor(name) {
   const ring = hexRing(ANCHOR_RING)
   return ring[hashString(`colony:${name}`) % ring.length]
@@ -451,13 +456,20 @@ function hexPrism(radius, height) {
 // ── plot mesh ─────────────────────────────────────────────────────────────────────────
 
 export class Plot {
-  constructor({ id, name, index, cells, accent }) {
+  constructor({ id, name, index, cells, accent, groundY = 0 }) {
     this.id = id
     this.name = name
     this.index = index
     this.cells = cells
     this.accent = accent
     this.cellKeys = new Set(cells.map((c) => key(c.q, c.r)))
+    /**
+     * The terrain height the whole slab sits on. Near the ship this is ~0 and changes nothing,
+     * but a visiting colony's district is anchored far out where the ground rolls, and a slab
+     * pinned to y=0 there floats over a dip or is swallowed by a rise. Everything on the plot —
+     * deck, border, buildings, the crew's footing — is measured up from this.
+     */
+    this.groundY = groundY
 
     // The plot's origin is its **root** tile — the one it was seeded on and never gives up
     // — rather than the centroid of whatever cells it holds this minute. A zone that gains
@@ -491,7 +503,7 @@ export class Plot {
     this.radius = CELL * Math.sqrt(cells.length)
 
     this.group = new THREE.Group()
-    this.group.position.copy(this.center)
+    this.group.position.set(this.center.x, this.groundY, this.center.z)
     this.group.name = `plot:${id}`
 
     this._buildDeck()
@@ -715,8 +727,10 @@ export class Plot {
   }
 
   worldSlot(index, out = new THREE.Vector3()) {
+    // Buildings live in world space, not under the plot group, so the slab's own ground height
+    // has to be added back in here or a sunk district's buildings hang in the air above it.
     const s = this.slotFor(index)
-    return out.set(this.center.x + s.x, DECK_TOP, this.center.z + s.z)
+    return out.set(this.center.x + s.x, this.groundY + DECK_TOP, this.center.z + s.z)
   }
 
   /** Night lighting, plus a pulse on the border when this plot holds something urgent. */

--- a/src/world/plots.js
+++ b/src/world/plots.js
@@ -261,8 +261,13 @@ function layOut(projects, previous) {
     }
   }
 
+  // How far an anchored zone's remembered root may sit from its colony's anchor before the
+  // memory is thrown away and it re-seeds by the anchor. A visiting colony's repos are meant to
+  // read as one district; a plot that was placed before its colony was known — or under an
+  // older anchor — stays stranded across the map otherwise, which is exactly what this catches.
+  const DISTRICT_DRIFT = 3
   const held = new Map()
-  for (const { id, want } of wanted) {
+  for (const { id, want, anchor } of wanted) {
     const before = previous.get(id)
     if (!before || !before.length) continue
     // The root cell is the whole point — it is the zone's origin, and everything standing
@@ -270,6 +275,9 @@ function layOut(projects, previous) {
     // the root is gone this project is seeded afresh rather than quietly re-rooted onto
     // whichever of its old cells happens to still be free.
     if (!free.has(key(before[0].q, before[0].r))) continue
+    // A district member whose memory drifted far from the anchor is re-seeded, so a stale
+    // placement cannot hold a repo out on its own away from the rest of its colony.
+    if (anchor && hexDistance(before[0], anchor) > DISTRICT_DRIFT) continue
     const keep = []
     for (const cell of before) {
       if (keep.length >= want) break // shrunk: whatever it claimed last is what it gives up

--- a/src/world/plots.js
+++ b/src/world/plots.js
@@ -127,6 +127,19 @@ function hexRing(radius) {
 const cellsNeeded = (threadCount) =>
   Math.max(1, Math.min(MAX_CELLS, Math.ceil(threadCount / SLOTS_PER_CELL)))
 
+/**
+ * Where a visiting colony pitches its district: a fixed cell on a ring well outside the home
+ * zones, picked by the colony's name so the same neighbour always lands on the same ground —
+ * across polls, reloads and machines. The gap of bare terrain between ring ~4 and here is
+ * deliberate: a district you walk to reads as somebody else's settlement, not as your own
+ * colony growing a lobe.
+ */
+const ANCHOR_RING = 7
+export function colonyAnchor(name) {
+  const ring = hexRing(ANCHOR_RING)
+  return ring[hashString(`colony:${name}`) % ring.length]
+}
+
 /** Hex distance in axial coordinates: the cube distance, halved. */
 function hexDistance(a, b) {
   return (Math.abs(a.q - b.q) + Math.abs(a.q + a.r - b.q - b.r) + Math.abs(a.r - b.r)) / 2
@@ -173,9 +186,14 @@ function hexDistance(a, b) {
  * The ship's cell counts as walkable here even though nobody may claim it: a colony that
  * happens to wrap around the ship is not two colonies.
  */
-function isConnected(out) {
+function isConnected(out, anchored = new Set()) {
   const cells = new Map()
-  for (const [, list] of out) for (const c of list) cells.set(key(c.q, c.r), c)
+  // Anchored zones are *meant* to be islands — a visiting colony's district sits out past
+  // the home zones by design — so they neither have to be reached nor count as unreachable.
+  for (const [id, list] of out) {
+    if (anchored.has(id)) continue
+    for (const c of list) cells.set(key(c.q, c.r), c)
+  }
   if (cells.size < 2) return true
   const ship = key(SHIP_CELL.q, SHIP_CELL.r)
   const passable = new Set([...cells.keys(), ship])
@@ -199,17 +217,18 @@ function isConnected(out) {
 }
 
 export function allocateCells(projects, previous = new Map()) {
+  const anchored = new Set(projects.filter((p) => p.anchor).map((p) => p.id))
   const laid = layOut(projects, previous)
   // Remembering where a zone sat is worth a great deal, right up until it leaves the colony
   // as scattered islands. Then the memory is describing a map that no longer exists, and
   // starting over — compact, from the middle, the way a first run does it — is the lesser
   // upheaval. It only happens when the alternative is visibly broken.
-  return isConnected(laid) ? laid : layOut(projects, new Map())
+  return isConnected(laid, anchored) ? laid : layOut(projects, new Map())
 }
 
 function layOut(projects, previous) {
   const reserved = key(SHIP_CELL.q, SHIP_CELL.r)
-  const wanted = projects.map((p) => ({ id: p.id, want: cellsNeeded(p.size) }))
+  const wanted = projects.map((p) => ({ id: p.id, want: cellsNeeded(p.size), anchor: p.anchor || null }))
   const total = wanted.reduce((n, w) => n + w.want, 0)
 
   // Spiral order decides where a *new* project settles. The pool runs past what is needed
@@ -224,8 +243,11 @@ function layOut(projects, previous) {
   let farthest = 0
   for (const project of projects) {
     for (const cell of previous.get(project.id) || []) farthest = Math.max(farthest, hexDistance(cell, ORIGIN))
+    // An anchored district sits out past the home zones, so the pool has to reach it — plus
+    // a ring of slack for the district to grow into.
+    if (project.anchor) farthest = Math.max(farthest, hexDistance(project.anchor, ORIGIN) + 2)
   }
-  for (let ring = 0; (pool.length < total + 30 || ring <= farthest) && ring < 12; ring++) {
+  for (let ring = 0; (pool.length < total + 30 || ring <= farthest) && ring < ANCHOR_RING + 5; ring++) {
     for (const cell of hexRing(ring)) {
       const k = key(cell.q, cell.r)
       if (k === reserved) continue
@@ -257,31 +279,54 @@ function layOut(projects, previous) {
   const out = new Map()
   // Anybody who was already here grows first, so a newcomer cannot take the cell a zone
   // was about to expand into while its own seed is still free.
-  for (const { id, want } of wanted) {
+  for (const { id, want, anchor } of wanted) {
     const cells = held.get(id)
     if (!cells) continue
-    growBlob(cells, want, free)
+    growBlob(cells, want, free, anchor)
     out.set(id, cells)
   }
 
-  for (const { id, want } of wanted) {
+  for (const { id, want, anchor } of wanted) {
     if (out.has(id)) continue
-    const seed = pool.find((c) => free.has(key(c.q, c.r)))
+    // A home project settles on the innermost free cell; an anchored one settles as close to
+    // its colony's anchor as the ground allows, which is what pulls a neighbour's repos into
+    // one district instead of scattering them through the home zones.
+    const seed = anchor
+      ? nearestFree(pool, free, anchor)
+      : pool.find((c) => free.has(key(c.q, c.r)))
     if (!seed) {
       out.set(id, [])
       continue
     }
     free.delete(key(seed.q, seed.r))
     const cells = [{ q: seed.q, r: seed.r }]
-    growBlob(cells, want, free)
+    growBlob(cells, want, free, anchor)
     out.set(id, cells)
   }
   return out
 }
 
+/** The free pool cell nearest a point — the anchored counterpart of "first in the spiral". */
+function nearestFree(pool, free, to) {
+  let best = null
+  let bestD = Infinity
+  for (const c of pool) {
+    if (!free.has(key(c.q, c.r))) continue
+    const d = hexDistance(c, to)
+    if (d < bestD) {
+      bestD = d
+      best = c
+    }
+  }
+  return best
+}
+
 /** Claim free neighbours until the blob is big enough, hugging its root cell first. */
-function growBlob(cells, want, free) {
+function growBlob(cells, want, free, anchor = null) {
   const root = cells[0]
+  // Growth leans toward the middle of whatever this zone belongs to: the colony's origin for
+  // a home zone, the district's anchor for a visiting one.
+  const pull = anchor || ORIGIN
   while (cells.length < want) {
     let best = null
     let bestScore = Infinity
@@ -290,7 +335,7 @@ function growBlob(cells, want, free) {
         const n = { q: c.q + dq, r: c.r + dr }
         if (!free.has(key(n.q, n.r))) continue
         // Hug the root first, then the middle of the colony, so blobs come out compact.
-        const score = hexDistance(n, root) * 100 + hexDistance(n, ORIGIN)
+        const score = hexDistance(n, root) * 100 + hexDistance(n, pull)
         if (score < bestScore) {
           bestScore = score
           best = n
@@ -779,6 +824,86 @@ export function createLabel(text, accent, pixelRatio = 4) {
   }
   const mesh = new THREE.Mesh(geo, mat)
   mesh.renderOrder = 8
+  mesh.frustumCulled = false
+  mesh.visible = false
+  mesh.userData.dispose = () => {
+    texture.dispose()
+    geo.dispose()
+    mat.dispose()
+  }
+  return mesh
+}
+
+/**
+ * A district banner: a bigger, bolder version of a name plate, floating over a visiting
+ * colony's cluster of plots. Same billboarding as `createLabel`, scaled up so it reads as the
+ * heading over a whole neighbourhood rather than a single zone's plate, with a leading glyph
+ * that marks the district as a visitor's.
+ */
+export function createBanner(text, accent, pixelRatio = 4) {
+  const fontSize = 46
+  const font = `600 ${fontSize}px ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif`
+  const pad = 20
+  const prefix = '◈ '
+  const label = prefix + text
+
+  const measure = document.createElement('canvas').getContext('2d')
+  measure.font = font
+  const textWidth = Math.ceil(measure.measureText(label).width)
+
+  const canvas = document.createElement('canvas')
+  const w = textWidth + pad * 2
+  const h = fontSize + pad * 2
+  canvas.width = Math.ceil(w * pixelRatio)
+  canvas.height = Math.ceil(h * pixelRatio)
+  const c = canvas.getContext('2d')
+  c.scale(pixelRatio, pixelRatio)
+
+  c.font = font
+  c.textAlign = 'left'
+  c.textBaseline = 'middle'
+  const midY = h / 2
+  c.shadowColor = 'rgba(0,0,0,0.9)'
+  c.shadowBlur = 12
+  c.fillStyle = 'rgba(0,0,0,0.92)'
+  for (let i = 0; i < 3; i++) c.fillText(label, pad, midY)
+  c.shadowBlur = 0
+  // The visitor glyph takes the accent; the name stays bright so it reads at distance.
+  c.fillStyle = '#' + new THREE.Color(accent).getHexString()
+  c.fillText(prefix, pad, midY)
+  c.fillStyle = '#f4f2ee'
+  c.fillText(text, pad + Math.ceil(c.measureText(prefix).width), midY)
+
+  const texture = new THREE.CanvasTexture(canvas)
+  texture.colorSpace = THREE.SRGBColorSpace
+  texture.minFilter = THREE.LinearMipmapLinearFilter
+  texture.magFilter = THREE.LinearFilter
+  texture.generateMipmaps = true
+  texture.anisotropy = 8
+
+  const height = 0.95
+  const geo = new THREE.PlaneGeometry(height * (w / h), height)
+  const mat = new THREE.MeshBasicMaterial({
+    map: texture,
+    transparent: true,
+    depthWrite: false,
+    depthTest: false,
+    toneMapped: false,
+    opacity: 0,
+  })
+  // A touch larger on screen than a plate, and it shrinks less with distance so it stays the
+  // heading you can pick the district out by from across the colony.
+  mat.onBeforeCompile = (shader) => {
+    shader.vertexShader = shader.vertexShader.replace(
+      '#include <project_vertex>',
+      `vec4 mvPosition = modelViewMatrix * vec4( 0.0, 0.0, 0.0, 1.0 );
+       float dist = -mvPosition.z;
+       mvPosition.xy += position.xy * ( 0.85 + dist * 0.045 );
+       gl_Position = projectionMatrix * mvPosition;`
+    )
+  }
+  const mesh = new THREE.Mesh(geo, mat)
+  mesh.renderOrder = 9
   mesh.frustumCulled = false
   mesh.visible = false
   mesh.userData.dispose = () => {

--- a/test/shared-colonies.test.mjs
+++ b/test/shared-colonies.test.mjs
@@ -95,6 +95,18 @@ test('the guest socket answers only loopback and added neighbours', () => {
   assert.equal(normalizeIp('::ffff:10.0.0.1'), '10.0.0.1')
 })
 
+test('a refused stranger is remembered so it can be added, and forgotten after a while', () => {
+  const guest = new GuestServer({ instanceId: 'x', getName: () => 'X', getThreads: async () => [], getAllowedHosts: () => [] })
+  guest._noteRefused('10.212.134.7')
+  assert.equal(guest.recentRefused().some((r) => r.host === '10.212.134.7'), true)
+  // Stale entries drop out of the window.
+  guest._refused.set('10.212.134.7', Date.now() - 10 * 60 * 1000)
+  assert.equal(guest.recentRefused().length, 0)
+  // And the list is bounded rather than growing without limit.
+  for (let i = 0; i < 40; i++) guest._noteRefused(`10.0.0.${i}`)
+  assert.ok(guest._refused.size <= 12)
+})
+
 // ── the merge ─────────────────────────────────────────────────────────────────
 
 test('cleanNeighbor drops garbage and keeps the valid shape', () => {

--- a/test/shared-colonies.test.mjs
+++ b/test/shared-colonies.test.mjs
@@ -1,0 +1,207 @@
+/**
+ * Shared colonies: the guest socket's allowlist, the merge's collision safety, and the
+ * discovery datagram's parsing. Nothing here touches the real network beyond loopback.
+ */
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { GuestServer, guestThread } from '../server/guest.mjs'
+import { Neighbors, cleanNeighbor } from '../server/neighbors.mjs'
+import { Discovery } from '../server/discovery.mjs'
+import { allocateCells, colonyAnchor } from '../src/world/plots.js'
+
+// ── the guest socket ──────────────────────────────────────────────────────────
+
+const FIXTURE_THREAD = {
+  id: 'claude-code:aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+  title: 'Fix the flux capacitor',
+  project: 'wra',
+  projectPath: 'C:\\somewhere\\wra',
+  canOpen: true,
+  ref: { desktopSessionId: 'local_x', cliSessionId: 'y', cwd: 'C:\\somewhere\\wra' },
+  transcriptFile: 'C:\\Users\\chantal\\.claude\\projects\\x\\y.jsonl',
+  running: true,
+  sizeBytes: 12345,
+}
+
+async function withGuest(fn) {
+  const guest = new GuestServer({
+    port: 0, // any free port — the tests read it back off the socket
+    instanceId: 'test-instance',
+    getName: () => 'Chantal',
+    getThreads: async () => [FIXTURE_THREAD],
+  })
+  guest.start()
+  await new Promise((resolve) => guest._server.once('listening', resolve))
+  const base = `http://127.0.0.1:${guest._server.address().port}`
+  try {
+    await fn(base)
+  } finally {
+    guest.stop()
+  }
+}
+
+test('guest threads carry nothing actionable and no local paths', () => {
+  const t = guestThread(FIXTURE_THREAD)
+  assert.equal(t.canOpen, false)
+  assert.equal(t.ref, undefined)
+  assert.equal(t.transcriptFile, undefined)
+  // Everything a visitor legitimately looks at is still there.
+  assert.equal(t.title, FIXTURE_THREAD.title)
+  assert.equal(t.running, true)
+})
+
+test('the guest socket answers info and threads, and nothing else', async () => {
+  await withGuest(async (base) => {
+    const info = await (await fetch(`${base}/guest/info`)).json()
+    assert.equal(info.app, 'bot-crossing')
+    assert.equal(info.name, 'Chantal')
+
+    const res = await fetch(`${base}/guest/threads`)
+    assert.equal(res.status, 200)
+    const body = await res.json()
+    assert.equal(body.threads.length, 1)
+    assert.equal(body.threads[0].ref, undefined)
+    assert.equal(body.threads[0].canOpen, false)
+
+    // The action routes of the real API must not exist here — that absence is the security
+    // model, so it is asserted rather than assumed.
+    for (const path of ['/api/open', '/api/state', '/api/new-session', '/api/threads', '/guest/anything']) {
+      assert.equal((await fetch(`${base}${path}`)).status, 404, `${path} must not exist on the guest socket`)
+    }
+    for (const method of ['POST', 'PUT', 'DELETE']) {
+      assert.equal((await fetch(`${base}/guest/threads`, { method })).status, 405, `${method} must be refused`)
+    }
+  })
+})
+
+// ── the merge ─────────────────────────────────────────────────────────────────
+
+test('cleanNeighbor drops garbage and keeps the valid shape', () => {
+  assert.equal(cleanNeighbor(null), null)
+  assert.equal(cleanNeighbor({ host: '', port: 5275 }), null)
+  assert.equal(cleanNeighbor({ host: 'chantal-pc', port: 0 }), null)
+  assert.equal(cleanNeighbor({ host: 'chantal pc; rm -rf', port: 5275 }), null)
+  assert.deepEqual(cleanNeighbor({ name: 'Chantal', host: 'chantal-pc', port: 5275 }), {
+    name: 'Chantal',
+    host: 'chantal-pc',
+    port: 5275,
+  })
+  // A nameless neighbour is named after its host rather than refused.
+  assert.equal(cleanNeighbor({ host: '10.0.0.7', port: 5275 }).name, '10.0.0.7')
+})
+
+test('merged threads can never collide with local ones, and are inert', () => {
+  const n = new Neighbors()
+  n.setConfigured([{ name: 'Chantal', host: 'chantal-pc', port: 5275 }])
+  // Seed the cache directly — the fetch path is the guest-socket test's job.
+  n._cache.set('chantal-pc:5275', {
+    name: 'Chantal',
+    okAt: Date.now(),
+    fetchedAt: Date.now(),
+    threads: [{ ...guestThread(FIXTURE_THREAD) }],
+  })
+
+  const { threads, colonies } = n.merged()
+  assert.equal(threads.length, 1)
+  const t = threads[0]
+  // Same session id scanned on both machines still yields a distinct id here.
+  assert.equal(t.id, `guest:chantal-pc:5275:${FIXTURE_THREAD.id}`)
+  // Same repo name on both machines still yields a distinct plot.
+  assert.equal(t.project, 'Chantal · wra')
+  assert.equal(t.colony, 'Chantal')
+  assert.equal(t.canOpen, false)
+  assert.equal(t.ref, undefined)
+
+  assert.equal(colonies.length, 1)
+  assert.equal(colonies[0].online, true)
+})
+
+test('a neighbour that stopped answering goes offline but keeps its last threads', () => {
+  const n = new Neighbors()
+  n.setConfigured([{ name: 'Chantal', host: 'chantal-pc', port: 5275 }])
+  n._cache.set('chantal-pc:5275', {
+    name: 'Chantal',
+    okAt: Date.now() - 10 * 60 * 1000, // long silent
+    fetchedAt: Date.now(),
+    threads: [guestThread(FIXTURE_THREAD)],
+  })
+  const { threads, colonies } = n.merged()
+  assert.equal(colonies[0].online, false)
+  assert.equal(threads.length, 1, 'the district survives the machine sleeping')
+  assert.equal(threads[0].colonyOnline, false)
+})
+
+test('removing a neighbour drops its cache with it', () => {
+  const n = new Neighbors()
+  n.setConfigured([{ name: 'Chantal', host: 'chantal-pc', port: 5275 }])
+  n._cache.set('chantal-pc:5275', { name: 'Chantal', okAt: Date.now(), fetchedAt: Date.now(), threads: [] })
+  n.setConfigured([])
+  assert.equal(n.merged().threads.length, 0)
+  assert.equal(n.merged().colonies.length, 0)
+})
+
+// ── district layout ─────────────────────────────────────────────────────────────
+
+const hexDist = (a, b) => (Math.abs(a.q - b.q) + Math.abs(a.q + a.r - b.q - b.r) + Math.abs(a.r - b.r)) / 2
+
+test("a visiting colony's repos cluster near its anchor, out past the home zones", () => {
+  const anchor = colonyAnchor('Chantal')
+  const layout = allocateCells([
+    { id: 'home-a', size: 20 },
+    { id: 'home-b', size: 10 },
+    { id: 'Chantal · wra', size: 3, anchor },
+    { id: 'Chantal · mios', size: 5, anchor },
+  ])
+
+  // Both of Chantal's repos land within a couple of rings of her anchor…
+  for (const id of ['Chantal · wra', 'Chantal · mios']) {
+    const cells = layout.get(id)
+    assert.ok(cells.length > 0, `${id} got no cells`)
+    const nearest = Math.min(...cells.map((c) => hexDist(c, anchor)))
+    assert.ok(nearest <= 2, `${id} settled ${nearest} rings from its anchor`)
+  }
+
+  // …and well clear of the home zones, which sit in the middle.
+  const home = [...layout.get('home-a'), ...layout.get('home-b')]
+  const guest = layout.get('Chantal · mios')
+  const farthestHome = Math.max(...home.map((c) => hexDist(c, { q: 0, r: 0 })))
+  const nearestGuest = Math.min(...guest.map((c) => hexDist(c, { q: 0, r: 0 })))
+  assert.ok(nearestGuest > farthestHome, 'the district overlaps the home zones instead of standing apart')
+})
+
+test('two colonies that both know a repo called "wra" get separate districts', () => {
+  const layout = allocateCells([
+    { id: 'Chantal · wra', size: 2, anchor: colonyAnchor('Chantal') },
+    { id: 'Bram · wra', size: 2, anchor: colonyAnchor('Bram') },
+  ])
+  const c = layout.get('Chantal · wra')
+  const b = layout.get('Bram · wra')
+  // No shared cell between the two districts.
+  const cKeys = new Set(c.map((x) => `${x.q},${x.r}`))
+  assert.ok(b.every((x) => !cKeys.has(`${x.q},${x.r}`)), 'the two "wra" districts overlap')
+})
+
+// ── discovery ─────────────────────────────────────────────────────────────────
+
+test('discovery parses well-formed announcements and refuses everything else', () => {
+  const d = new Discovery({ instanceId: 'me' })
+  const from = { address: '10.0.0.7' }
+  const hear = (msg) => d._onMessage(Buffer.from(JSON.stringify(msg)), from)
+
+  hear({ v: 1, app: 'bot-crossing', name: 'Chantal', guestPort: 5275, instanceId: 'her' })
+  assert.equal(d.peers().length, 1)
+  assert.deepEqual(d.peers()[0].host, '10.0.0.7')
+
+  // Our own echo, a wrong app, a bad port, an empty name: none of them become peers.
+  hear({ v: 1, app: 'bot-crossing', name: 'Me', guestPort: 5275, instanceId: 'me' })
+  hear({ v: 1, app: 'other-thing', name: 'X', guestPort: 5275, instanceId: 'x' })
+  hear({ v: 1, app: 'bot-crossing', name: 'X', guestPort: 999999, instanceId: 'x' })
+  hear({ v: 1, app: 'bot-crossing', name: '   ', guestPort: 5275, instanceId: 'x' })
+  d._onMessage(Buffer.from('not json'), from)
+  assert.equal(d.peers().length, 1)
+
+  // And a peer that goes quiet falls off the list.
+  d._peers.get('10.0.0.7:5275').lastSeen = Date.now() - 10 * 60 * 1000
+  assert.equal(d.peers().length, 0)
+})

--- a/test/shared-colonies.test.mjs
+++ b/test/shared-colonies.test.mjs
@@ -5,7 +5,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import { GuestServer, guestThread } from '../server/guest.mjs'
+import { GuestServer, guestThread, hostAllowed, normalizeIp } from '../server/guest.mjs'
 import { Neighbors, cleanNeighbor } from '../server/neighbors.mjs'
 import { Discovery } from '../server/discovery.mjs'
 import { allocateCells, colonyAnchor } from '../src/world/plots.js'
@@ -30,6 +30,7 @@ async function withGuest(fn) {
     instanceId: 'test-instance',
     getName: () => 'Chantal',
     getThreads: async () => [FIXTURE_THREAD],
+    getAllowedHosts: () => [], // loopback is always allowed, so the tests still reach it
   })
   guest.start()
   await new Promise((resolve) => guest._server.once('listening', resolve))
@@ -73,6 +74,25 @@ test('the guest socket answers info and threads, and nothing else', async () => 
       assert.equal((await fetch(`${base}/guest/threads`, { method })).status, 405, `${method} must be refused`)
     }
   })
+})
+
+// ── the origin check ────────────────────────────────────────────────────────────
+
+test('the guest socket answers only loopback and added neighbours', () => {
+  // Loopback, however it is spelled, always: the local page and the tests reach the socket.
+  assert.equal(hostAllowed('127.0.0.1', []), true)
+  assert.equal(hostAllowed('::1', []), true)
+  assert.equal(hostAllowed('::ffff:127.0.0.1', []), true)
+
+  // A LAN host is answered only when it is on the neighbour list.
+  const neighbours = ['192.168.55.42', 'chantal-pc']
+  assert.equal(hostAllowed('192.168.55.42', neighbours), true)
+  // Node reports a v4 client on a dual-stack socket with the ::ffff: prefix.
+  assert.equal(hostAllowed('::ffff:192.168.55.42', neighbours), true)
+  // A stranger on the same LAN is refused, even with sharing on and an allowlist set.
+  assert.equal(hostAllowed('192.168.55.99', neighbours), false)
+  assert.equal(hostAllowed('192.168.55.99', []), false)
+  assert.equal(normalizeIp('::ffff:10.0.0.1'), '10.0.0.1')
 })
 
 // ── the merge ─────────────────────────────────────────────────────────────────

--- a/test/shared-colonies.test.mjs
+++ b/test/shared-colonies.test.mjs
@@ -190,6 +190,22 @@ test("a visiting colony's repos cluster near its anchor, out past the home zones
   assert.ok(nearestGuest > farthestHome, 'the district overlaps the home zones instead of standing apart')
 })
 
+test("a district member stranded far from its anchor is pulled back to the district", () => {
+  const anchor = colonyAnchor('Chantie')
+  // Its memory says it sits near the middle of the map — a stale placement from before its
+  // colony was known. It must not stay there; it belongs in Chantie's district.
+  const stale = new Map([['Chantie · bot-crossing', [{ q: 0, r: 0 }]]])
+  const layout = allocateCells(
+    [
+      { id: 'Chantie · mios', size: 60, anchor },
+      { id: 'Chantie · bot-crossing', size: 1, anchor },
+    ],
+    stale
+  )
+  const root = layout.get('Chantie · bot-crossing')[0]
+  assert.ok(hexDist(root, anchor) <= 3, `bot-crossing stayed ${hexDist(root, anchor)} rings from the anchor`)
+})
+
 test('two colonies that both know a repo called "wra" get separate districts', () => {
   const layout = allocateCells([
     { id: 'Chantal · wra', size: 2, anchor: colonyAnchor('Chantal') },

--- a/test/state.test.mjs
+++ b/test/state.test.mjs
@@ -25,6 +25,15 @@ test('a removal survives the merge — a plain union would resurrect it', () => 
   assert.deepEqual(out.archived, ['t2'])
 })
 
+test('network config takes the local tab whole, like settings — never half a share toggle', () => {
+  const base = { network: { colonyName: 'Dimitri', share: false, neighbors: [] } }
+  const local = { network: { colonyName: 'Dimitri', share: true, neighbors: [{ name: 'Chantal', host: 'c-pc', port: 5275 }] } }
+  const remote = { network: { colonyName: 'Dimitri', share: false, neighbors: [] } }
+  const out = mergeState(base, local, remote)
+  assert.equal(out.network.share, true)
+  assert.equal(out.network.neighbors.length, 1)
+})
+
 test('two tabs moving different zones both keep their move', () => {
   const out = mergeState(
     { plots: { a: [[0, 0]], b: [[1, 1]] } },

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,11 +1,13 @@
 import { defineConfig } from 'vite'
-import { apiMiddleware } from './server/api.mjs'
+import { apiMiddleware, initNetwork } from './server/api.mjs'
 
 /** Serves /api from inside the Vite dev server, so `npm run dev` is the whole game. */
 const api = () => ({
   name: 'bot-crossing-api',
   configureServer(server) {
     server.middlewares.use(apiMiddleware)
+    // Shared colonies work in dev exactly as in production.
+    initNetwork().catch(() => {})
   },
 })
 


### PR DESCRIPTION
## What

Two Bot Crossing installs on one intranet can share. Sharing is **off by default**; when its owner turns it on, the machine answers a read-only guest API and announces itself over UDP. A visitor adds (or auto-discovers) the neighbour, and their repos rise as a named district beside the home zones — their astronauts walking and building from live status. Nothing on the map can be opened, archived or started from a visitor's side; that is enforced both in the UI and on the wire.

Motivation: seeing what your teammates' agents are up to, at a glance, on the same colony you already keep open.

## How

**Server (new modules, plus a `network` block in `colony.json`)**
- `guest.mjs` — a second HTTP listener (`0.0.0.0:5275`) with exactly `GET /guest/info` and `GET /guest/threads`. Read-only is *structural*: the action routes do not exist on this socket, and `ref` / transcript paths are stripped before anything leaves. The owner's own UI stays on 127.0.0.1.
- `discovery.mjs` — a UDP heartbeat (`5276`): announce while sharing, always listen; peers expire after three missed beats, own echo dropped by a per-boot `instanceId`.
- `neighbors.mjs` — fetch each neighbour's guest API on a 2s timeout and merge the *cached* answer, so a slow or sleeping peer never delays the owner's own map. Guest threads are tagged (`guest:<host>:<id>`, colony name) so two machines that both know a repo called `wra` can never collide.
- `api.mjs` folds neighbours into `/api/threads`, adds `/api/neighbors`, and starts/stops the guest listener + announcer whenever the saved `network` block changes.

**Client**
- `plots.js` anchors a visiting colony's district to a fixed outer ring by name, so its repos cluster into a recognisable settlement rather than interleaving; a floating banner names it.
- `colony.js` clusters guest plots at the anchor, dims the district when its colony goes offline, and keeps its ground when it returns.
- `hud.js` / `main.js` add a **Network** settings section (share toggle, colony name, discovered + manual neighbours with online dots). Visiting threads and districts are read-only in the UI; every action also guards server-side.
- `merge-state.js` merges the network config local-wins, like `settings`.

## Trust model

Same intranet, opt-in, read-only socket. No transitive sharing, no auth beyond the LAN boundary, no TLS — deliberately (documented in the design doc under `docs/superpowers/specs/`). The guest socket exposes only what the owner already sees on their own map, minus anything actionable.

## Tested

- **43 unit tests pass**, including: the guest allowlist (action routes 404/405 on the guest socket, `ref` stripped), merge tagging + collision safety, discovery parse/expiry, anchored-district layout, and the network merge.
- A **two-instance end-to-end on one machine** (a second instance plays a neighbour) confirms the district renders read-only, actions are refused, discovery finds the peer, and unplugging it dims the district while its last-known threads survive from cache.
- Verified visually on Windows 11: neighbour auto-discovered, added, district + banner rendered, astronaut and district panels read-only.

Windows-friendly installer included under `install/` (portable Node, build, autostart, firewall) but the feature itself is plain Node networking and platform-neutral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)