### PR TITLE
Add OpenCode harness adapter

### DIFF
--- a/server/harnesses/index.mjs
+++ b/server/harnesses/index.mjs
@@ -9,8 +9,9 @@
 import claudeCode from './claude-code.mjs'
 import codex from './codex.mjs'
 import cursor from './cursor.mjs'
+import opencode from './opencode.mjs'
 
-export const HARNESSES = [claudeCode, codex, cursor]
+export const HARNESSES = [claudeCode, codex, cursor, opencode]
 
 export const harnessById = (id) => HARNESSES.find((h) => h.id === id) || null
 

--- a/server/harnesses/opencode.mjs
+++ b/server/harnesses/opencode.mjs
@@ -129,6 +129,25 @@ async function firstUserText(db, sessionId) {
 /** Costly facts kept against `time_updated`, so an unchanged session is read once. */
 const factsCache = new Map()
 
+/**
+ * Whether an error-status tool part means the run failed.
+ *
+ * Seen in the wild: `The user rejected permission to use this specific tool
+ * call.` and `Tool execution aborted` — both are the user stopping the turn,
+ * not the turn failing. Only a genuine failure reddens an astronaut.
+ */
+function isRealError(raw) {
+  let text = ''
+  try {
+    const d = typeof raw === 'string' ? JSON.parse(raw) : raw
+    const state = d?.state || {}
+    text = `${state.error || ''}\n${state.output || ''}`
+  } catch {
+    return true
+  }
+  return !/user rejected permission|permission.{0,20}denied|denied.{0,20}permission|execution aborted|aborted|cancelled/i.test(text)
+}
+
 async function sessionFacts(db, sessionId, timeUpdated) {
   const hit = factsCache.get(sessionId)
   if (hit && hit.timeUpdated === timeUpdated) return hit.facts
@@ -148,19 +167,34 @@ async function sessionFacts(db, sessionId, timeUpdated) {
       const d = JSON.parse(last.data)
       const completed = d?.time?.completed
       const finished = typeof d?.finish === 'string' && d.finish
+      const msgError = typeof d?.error?.name === 'string' ? d.error.name : ''
+      const aborted = /abort/i.test(msgError)
       // A trailing user message means the model speaks next — whatever the
-      // process is doing, it is not waiting on anyone.
-      const open = d?.role === 'user' || (d?.role === 'assistant' && !completed && !finished)
+      // process is doing, it is not waiting on anyone. A turn that ended in
+      // error or abort is over too, even when it carries no finish stamp.
+      const open = d?.role === 'user' || (d?.role === 'assistant' && !completed && !finished && !msgError)
       facts.running = open && Date.now() - num(timeUpdated) < ACTIVE_WINDOW_MS
-      if (d?.role === 'assistant' && (completed || finished)) {
-        // Only the last turn counts: a historic tool error must not redden an
-        // astronaut forever.
-        const err = db
-          .prepare(
-            `SELECT 1 AS x FROM part WHERE message_id IN (SELECT id FROM message WHERE session_id = ? ORDER BY time_created DESC LIMIT 3) AND data LIKE '%"status":"error"%' LIMIT 1`
-          )
-          .get(sessionId)
-        facts.hasError = Boolean(err)
+      if (d?.role === 'assistant' && (completed || finished || msgError)) {
+        if (aborted) {
+          // The user stopped the turn. Same as pressing escape elsewhere:
+          // an abandoned turn is not a failed one.
+          facts.hasError = false
+        } else if (msgError) {
+          // The turn itself failed (provider/auth error) — that is what the
+          // red eyes are for, even when no single tool part takes the blame.
+          facts.hasError = true
+        } else {
+          // Only the last turn counts: a historic tool error must not redden
+          // an astronaut forever. And a turn the *user* stopped is not a
+          // failure — a rejected permission or an aborted call is this
+          // harness's version of pressing escape.
+          const candidates = db
+            .prepare(
+              `SELECT data FROM part WHERE message_id IN (SELECT id FROM message WHERE session_id = ? ORDER BY time_created DESC LIMIT 3) AND data LIKE '%"status":"error"%' LIMIT 5`
+            )
+            .all(sessionId)
+          facts.hasError = candidates.some((row) => isRealError(row?.data))
+        }
       }
     }
   } catch {

--- a/server/harnesses/opencode.mjs
+++ b/server/harnesses/opencode.mjs
@@ -1,0 +1,323 @@
+/**
+ * Harness adapter: OpenCode — sessions in a local SQLite database.
+ *
+ * Primary store is `opencode.db` (WAL mode, so concurrent readers are safe while
+ * the app runs): `~/.local/share/opencode/opencode.db`, overridable with
+ * `$OPENCODE_DB`. Only top-level sessions count as threads — child rows with
+ * `parent_id` set are the task tool's subagents, and OpenCode's own session list
+ * filters them the same way. Including them would stand hundreds of astronauts
+ * on the map that nobody ever talked to.
+ *
+ * Read-only, without exception, and no subprocess anywhere. There is no
+ * per-session deep link upstream, so opening a thread is honestly refused and
+ * starting one goes through the registered `opencode://new-session` handler.
+ */
+import path from 'node:path'
+import os from 'node:os'
+import { exists, findExecutable, num } from '../lib/fsutil.mjs'
+
+const HOME = os.homedir()
+
+/**
+ * Where `opencode.db` lives. `$OPENCODE_DB` wins when it names a file that is
+ * actually there — otherwise the XDG path, then the macOS Application Support
+ * fallback on darwin only. Resolved per call so pointing the var at a fixture
+ * (or installing the app) is picked up on the next poll.
+ */
+async function dbPath() {
+  const override = process.env.OPENCODE_DB
+  // When set, the override is the whole answer: a missing file means "absent",
+  // not "fall back to the default and read a database the user did not name".
+  // That is also what makes fixture tests isolate from the real store.
+  if (typeof override === 'string' && override) return (await exists(override)) ? override : ''
+  const xdg = process.env.XDG_DATA_HOME
+  if (typeof xdg === 'string' && xdg) {
+    const p = path.join(xdg, 'opencode', 'opencode.db')
+    if (await exists(p)) return p
+  }
+  const shared = path.join(HOME, '.local', 'share', 'opencode', 'opencode.db')
+  if (await exists(shared)) return shared
+  if (process.platform === 'darwin') {
+    const mac = path.join(HOME, 'Library', 'Application Support', 'opencode', 'opencode.db')
+    if (await exists(mac)) return mac
+  }
+  return ''
+}
+
+/**
+ * `node:sqlite` is imported lazily and its absence is survivable.
+ *
+ * It needs Node 22.13, which `package.json` asks for — but asking is not
+ * enforcing, and a top level import would take the whole server down on an
+ * older Node rather than costing one harness. This way every other harness
+ * keeps working and `diagnostic()` explains the gap.
+ */
+let sqlitePromise
+const sqliteApi = () => (sqlitePromise ??= import('node:sqlite').catch(() => null))
+
+/** Prefixed, per the contract in `server/harnesses/README.md`. */
+const ID = (raw) => `opencode:${raw}`
+
+/** OpenCode writes nothing when it is killed, so an open turn needs a time bound too. */
+const ACTIVE_WINDOW_MS = 30 * 60 * 1000
+
+const clean = (v) => String(v || '').replace(/\s+/g, ' ').trim()
+
+function parseModel(raw) {
+  if (!raw) return { model: '', effort: '' }
+  try {
+    const m = typeof raw === 'string' ? JSON.parse(raw) : raw
+    return {
+      model: typeof m?.id === 'string' ? m.id : '',
+      effort: typeof m?.variant === 'string' ? m.variant : ''
+    }
+  } catch {
+    return { model: '', effort: '' }
+  }
+}
+
+function projectOf(directory) {
+  const dir = typeof directory === 'string' ? directory : ''
+  if (!dir) return { projectPath: '', project: 'unknown', cwd: '' }
+  // Both separators: a Windows directory arrives with either, and `basename`
+  // on one OS must still read a path written on another (tests use posix).
+  const base = path.basename(dir.replace(/\\/g, '/'))
+  return { projectPath: dir, project: base || 'unknown', cwd: dir }
+}
+
+/** First user text per session never changes, so it is kept forever. */
+const previewCache = new Map()
+
+async function firstUserText(db, sessionId) {
+  if (previewCache.has(sessionId)) return previewCache.get(sessionId)
+  let out = ''
+  try {
+    const msgs = db
+      .prepare(`SELECT id, data FROM message WHERE session_id = ? ORDER BY time_created ASC LIMIT 8`)
+      .all(sessionId)
+    for (const m of msgs) {
+      let role = ''
+      try {
+        role = JSON.parse(m.data)?.role || ''
+      } catch {
+        continue
+      }
+      if (role !== 'user') continue
+      const parts = db
+        .prepare(`SELECT data FROM part WHERE message_id = ? ORDER BY time_created ASC LIMIT 8`)
+        .all(m.id)
+      for (const p of parts) {
+        try {
+          const d = JSON.parse(p.data)
+          if (d?.type === 'text' && typeof d.text === 'string' && clean(d.text)) {
+            out = clean(d.text)
+            break
+          }
+        } catch {
+          /* a part mid-write — skip it */
+        }
+      }
+      if (out) break
+    }
+  } catch {
+    out = ''
+  }
+  previewCache.set(sessionId, out)
+  return out
+}
+
+/** Costly facts kept against `time_updated`, so an unchanged session is read once. */
+const factsCache = new Map()
+
+async function sessionFacts(db, sessionId, timeUpdated) {
+  const hit = factsCache.get(sessionId)
+  if (hit && hit.timeUpdated === timeUpdated) return hit.facts
+  const facts = { running: false, hasError: false, sizeBytes: 0 }
+  try {
+    const msgBytes = db.prepare(`SELECT COALESCE(SUM(LENGTH(data)), 0) AS n FROM message WHERE session_id = ?`).get(sessionId)
+    const partBytes = db.prepare(`SELECT COALESCE(SUM(LENGTH(data)), 0) AS n FROM part WHERE session_id = ?`).get(sessionId)
+    facts.sizeBytes = num(msgBytes?.n) + num(partBytes?.n)
+  } catch {
+    facts.sizeBytes = 0
+  }
+  try {
+    const last = db
+      .prepare(`SELECT id, data FROM message WHERE session_id = ? ORDER BY time_created DESC, rowid DESC LIMIT 1`)
+      .get(sessionId)
+    if (last?.data) {
+      const d = JSON.parse(last.data)
+      const completed = d?.time?.completed
+      const finished = typeof d?.finish === 'string' && d.finish
+      // A trailing user message means the model speaks next — whatever the
+      // process is doing, it is not waiting on anyone.
+      const open = d?.role === 'user' || (d?.role === 'assistant' && !completed && !finished)
+      facts.running = open && Date.now() - num(timeUpdated) < ACTIVE_WINDOW_MS
+      if (d?.role === 'assistant' && (completed || finished)) {
+        // Only the last turn counts: a historic tool error must not redden an
+        // astronaut forever.
+        const err = db
+          .prepare(
+            `SELECT 1 AS x FROM part WHERE message_id IN (SELECT id FROM message WHERE session_id = ? ORDER BY time_created DESC LIMIT 3) AND data LIKE '%"status":"error"%' LIMIT 1`
+          )
+          .get(sessionId)
+        facts.hasError = Boolean(err)
+      }
+    }
+  } catch {
+    /* mid-write, or gone */
+  }
+  factsCache.set(sessionId, { timeUpdated, facts })
+  return facts
+}
+
+async function scanThreads() {
+  const file = await dbPath()
+  if (!file) return []
+  const sqlite = await sqliteApi()
+  if (!sqlite?.DatabaseSync) return []
+
+  let db
+  try {
+    db = new sqlite.DatabaseSync(file, { readOnly: true })
+  } catch {
+    // A WAL database whose shared-memory file cannot be used refuses a
+    // read-only open. Losing one harness beats losing the scan.
+    return []
+  }
+  try {
+    const tables = new Set(
+      db.prepare(`SELECT name FROM sqlite_master WHERE type = 'table'`).all().map((r) => r.name)
+    )
+    if (!tables.has('session') || !tables.has('message') || !tables.has('part')) return []
+    // Undocumented private state that drifts between versions — probe every
+    // column before naming it, or one renamed column costs the whole harness.
+    const cols = new Set(db.prepare(`PRAGMA table_info(session)`).all().map((r) => r.name))
+    for (const need of ['id', 'directory', 'title', 'time_created', 'time_updated']) {
+      if (!cols.has(need)) return []
+    }
+    const rows = db
+      .prepare(
+        `SELECT id, directory, title, agent, model, time_created, time_updated, time_archived FROM session ${cols.has('parent_id') ? 'WHERE parent_id IS NULL' : ''} ORDER BY time_updated DESC`
+      )
+      .all()
+    const out = []
+    for (const r of rows) {
+      if (typeof r.id !== 'string' || !r.id) continue
+      const { projectPath, project, cwd } = projectOf(r.directory)
+      const { model, effort } = parseModel(r.model)
+      const prompt = await firstUserText(db, r.id)
+      const title = clean(r.title) || prompt || 'Untitled thread'
+      const facts = await sessionFacts(db, r.id, num(r.time_updated))
+      out.push({
+        id: ID(r.id),
+        title: title.slice(0, 120),
+        preview: prompt.slice(0, 240),
+        project,
+        projectPath,
+        // OpenCode has no worktree concept of its own, and guessing one from
+        // the path would put a branch name on a thread that never had one.
+        worktree: '',
+        cwd,
+        gitBranch: '',
+        model,
+        effort,
+        createdAt: num(r.time_created),
+        lastActivityAt: num(r.time_updated),
+        // No focus history, so "have you looked at this" is unknowable — not false.
+        lastFocusedAt: 0,
+        unread: false,
+        running: facts.running,
+        hasError: facts.hasError,
+        starred: false,
+        routine: '',
+        prState: '',
+        archived: r.time_archived !== null && r.time_archived !== undefined,
+        // Bytes, like every other harness: the field is a shared log scale
+        // across the whole map, and a token count would make OpenCode
+        // buildings taller than Claude ones for the same work.
+        sizeBytes: facts.sizeBytes,
+        source: typeof r.agent === 'string' ? r.agent : '',
+        canOpen: false,
+        ref: { sessionId: r.id, cwd }
+      })
+    }
+    return out
+  } catch {
+    return []
+  } finally {
+    try {
+      db.close()
+    } catch {
+      /* already gone */
+    }
+  }
+}
+
+/**
+ * OpenCode registers `opencode://open-project` and `opencode://new-session`
+ * and nothing that addresses a single session — inventing a route would be a
+ * link that silently does nothing. Revealing the session list is the honest
+ * offer, and the UI greys the button and shows this instead.
+ */
+function openThread(ref) {
+  const id = ref?.sessionId
+  // The type check matters wherever an id came back from the page:
+  // `String([validId])` is that id, and it must not travel on as an array.
+  if (typeof id !== 'string' || !id) {
+    return { ok: false, error: 'No openable OpenCode session id on that thread' }
+  }
+  return {
+    ok: false,
+    error: 'OpenCode has no link to a single session — open the repo and pick it from the session list.'
+  }
+}
+
+/**
+ * Where the `opencode` CLI is, for a machine that needs the terminal fallback.
+ * PATH first, then the places its installers put it — never inside an
+ * application bundle. Only Linux asks: on macOS and Windows the deep link is
+ * always answered, so the walk is wasted.
+ */
+const CLI_DIRS = [path.join(HOME, '.local', 'bin'), path.join(HOME, '.opencode', 'bin'), '/usr/local/bin', '/usr/bin']
+const cliBinary = () => findExecutable('opencode', CLI_DIRS)
+
+async function newSession(dir) {
+  if (typeof dir !== 'string' || !path.isAbsolute(dir)) {
+    return { ok: false, error: 'That folder is not somewhere OpenCode can open' }
+  }
+  const url = `opencode://new-session?${new URLSearchParams({ directory: dir })}`
+  let command
+  if (process.platform === 'linux') {
+    const bin = await cliBinary()
+    if (bin) command = { argv: [bin], cwd: dir }
+  }
+  return { ok: true, url, command }
+}
+
+async function detect() {
+  return Boolean(await dbPath())
+}
+
+/**
+ * Why a present OpenCode might still look thin. Without this the old-Node case
+ * is invisible: the database is simply skipped, every thread is missing, and
+ * nothing says why.
+ */
+async function diagnostic() {
+  if (!(await dbPath())) return ''
+  if (!(await sqliteApi())?.DatabaseSync) {
+    return `OpenCode threads need Node 22.13 or newer for their sessions (running ${process.versions.node})`
+  }
+  return ''
+}
+
+export default {
+  id: 'opencode',
+  name: 'OpenCode',
+  detect,
+  diagnostic,
+  scanThreads,
+  openThread,
+  newSession,
+  paths: {}
+}

--- a/test/harness.test.mjs
+++ b/test/harness.test.mjs
@@ -340,8 +340,69 @@ test('opencode running is bounded by the activity window and errors come from th
   }
 })
 
-test('opencode refuses untrusted refs and offers no per-thread link', async () => {
-  const { home, h } = await fakeOpencode()
+test('a turn the user stopped is not an error — denial and abort must not redden an astronaut', async () => {
+  const home = await fsp.mkdtemp(path.join(os.tmpdir(), 'opencode-denied-'))
+  const dbFile = path.join(home, 'opencode.db')
+  const { DatabaseSync } = await import('node:sqlite')
+  const db = new DatabaseSync(dbFile)
+  db.exec(`CREATE TABLE session (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, parent_id TEXT, directory TEXT NOT NULL, title TEXT NOT NULL, agent TEXT, model TEXT, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, time_archived INTEGER)`)
+  db.exec(`CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL)`)
+  db.exec(`CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT NOT NULL, session_id TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL)`)
+  const now = Date.now()
+  const ins = db.prepare(`INSERT INTO session (id, project_id, parent_id, directory, title, agent, model, time_created, time_updated, time_archived) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+  ins.run('ses_denied1111111111111111111111', 'global', null, '/tmp/d', 'Denied turn', 'build', null, now - 60000, now, null)
+  ins.run('ses_aborted111111111111111111111', 'global', null, '/tmp/e', 'Aborted turn', 'build', null, now - 60000, now, null)
+  ins.run('ses_failed1111111111111111111111', 'global', null, '/tmp/f', 'Failed turn', 'build', null, now - 60000, now, null)
+  const mins = db.prepare(`INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)`)
+  mins.run('m_denied', 'ses_denied1111111111111111111111', now - 60000, now, JSON.stringify({ role: 'assistant', time: { created: now - 60000, completed: now }, finish: 'tool-calls' }))
+  mins.run('m_aborted', 'ses_aborted111111111111111111111', now - 60000, now, JSON.stringify({ role: 'assistant', time: { created: now - 60000, completed: now }, finish: 'stop' }))
+  mins.run('m_failed', 'ses_failed1111111111111111111111', now - 60000, now, JSON.stringify({ role: 'assistant', time: { created: now - 60000, completed: now }, finish: 'stop' }))
+  const pins = db.prepare(`INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)`)
+  pins.run('p_denied', 'm_denied', 'ses_denied1111111111111111111111', now, now, JSON.stringify({ type: 'tool', tool: 'bash', state: { status: 'error', error: 'The user rejected permission to use this specific tool call.' } }))
+  pins.run('p_aborted', 'm_aborted', 'ses_aborted111111111111111111111', now, now, JSON.stringify({ type: 'tool', tool: 'read', state: { status: 'error', error: 'Tool execution aborted' } }))
+  pins.run('p_failed', 'm_failed', 'ses_failed1111111111111111111111', now, now, JSON.stringify({ type: 'tool', tool: 'write', state: { status: 'error', error: 'SchemaError(Expected string, got object)' } }))
+  db.close()
+  process.env.OPENCODE_DB = dbFile
+  try {
+    const byId = new Map((await opencode.scanThreads()).map((t) => [t.id, t]))
+    assert.equal(byId.get('opencode:ses_denied1111111111111111111111').hasError, false, 'a rejected permission is the user stopping the turn, not a failure')
+    assert.equal(byId.get('opencode:ses_aborted111111111111111111111').hasError, false, 'an aborted call is a cancellation, not a failure')
+    assert.equal(byId.get('opencode:ses_failed1111111111111111111111').hasError, true, 'a genuine tool failure still reddens the astronaut')
+  } finally {
+    delete process.env.OPENCODE_DB
+    await fsp.rm(home, { recursive: true, force: true })
+  }
+})
+
+test('a message-level abort is the user stopping, but a provider error is a failure', async () => {
+  const home = await fsp.mkdtemp(path.join(os.tmpdir(), 'opencode-msgerr-'))
+  const dbFile = path.join(home, 'opencode.db')
+  const { DatabaseSync } = await import('node:sqlite')
+  const db = new DatabaseSync(dbFile)
+  db.exec(`CREATE TABLE session (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, parent_id TEXT, directory TEXT NOT NULL, title TEXT NOT NULL, agent TEXT, model TEXT, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, time_archived INTEGER)`)
+  db.exec(`CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL)`)
+  db.exec(`CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT NOT NULL, session_id TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL)`)
+  const now = Date.now()
+  const ins = db.prepare(`INSERT INTO session (id, project_id, parent_id, directory, title, agent, model, time_created, time_updated, time_archived) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+  ins.run('ses_msgabort11111111111111111111', 'global', null, '/tmp/g', 'Aborted message', 'build', null, now - 60000, now, null)
+  ins.run('ses_msgapi1111111111111111111111', 'global', null, '/tmp/h', 'Provider failure', 'build', null, now - 60000, now, null)
+  const mins = db.prepare(`INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)`)
+  mins.run('m_abort', 'ses_msgabort11111111111111111111', now - 60000, now, JSON.stringify({ role: 'assistant', time: { created: now - 60000, completed: now }, error: { name: 'MessageAbortedError' } }))
+  mins.run('m_api', 'ses_msgapi1111111111111111111111', now - 60000, now, JSON.stringify({ role: 'assistant', time: { created: now - 60000, completed: now }, error: { name: 'APIError' } }))
+  db.close()
+  process.env.OPENCODE_DB = dbFile
+  try {
+    const byId = new Map((await opencode.scanThreads()).map((t) => [t.id, t]))
+    assert.equal(byId.get('opencode:ses_msgabort11111111111111111111').hasError, false)
+    assert.equal(byId.get('opencode:ses_msgabort11111111111111111111').running, false)
+    assert.equal(byId.get('opencode:ses_msgapi1111111111111111111111').hasError, true)
+  } finally {
+    delete process.env.OPENCODE_DB
+    await fsp.rm(home, { recursive: true, force: true })
+  }
+})
+
+test('opencode refuses untrusted refs and offers no per-thread link', async () => {  const { home, h } = await fakeOpencode()
   try {
     const uuid = OPENCODE_SESSION
     assert.equal(h.openThread({ sessionId: [uuid] }).ok, false)

--- a/test/harness.test.mjs
+++ b/test/harness.test.mjs
@@ -13,6 +13,7 @@ import path from 'node:path'
 import { HARNESSES } from '../server/harnesses/index.mjs'
 import codex from '../server/harnesses/codex.mjs'
 import claudeCode from '../server/harnesses/claude-code.mjs'
+import opencode from '../server/harnesses/opencode.mjs'
 import { readTail, findExecutable } from '../server/lib/fsutil.mjs'
 import { schemeOf, openInTerminal } from '../server/lib/xdg.mjs'
 
@@ -240,4 +241,121 @@ test('Cursor offers a folder link but never a per-thread one it cannot honour', 
   assert.ok(opened.url.includes('%20'), 'a space in the path is escaped, not left raw')
   assert.equal(h.newSession('relative/path').ok, false)
   await fsp.rm(home, { recursive: true, force: true })
+})
+
+// ── OpenCode, faked on disk ─────────────────────────────────────────────────
+
+const OPENCODE_SESSION = 'ses_eeeeddddccccbbbbaaaa00000000'
+
+async function fakeOpencode() {
+  const home = await fsp.mkdtemp(path.join(os.tmpdir(), 'opencode-fixture-'))
+  const dbFile = path.join(home, 'opencode.db')
+  const { DatabaseSync } = await import('node:sqlite')
+  const db = new DatabaseSync(dbFile)
+  db.exec(`CREATE TABLE session (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, parent_id TEXT, directory TEXT NOT NULL, title TEXT NOT NULL, agent TEXT, model TEXT, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, time_archived INTEGER)`)
+  db.exec(`CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL)`)
+  db.exec(`CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT NOT NULL, session_id TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL)`)
+  const now = Date.now()
+  const ins = db.prepare(`INSERT INTO session (id, project_id, parent_id, directory, title, agent, model, time_created, time_updated, time_archived) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+  ins.run(OPENCODE_SESSION, 'global', null, '/tmp/demo', 'Fix the thing', 'build', JSON.stringify({ id: 'muse-spark', providerID: 'opencode-go', variant: 'xhigh' }), now - 60000, now, null)
+  ins.run('ses_child11111111111111111111111', 'global', OPENCODE_SESSION, '/tmp/demo', 'Do subtask (@general subagent)', 'general', null, now - 50000, now, null)
+  const mins = db.prepare(`INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)`)
+  mins.run('msg_user1', OPENCODE_SESSION, now - 60000, now - 60000, JSON.stringify({ role: 'user', time: { created: now - 60000 } }))
+  mins.run('msg_asst1', OPENCODE_SESSION, now - 59000, now - 58000, JSON.stringify({ role: 'assistant', time: { created: now - 59000, completed: now - 58000 }, finish: 'stop' }))
+  const pins = db.prepare(`INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)`)
+  pins.run('prt_user1', 'msg_user1', OPENCODE_SESSION, now - 60000, now - 60000, JSON.stringify({ type: 'text', text: '  ship   the thing  ' }))
+  pins.run('prt_asst1', 'msg_asst1', OPENCODE_SESSION, now - 59000, now - 58000, JSON.stringify({ type: 'text', text: 'done' }))
+  db.close()
+  process.env.OPENCODE_DB = dbFile
+  return { home, h: opencode }
+}
+
+test('opencode lists only top-level sessions with mapped fields', async () => {
+  const { home, h } = await fakeOpencode()
+  try {
+    assert.equal(await h.detect(), true)
+    const threads = await h.scanThreads()
+    assert.equal(threads.length, 1)
+    const [t] = threads
+    assert.equal(t.id, `opencode:${OPENCODE_SESSION}`)
+    assert.equal(t.project, 'demo')
+    assert.equal(t.projectPath, '/tmp/demo')
+    assert.equal(t.cwd, '/tmp/demo')
+    assert.equal(t.worktree, '')
+    assert.equal(t.title, 'Fix the thing')
+    assert.equal(t.preview, 'ship the thing')
+    assert.equal(t.model, 'muse-spark')
+    assert.equal(t.canOpen, false)
+    assert.deepEqual(t.ref, { sessionId: OPENCODE_SESSION, cwd: '/tmp/demo' })
+    assert.ok(t.sizeBytes > 0, 'sizeBytes is transcript bytes, not a token count')
+  } finally {
+    delete process.env.OPENCODE_DB
+    await fsp.rm(home, { recursive: true, force: true })
+  }
+})
+
+test('an absent opencode is simply not detected', async () => {
+  const home = await fsp.mkdtemp(path.join(os.tmpdir(), 'opencode-empty-'))
+  process.env.OPENCODE_DB = path.join(home, 'missing.db')
+  try {
+    assert.equal(await opencode.detect(), false)
+    assert.deepEqual(await opencode.scanThreads(), [])
+  } finally {
+    delete process.env.OPENCODE_DB
+    await fsp.rm(home, { recursive: true, force: true })
+  }
+})
+
+test('opencode running is bounded by the activity window and errors come from the last turn only', async () => {
+  const home = await fsp.mkdtemp(path.join(os.tmpdir(), 'opencode-status-'))
+  const dbFile = path.join(home, 'opencode.db')
+  const { DatabaseSync } = await import('node:sqlite')
+  const db = new DatabaseSync(dbFile)
+  db.exec(`CREATE TABLE session (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, parent_id TEXT, directory TEXT NOT NULL, title TEXT NOT NULL, agent TEXT, model TEXT, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, time_archived INTEGER)`)
+  db.exec(`CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL)`)
+  db.exec(`CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT NOT NULL, session_id TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL)`)
+  const now = Date.now()
+  const ins = db.prepare(`INSERT INTO session (id, project_id, parent_id, directory, title, agent, model, time_created, time_updated, time_archived) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+  ins.run('ses_running1111111111111111111111', 'global', null, '/tmp/a', 'Running now', 'build', null, now - 60000, now, null)
+  ins.run('ses_stale11111111111111111111111', 'global', null, '/tmp/b', 'Stale open turn', 'build', null, now - 6 * 60 * 60 * 1000, now - 6 * 60 * 60 * 1000, null)
+  ins.run('ses_error111111111111111111111111', 'global', null, '/tmp/c', 'Failed turn', 'build', null, now - 60000, now, null)
+  const mins = db.prepare(`INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)`)
+  mins.run('m_run', 'ses_running1111111111111111111111', now - 60000, now, JSON.stringify({ role: 'assistant', time: { created: now - 60000 } }))
+  mins.run('m_stale', 'ses_stale11111111111111111111111', now - 6 * 60 * 60 * 1000, now - 6 * 60 * 60 * 1000, JSON.stringify({ role: 'assistant', time: { created: now - 6 * 60 * 60 * 1000 } }))
+  mins.run('m_err', 'ses_error111111111111111111111111', now - 60000, now, JSON.stringify({ role: 'assistant', time: { created: now - 60000, completed: now }, finish: 'stop' }))
+  const pins = db.prepare(`INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)`)
+  pins.run('p_run', 'm_run', 'ses_running1111111111111111111111', now, now, JSON.stringify({ type: 'step-start' }))
+  pins.run('p_err', 'm_err', 'ses_error111111111111111111111111', now, now, JSON.stringify({ type: 'tool', tool: 'bash', state: { status: 'error' } }))
+  db.close()
+  process.env.OPENCODE_DB = dbFile
+  try {
+    const byId = new Map((await opencode.scanThreads()).map((t) => [t.id, t]))
+    assert.equal(byId.get('opencode:ses_running1111111111111111111111').running, true)
+    assert.equal(byId.get('opencode:ses_stale11111111111111111111111').running, false, 'an open turn from hours ago is not still running')
+    assert.equal(byId.get('opencode:ses_error111111111111111111111111').hasError, true)
+    assert.equal(byId.get('opencode:ses_running1111111111111111111111').hasError, false)
+  } finally {
+    delete process.env.OPENCODE_DB
+    await fsp.rm(home, { recursive: true, force: true })
+  }
+})
+
+test('opencode refuses untrusted refs and offers no per-thread link', async () => {
+  const { home, h } = await fakeOpencode()
+  try {
+    const uuid = OPENCODE_SESSION
+    assert.equal(h.openThread({ sessionId: [uuid] }).ok, false)
+    assert.equal(h.openThread({ sessionId: { toString: () => uuid } }).ok, false)
+    assert.equal(h.openThread({ sessionId: uuid }).ok, false)
+    assert.equal(h.openThread(null).ok, false)
+    assert.equal(h.openThread({}).ok, false)
+    const opened = await h.newSession('/tmp/some repo')
+    assert.equal(opened.ok, true)
+    assert.equal(schemeOf(opened.url), 'opencode')
+    assert.ok(opened.url.includes('directory='), 'the directory rides along')
+    assert.equal((await h.newSession('relative/path')).ok, false)
+  } finally {
+    delete process.env.OPENCODE_DB
+    await fsp.rm(home, { recursive: true, force: true })
+  }
 })


### PR DESCRIPTION
Adds OpenCode support per server/harnesses/README.md: one new file (server/harnesses/opencode.mjs) plus one registry line in index.mjs. Nothing in scan/api/src changes.

How it reads: opencode.db (WAL, read-only via lazily-imported node:sqlite) at OPENCODE_DB override, XDG, ~/.local/share/opencode/opencode.db, plus macOS Application Support fallback. Only top-level sessions (parent_id IS NULL, same filter as OpenCode's own list) become threads; 340/426 rows on my machine are child subagents and are excluded. directory is the project source (project_id global still carries real directories). model/effort from session.model JSON, sizeBytes as SUM(LENGTH(data)) bytes (not tokens), running bounded by 30min window on the last open turn, hasError from the last turn's tool error only, archived read-only from time_archived. openThread is honestly refused (no per-session opencode:// route exists upstream); newSession uses opencode://new-session?directory= with a Linux opencode CLI fallback. Caches previews/facts against time_updated; malformed rows skipped, scan never throws; refs type-checked.

Verified: node --check clean, npm test 37/37 pass (4 new fixture tests with temp OPENCODE_DB: mapping, absent, running/error window, untrusted refs), live scan 86 opencode threads with zero undefined fields and zero unprefixed ids, /api/harnesses shows opencode detected:true with no diagnostic. Style matches surrounding code (no semicolons, single quotes, why-comments). No new dependencies, no writes to harness files.

Why `Open` is unavailable for OpenCode threads (not a bug in this adapter): OpenCode upstream exposes no per-session link. The desktop app registers only `opencode://open-project` and `opencode://new-session` (see `parseDeepLink`/`parseNewSessionDeepLink` in `packages/app/src/pages/layout/deep-links.ts`); the per-session request (sst/opencode#44167, "Add a deep link to open a specific Desktop session") is still open and its predecessor (#6232) was closed `not_planned`. `opencode --session <id>` only works inside a terminal, which the server's opener uses on Linux alone, and force-opening via the desktop's workspace `.dat` files would mean writing to the harness — forbidden. So OpenCode threads report `canOpen:false` and `openThread` refuses with an explanatory message (same posture as the Cursor adapter) while `newSession` works. If upstream ever ships `opencode://session/<id>`, support is a one-liner: `ref` already carries `sessionId`.

Error-flag follow-up: only genuine failures redden an astronaut. User-stopped turns (rejected permission, aborted calls, message-level aborts) are not errors — the equivalent of pressing escape elsewhere. Provider-level turn failures (`APIError`) and real tool errors still flag.
