### PR TITLE
Spawn the crew by status, not scan position, so the chips stay clickable

### DIFF
--- a/src/agents/astronauts.js
+++ b/src/agents/astronauts.js
@@ -471,7 +471,11 @@ export class Astronauts {
     // Agents on their way back to the ship still hold a slot, so the roster has to leave room
     // for them. Without this the clamp above would quietly drop whoever sorted last, which is
     // better than an empty planet but still not what the scan said.
-    const leaving = this.agents.reduce((n, a) => n + (a.state === 'leaving' ? 1 : 0), 0)
+    const ids = new Set(entries.map((entry) => entry.id))
+    // Only leavers the scan no longer wants hold a slot for the walk home. One whose thread
+    // is back in the roster is about to be revived in place by _updateAgent, and counting
+    // it would cut somebody else to reserve a slot it is not going to use.
+    const leaving = this.agents.reduce((n, a) => n + (a.state === 'leaving' && !ids.has(a.id) ? 1 : 0), 0)
     // Status-aware, not positional: whatever the chips count as urgent must actually be on
     // the surface to click. See roster.js for why a plain slice hides exactly those threads.
     const wanted = capRoster(entries, Math.max(1, cap - leaving))
@@ -594,6 +598,11 @@ export class Astronauts {
     if (entry.status !== agent.status) {
       agent.status = entry.status
       this._applyStatus(agent, entry.status)
+    } else if (agent.state === 'leaving') {
+      // A leaver the scan wants back has no status edge to revive it — _sendHome pointed it
+      // at the door without touching its status. Reapply in place, or it walks into the
+      // ship and despawns while still on the roster, then respawns from scratch next poll.
+      this._applyStatus(agent, agent.status)
     }
   }
 

--- a/src/agents/astronauts.js
+++ b/src/agents/astronauts.js
@@ -2,6 +2,7 @@ import * as THREE from 'three'
 import * as BufferGeometryUtils from 'three/addons/utils/BufferGeometryUtils.js'
 import { buildFaceAtlas, FACE, FACE_LOOPS, FRAME_COLS, FRAME_ROWS } from './faces.js'
 import { attachMatrixAt, decorateSkinned, frameFor } from './crew.js'
+import { capRoster } from '../game/roster.js'
 
 /**
  * Every astronaut in the colony, drawn in seven draw calls.
@@ -471,7 +472,9 @@ export class Astronauts {
     // for them. Without this the clamp above would quietly drop whoever sorted last, which is
     // better than an empty planet but still not what the scan said.
     const leaving = this.agents.reduce((n, a) => n + (a.state === 'leaving' ? 1 : 0), 0)
-    const wanted = entries.slice(0, Math.max(1, cap - leaving))
+    // Status-aware, not positional: whatever the chips count as urgent must actually be on
+    // the surface to click. See roster.js for why a plain slice hides exactly those threads.
+    const wanted = capRoster(entries, Math.max(1, cap - leaving))
     const seen = new Set()
 
     // The ramp is one door and the ship is a solid obstacle around it, so an entrance is a

--- a/src/agents/astronauts.js
+++ b/src/agents/astronauts.js
@@ -468,17 +468,20 @@ export class Astronauts {
     this.roster = entries
     this.world = world || this.world
     const cap = Math.min(this.capacity, this.settings.get('maxAgents'))
-    // Agents on their way back to the ship still hold a slot, so the roster has to leave room
-    // for them. Without this the clamp above would quietly drop whoever sorted last, which is
-    // better than an empty planet but still not what the scan said.
-    const ids = new Set(entries.map((entry) => entry.id))
-    // Only leavers the scan no longer wants hold a slot for the walk home. One whose thread
-    // is back in the roster is about to be revived in place by _updateAgent, and counting
-    // it would cut somebody else to reserve a slot it is not going to use.
-    const leaving = this.agents.reduce((n, a) => n + (a.state === 'leaving' && !ids.has(a.id) ? 1 : 0), 0)
     // Status-aware, not positional: whatever the chips count as urgent must actually be on
     // the surface to click. See roster.js for why a plain slice hides exactly those threads.
-    const wanted = capRoster(entries, Math.max(1, cap - leaving))
+    //
+    // Cut first, then reserve. A leaver holds a slot for its walk home only when the cut
+    // did not re-adopt it — one inside the cut is revived in place by _updateAgent below.
+    // Judging leavers against the scan instead of the cut would let a leaver that is in
+    // the scan but capped out slip both counts, and the crew would overshoot the cap.
+    let wanted = capRoster(entries, cap)
+    const wantedIds = new Set(wanted.map((entry) => entry.id))
+    const leaving = this.agents.reduce(
+      (n, a) => n + (a.state === 'leaving' && !wantedIds.has(a.id) ? 1 : 0),
+      0
+    )
+    if (leaving) wanted = capRoster(entries, Math.max(1, cap - leaving))
     const seen = new Set()
 
     // The ramp is one door and the ship is a solid obstacle around it, so an entrance is a

--- a/src/game/colony.js
+++ b/src/game/colony.js
@@ -49,9 +49,6 @@ const LIVE_GROWTH = 0.004
 /** How many zones' positions to remember, including repos with nothing running in them. */
 const LAYOUT_MEMORY = 80
 
-// Lives in roster.js (with the cap that uses it as a spawn priority); re-exported so the
-// HUD and card sorting keep importing it from here.
-export { STATUS_ORDER }
 
 export const STATUS_LABEL = {
   working: 'Working',

--- a/src/game/colony.js
+++ b/src/game/colony.js
@@ -20,7 +20,7 @@ import { MAX_AGENT_CAP } from '../core/settings.js'
 import { Particles } from '../agents/particles.js'
 import { Navigation } from '../agents/navigation.js'
 import { liveThreadsForColony } from './hidden-projects.js'
-import { STATUS_ORDER } from './roster.js'
+import { projectKey, STATUS_ORDER } from './roster.js'
 
 /**
  * The colony: everything that turns a list of agent threads into a place.
@@ -270,7 +270,7 @@ export class Colony {
     // Group by repo, biggest project first so the busiest work lands nearest the middle.
     const byProject = new Map()
     for (const thread of live) {
-      const key = thread.project || 'unknown'
+      const key = projectKey(thread)
       if (!byProject.has(key)) byProject.set(key, [])
       byProject.get(key).push(thread)
     }

--- a/src/game/colony.js
+++ b/src/game/colony.js
@@ -20,6 +20,7 @@ import { MAX_AGENT_CAP } from '../core/settings.js'
 import { Particles } from '../agents/particles.js'
 import { Navigation } from '../agents/navigation.js'
 import { liveThreadsForColony } from './hidden-projects.js'
+import { STATUS_ORDER } from './roster.js'
 
 /**
  * The colony: everything that turns a list of agent threads into a place.
@@ -48,7 +49,9 @@ const LIVE_GROWTH = 0.004
 /** How many zones' positions to remember, including repos with nothing running in them. */
 const LAYOUT_MEMORY = 80
 
-export const STATUS_ORDER = ['blocked', 'waiting', 'working', 'celebrating', 'idle', 'sleeping']
+// Lives in roster.js (with the cap that uses it as a spawn priority); re-exported so the
+// HUD and card sorting keep importing it from here.
+export { STATUS_ORDER }
 
 export const STATUS_LABEL = {
   working: 'Working',

--- a/src/game/hidden-projects.js
+++ b/src/game/hidden-projects.js
@@ -13,6 +13,8 @@
  * same trade — so both are wrong in the same direction, which is at least predictable.
  */
 
+import { projectKey } from './roster.js'
+
 export function hideProject(hidden, name) {
   const id = String(name || '')
   if (!id || hidden.includes(id)) return [...hidden]
@@ -28,7 +30,7 @@ export function unhideProject(hidden, name) {
 export function liveThreadsForColony(threads, archivedIds, hiddenProjects) {
   const archived = archivedIds instanceof Set ? archivedIds : new Set(archivedIds)
   const hidden = hiddenProjects instanceof Set ? hiddenProjects : new Set(hiddenProjects)
-  return threads.filter((t) => !t.archived && !archived.has(t.id) && !hidden.has(t.project || 'unknown'))
+  return threads.filter((t) => !t.archived && !archived.has(t.id) && !hidden.has(projectKey(t)))
 }
 
 /**
@@ -39,6 +41,6 @@ export function hiddenCatalog(hidden, threads) {
   const names = [...new Set(hidden.map(String).filter(Boolean))].sort((a, b) => a.localeCompare(b))
   return names.map((name) => ({
     name,
-    count: threads.filter((t) => !t.archived && (t.project || 'unknown') === name).length,
+    count: threads.filter((t) => !t.archived && projectKey(t) === name).length,
   }))
 }

--- a/src/game/roster.js
+++ b/src/game/roster.js
@@ -20,7 +20,17 @@
 /** Loudest first. Doubles as the spawn priority when the cap forces a choice. */
 export const STATUS_ORDER = ['blocked', 'waiting', 'working', 'celebrating', 'idle', 'sleeping']
 
+/**
+ * The statuses the HUD turns into clickable chips. The representative guarantee below only
+ * spends bodies on these — seating an idle or dormant astronaut by evicting a blocked one
+ * would cost a click target to buy something no chip can reach.
+ */
+const CHIP_STATUSES = STATUS_ORDER.slice(0, 4)
+
 const RANK = new Map(STATUS_ORDER.map((status, i) => [status, i]))
+
+/** One rank source for every status sort — an unknown status always sorts last, everywhere. */
+export const statusRank = (status) => RANK.get(status) ?? STATUS_ORDER.length
 
 /**
  * Pick which roster entries get an astronaut. Entries must carry a `status`; the incoming
@@ -29,18 +39,18 @@ const RANK = new Map(STATUS_ORDER.map((status, i) => [status, i]))
  */
 export function capRoster(entries, cap) {
   if (entries.length <= cap) return entries
-  const rank = (entry) => RANK.get(entry.status) ?? STATUS_ORDER.length
   // Array.prototype.sort is stable, which is load-bearing here: it is what keeps a quiet
   // scan from reshuffling the crew.
-  const sorted = [...entries].sort((a, b) => rank(a) - rank(b))
+  const sorted = [...entries].sort((a, b) => statusRank(a.status) - statusRank(b.status))
   const wanted = sorted.slice(0, cap)
 
   // A tiny cap can still be exhausted by one loud status — 200 blocked threads under a cap
-  // of 90 would leave "1 building" unclickable all over again. Guarantee every status in
-  // the scan one representative by evicting from the tail, never a status's own last body.
+  // of 90 would leave "1 building" unclickable all over again. Guarantee every *chip*
+  // status in the scan one representative by evicting from the tail, never a status's own
+  // last body.
   const counts = new Map()
   for (const entry of wanted) counts.set(entry.status, (counts.get(entry.status) || 0) + 1)
-  for (const status of STATUS_ORDER) {
+  for (const status of CHIP_STATUSES) {
     if (counts.get(status)) continue
     const promote = sorted.find((entry) => entry.status === status)
     if (!promote) continue

--- a/src/game/roster.js
+++ b/src/game/roster.js
@@ -17,15 +17,24 @@
  * Pure and browser-free on purpose, like merge-state.js, so it runs under bare node.
  */
 
+/**
+ * The zone a thread belongs to. Scanners tolerate threads with no project, and the colony
+ * plots those under 'unknown' — every grouping, count and lookup has to apply the same
+ * rule, or the unknown zone drifts apart from its own card and legend.
+ */
+export const projectKey = (thread) => thread.project || 'unknown'
+
 /** Loudest first. Doubles as the spawn priority when the cap forces a choice. */
 export const STATUS_ORDER = ['blocked', 'waiting', 'working', 'celebrating', 'idle', 'sleeping']
 
 /**
- * The statuses the HUD turns into clickable chips. The representative guarantee below only
- * spends bodies on these — seating an idle or dormant astronaut by evicting a blocked one
+ * The statuses the HUD turns into clickable chips (STAT_DEFS in hud.js). Named outright
+ * rather than sliced off STATUS_ORDER, so reordering the spawn priority cannot silently
+ * change which statuses the representative guarantee below covers — it only ever spends
+ * bodies on these, because seating an idle or dormant astronaut by evicting a blocked one
  * would cost a click target to buy something no chip can reach.
  */
-const CHIP_STATUSES = STATUS_ORDER.slice(0, 4)
+export const CHIP_STATUSES = ['blocked', 'waiting', 'working', 'celebrating']
 
 const RANK = new Map(STATUS_ORDER.map((status, i) => [status, i]))
 

--- a/src/game/roster.js
+++ b/src/game/roster.js
@@ -1,0 +1,57 @@
+/**
+ * Which threads get a body when there are more threads than astronauts.
+ *
+ * The HUD counts every thread in the scan, but `maxAgents` caps how many astronauts are
+ * actually on the surface. A plain positional cut ("first N in roster order") is ordered by
+ * project size and thread age — never by status — so the threads most worth watching are the
+ * likeliest to be cut: a working thread is by definition recently active, which puts it at
+ * the very end of its project's age-sorted list. That is how a colony ends up saying
+ * "1 building" while no builder exists to click.
+ *
+ * So the cut is by status first: everything the chips call urgent — blocked, waiting,
+ * working — outranks idle and dormant, and inside one status the incoming order (biggest
+ * project, oldest thread) is preserved, so the crew stays put between scans. Membership only
+ * changes when a thread actually changes status, which is exactly when the player would
+ * expect the crew to change.
+ *
+ * Pure and browser-free on purpose, like merge-state.js, so it runs under bare node.
+ */
+
+/** Loudest first. Doubles as the spawn priority when the cap forces a choice. */
+export const STATUS_ORDER = ['blocked', 'waiting', 'working', 'celebrating', 'idle', 'sleeping']
+
+const RANK = new Map(STATUS_ORDER.map((status, i) => [status, i]))
+
+/**
+ * Pick which roster entries get an astronaut. Entries must carry a `status`; the incoming
+ * order is preserved within each status. Deterministic: the same entries and cap always
+ * return the same crew, so a re-scan that changed nothing moves nobody.
+ */
+export function capRoster(entries, cap) {
+  if (entries.length <= cap) return entries
+  const rank = (entry) => RANK.get(entry.status) ?? STATUS_ORDER.length
+  // Array.prototype.sort is stable, which is load-bearing here: it is what keeps a quiet
+  // scan from reshuffling the crew.
+  const sorted = [...entries].sort((a, b) => rank(a) - rank(b))
+  const wanted = sorted.slice(0, cap)
+
+  // A tiny cap can still be exhausted by one loud status — 200 blocked threads under a cap
+  // of 90 would leave "1 building" unclickable all over again. Guarantee every status in
+  // the scan one representative by evicting from the tail, never a status's own last body.
+  const counts = new Map()
+  for (const entry of wanted) counts.set(entry.status, (counts.get(entry.status) || 0) + 1)
+  for (const status of STATUS_ORDER) {
+    if (counts.get(status)) continue
+    const promote = sorted.find((entry) => entry.status === status)
+    if (!promote) continue
+    for (let i = wanted.length - 1; i >= 0; i--) {
+      const evict = wanted[i].status
+      if ((counts.get(evict) || 0) < 2) continue
+      counts.set(evict, counts.get(evict) - 1)
+      counts.set(status, 1)
+      wanted[i] = promote
+      break
+    }
+  }
+  return wanted
+}

--- a/src/main.js
+++ b/src/main.js
@@ -107,6 +107,13 @@ const actions = {
     const key = status === 'agents' ? null : status
     const pool = colony.astronauts.agents.filter((a) => (key ? a.status === key : true))
     if (!pool.length) {
+      // Counted in the chips but capped out of the crew: the zone card still lists every
+      // thread, so open the project instead of dead-ending on a hint.
+      const thread = key ? [...colony.threads.values()].find((t) => statusFor(t) === key) : null
+      if (thread && colony.plots.has(thread.project)) {
+        selectProject(thread.project, { fly: true })
+        return
+      }
       hud.hint(key ? `Nobody is ${(STATUS_LABEL[key] || key).toLowerCase()} right now` : 'No crew on the surface')
       return
     }

--- a/src/main.js
+++ b/src/main.js
@@ -4,7 +4,7 @@ import { DEFAULT_PRESET, Settings, hasStoredSettings } from './core/settings.js'
 import { Engine } from './core/engine.js'
 import { CameraRig } from './core/camera.js'
 import { Colony, STATUS_LABEL, statusFor, transcriptProgress } from './game/colony.js'
-import { statusRank } from './game/roster.js'
+import { projectKey, statusRank } from './game/roster.js'
 import { Hud } from './ui/hud.js'
 import { PLANETS } from './world/planet.js'
 import { loadKit } from './world/kit.js'
@@ -119,7 +119,7 @@ const actions = {
             ...new Set(
               [...colony.threads.values()]
                 .filter((t) => statusFor(t) === key)
-                .map((t) => t.project || 'unknown')
+                .map((t) => projectKey(t))
                 .filter((name) => colony.plots.has(name))
             ),
           ]
@@ -214,7 +214,7 @@ const actions = {
     // If the open thread belonged to the repo that just left, nothing is selected any more.
     if (selectedId) {
       const thread = threads.find((t) => t.id === selectedId)
-      if (thread?.project === name) select(null, {})
+      if (thread && projectKey(thread) === name) select(null, {})
     }
     selectedProject = null
     applyThreads(threads)
@@ -314,7 +314,8 @@ function select(id, { fly = false } = {}) {
   const thread = threads.find((t) => t.id === id) || agent.thread
   hud.setSelection(agent, thread)
   // Picking somebody is also picking the zone they are standing on: the sidebar follows.
-  if (thread?.project && colony.plots.has(thread.project)) selectedProject = thread.project
+  const zone = thread ? projectKey(thread) : null
+  if (zone && colony.plots.has(zone)) selectedProject = zone
   syncProject()
   if (fly) {
     rig.focus(new THREE.Vector3(agent.pos.x, 0, agent.pos.z), { distance: Math.min(rig.desiredDistance, 26) })
@@ -326,7 +327,7 @@ function selectProject(name, { fly = false } = {}) {
   if (!name || !colony.plots.has(name)) return
   selectedProject = name
   const current = threads.find((t) => t.id === selectedId)
-  if (current && current.project !== name) select(null, {})
+  if (current && projectKey(current) !== name) select(null, {})
   else syncProject()
   if (fly) actions.focusProject(name)
 }
@@ -352,7 +353,7 @@ function harnessLabel(id) {
 function harnessForProject(name) {
   const counts = new Map()
   for (const thread of colony.threads.values()) {
-    if (thread.project !== name || !thread.harness) continue
+    if (projectKey(thread) !== name || !thread.harness) continue
     counts.set(thread.harness, (counts.get(thread.harness) ?? 0) + 1)
   }
   let best = ''
@@ -368,7 +369,7 @@ function harnessForProject(name) {
 function pathForProject(name) {
   const counts = new Map()
   for (const thread of colony.threads.values()) {
-    if (thread.project !== name) continue
+    if (projectKey(thread) !== name) continue
     const dir = thread.projectPath || thread.cwd
     if (!dir) continue
     counts.set(dir, (counts.get(dir) ?? 0) + 1)
@@ -399,7 +400,7 @@ function syncProject() {
   const now = Date.now()
   const list = [...colony.threads.values()]
     // Same grouping the colony uses, or the 'unknown' zone's card would list nothing.
-    .filter((thread) => (thread.project || 'unknown') === plot.name)
+    .filter((thread) => projectKey(thread) === plot.name)
     .map((thread) => ({
       id: thread.id,
       title: thread.title,
@@ -646,7 +647,7 @@ function applyThreads(list) {
     .map((plot) => ({
       name: plot.name,
       accent: plot.accent,
-      count: list.filter((t) => !t.archived && !archivedSet.has(t.id) && t.project === plot.name).length,
+      count: list.filter((t) => !t.archived && !archivedSet.has(t.id) && projectKey(t) === plot.name).length,
       urgent: colony.urgentPlots?.has(plot.id) ?? false,
     }))
     .sort((a, b) => b.count - a.count)

--- a/src/main.js
+++ b/src/main.js
@@ -3,7 +3,8 @@ import './ui/styles.css'
 import { DEFAULT_PRESET, Settings, hasStoredSettings } from './core/settings.js'
 import { Engine } from './core/engine.js'
 import { CameraRig } from './core/camera.js'
-import { Colony, STATUS_LABEL, STATUS_ORDER, statusFor, transcriptProgress } from './game/colony.js'
+import { Colony, STATUS_LABEL, statusFor, transcriptProgress } from './game/colony.js'
+import { statusRank } from './game/roster.js'
 import { Hud } from './ui/hud.js'
 import { PLANETS } from './world/planet.js'
 import { loadKit } from './world/kit.js'
@@ -105,13 +106,26 @@ const actions = {
   /** Fly to the next astronaut in a given state, cycling through them on repeat presses. */
   focusStatus: (status) => {
     const key = status === 'agents' ? null : status
-    const pool = colony.astronauts.agents.filter((a) => (key ? a.status === key : true))
+    // Leavers keep their status for the walk to the ship; flying to one parks the camera
+    // on an astronaut mid-despawn.
+    const pool = colony.astronauts.agents.filter((a) => a.state !== 'leaving' && (key ? a.status === key : true))
     if (!pool.length) {
       // Counted in the chips but capped out of the crew: the zone card still lists every
-      // thread, so open the project instead of dead-ending on a hint.
-      const thread = key ? [...colony.threads.values()].find((t) => statusFor(t) === key) : null
-      if (thread && colony.plots.has(thread.project)) {
-        selectProject(thread.project, { fly: true })
+      // thread, so open the project instead of dead-ending on a hint. Threads group under
+      // 'unknown' when they carry no project, same as the colony does. Shares the cursor
+      // with the pool path so repeat presses cycle here too.
+      const names = key
+        ? [
+            ...new Set(
+              [...colony.threads.values()]
+                .filter((t) => statusFor(t) === key)
+                .map((t) => t.project || 'unknown')
+                .filter((name) => colony.plots.has(name))
+            ),
+          ]
+        : []
+      if (names.length) {
+        selectProject(names[statusCursor++ % names.length], { fly: true })
         return
       }
       hud.hint(key ? `Nobody is ${(STATUS_LABEL[key] || key).toLowerCase()} right now` : 'No crew on the surface')
@@ -384,7 +398,8 @@ function syncProject() {
   }
   const now = Date.now()
   const list = [...colony.threads.values()]
-    .filter((thread) => thread.project === plot.name)
+    // Same grouping the colony uses, or the 'unknown' zone's card would list nothing.
+    .filter((thread) => (thread.project || 'unknown') === plot.name)
     .map((thread) => ({
       id: thread.id,
       title: thread.title,
@@ -395,7 +410,7 @@ function syncProject() {
     // Whoever wants something first, then most recently touched — the same order of
     // importance the badges use above their heads.
     .sort((a, b) => {
-      const rank = STATUS_ORDER.indexOf(a.status) - STATUS_ORDER.indexOf(b.status)
+      const rank = statusRank(a.status) - statusRank(b.status)
       return rank || (b.lastActivityAt ?? 0) - (a.lastActivityAt ?? 0)
     })
 

--- a/test/roster.test.mjs
+++ b/test/roster.test.mjs
@@ -1,0 +1,70 @@
+/**
+ * The spawn cap: when threads outnumber astronauts, who gets a body.
+ *
+ * The regression these guard is the chips lying — a status counted at the top of the screen
+ * with no astronaut on the surface to click, because the cut was positional and the loudest
+ * thread sorted last.
+ */
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { capRoster, STATUS_ORDER } from '../src/game/roster.js'
+
+let n = 0
+const entry = (status) => ({ id: `t${n++}`, status })
+const many = (count, status) => Array.from({ length: count }, () => entry(status))
+const ids = (list) => list.map((e) => e.id)
+
+test('a roster under the cap is returned untouched, in order', () => {
+  const entries = [entry('idle'), entry('working'), entry('sleeping')]
+  assert.equal(capRoster(entries, 10), entries)
+})
+
+test('the one working thread spawns even when it sorts last — the reported bug', () => {
+  const entries = [...many(200, 'idle'), entry('working')]
+  const crew = capRoster(entries, 90)
+  assert.equal(crew.length, 90)
+  assert.ok(crew.some((e) => e.status === 'working'))
+})
+
+test('every urgent thread spawns before any idle one when they fit', () => {
+  const entries = [...many(100, 'idle'), ...many(51, 'blocked'), ...many(7, 'waiting'), entry('working')]
+  const crew = capRoster(entries, 90)
+  assert.equal(crew.filter((e) => e.status === 'blocked').length, 51)
+  assert.equal(crew.filter((e) => e.status === 'waiting').length, 7)
+  assert.equal(crew.filter((e) => e.status === 'working').length, 1)
+  assert.equal(crew.filter((e) => e.status === 'idle').length, 90 - 59)
+})
+
+test('incoming order is preserved within a status', () => {
+  const idles = many(50, 'idle')
+  const crew = capRoster([...idles, ...many(5, 'working')], 30)
+  const kept = crew.filter((e) => e.status === 'idle')
+  assert.deepEqual(ids(kept), ids(idles).slice(0, kept.length))
+})
+
+test('one loud status cannot crowd every other status out entirely', () => {
+  const entries = [...many(200, 'blocked'), entry('working'), entry('waiting'), entry('idle')]
+  const crew = capRoster(entries, 90)
+  for (const status of ['blocked', 'waiting', 'working', 'idle']) {
+    assert.ok(crew.some((e) => e.status === status), `${status} has a representative`)
+  }
+})
+
+test('a status’s lone representative is never evicted to seat another', () => {
+  // Cap of 2 cannot hold all three statuses; the two loudest win and neither loses its
+  // only body to the third.
+  const crew = capRoster([entry('blocked'), entry('waiting'), entry('working')], 2)
+  assert.deepEqual(crew.map((e) => e.status), ['blocked', 'waiting'])
+})
+
+test('the same scan twice yields the same crew — nobody walks home for nothing', () => {
+  const entries = [...many(40, 'idle'), ...many(10, 'blocked'), ...many(40, 'sleeping'), entry('working')]
+  assert.deepEqual(ids(capRoster(entries, 30)), ids(capRoster([...entries], 30)))
+})
+
+test('statuses cover STATUS_ORDER — a new status must pick a spawn priority', () => {
+  // capRoster ranks unknown statuses last silently; this trips instead when someone adds a
+  // status to statusFor without deciding where it sits in the cut.
+  assert.deepEqual(STATUS_ORDER, ['blocked', 'waiting', 'working', 'celebrating', 'idle', 'sleeping'])
+})

--- a/test/roster.test.mjs
+++ b/test/roster.test.mjs
@@ -43,12 +43,22 @@ test('incoming order is preserved within a status', () => {
   assert.deepEqual(ids(kept), ids(idles).slice(0, kept.length))
 })
 
-test('one loud status cannot crowd every other status out entirely', () => {
+test('one loud status cannot crowd the other chips out entirely', () => {
   const entries = [...many(200, 'blocked'), entry('working'), entry('waiting'), entry('idle')]
   const crew = capRoster(entries, 90)
-  for (const status of ['blocked', 'waiting', 'working', 'idle']) {
+  for (const status of ['blocked', 'waiting', 'working']) {
     assert.ok(crew.some((e) => e.status === status), `${status} has a representative`)
   }
+  // Idle has no chip: nobody can click its representative, so no blocked body is spent on one.
+  assert.ok(!crew.some((e) => e.status === 'idle'))
+})
+
+test('a dormant thread never costs a chip status its astronaut', () => {
+  const crew = capRoster([...many(2, 'blocked'), ...many(2, 'waiting'), entry('sleeping')], 4)
+  assert.deepEqual(
+    crew.map((e) => e.status),
+    ['blocked', 'blocked', 'waiting', 'waiting']
+  )
 })
 
 test('a status’s lone representative is never evicted to seat another', () => {
@@ -63,8 +73,11 @@ test('the same scan twice yields the same crew — nobody walks home for nothing
   assert.deepEqual(ids(capRoster(entries, 30)), ids(capRoster([...entries], 30)))
 })
 
-test('statuses cover STATUS_ORDER — a new status must pick a spawn priority', () => {
-  // capRoster ranks unknown statuses last silently; this trips instead when someone adds a
-  // status to statusFor without deciding where it sits in the cut.
-  assert.deepEqual(STATUS_ORDER, ['blocked', 'waiting', 'working', 'celebrating', 'idle', 'sleeping'])
+test('every status statusFor can return has a spawn priority', () => {
+  // capRoster ranks unknown statuses last silently; this trips instead when a status is
+  // removed from STATUS_ORDER (or renamed in one place) without deciding where it sits in
+  // the cut. The list mirrors the returns of statusFor in colony.js.
+  for (const status of ['blocked', 'working', 'celebrating', 'waiting', 'sleeping', 'idle']) {
+    assert.ok(STATUS_ORDER.includes(status), `${status} is ranked`)
+  }
 })

--- a/test/roster.test.mjs
+++ b/test/roster.test.mjs
@@ -8,7 +8,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import { capRoster, STATUS_ORDER } from '../src/game/roster.js'
+import { capRoster, CHIP_STATUSES, STATUS_ORDER } from '../src/game/roster.js'
 
 let n = 0
 const entry = (status) => ({ id: `t${n++}`, status })
@@ -71,6 +71,13 @@ test('a status’s lone representative is never evicted to seat another', () => 
 test('the same scan twice yields the same crew — nobody walks home for nothing', () => {
   const entries = [...many(40, 'idle'), ...many(10, 'blocked'), ...many(40, 'sleeping'), entry('working')]
   assert.deepEqual(ids(capRoster(entries, 30)), ids(capRoster([...entries], 30)))
+})
+
+test('the chip statuses mirror the chips the HUD actually draws', () => {
+  // STAT_DEFS in hud.js is the other half of this list. hud.js cannot be imported under
+  // bare node, so the correspondence is pinned here instead of read from it.
+  assert.deepEqual(CHIP_STATUSES, ['blocked', 'waiting', 'working', 'celebrating'])
+  for (const status of CHIP_STATUSES) assert.ok(STATUS_ORDER.includes(status), `${status} is ranked`)
 })
 
 test('every status statusFor can return has a spawn priority', () => {


### PR DESCRIPTION
## The bug

The header chips count every thread in the scan, but the crew is capped by `maxAgents`, and the cut was positional — project size, then thread age. A `working` thread is by definition recently active, so it sorted last and was cut first. On a real 540-thread colony the header read **"1 building"** while clicking it said *"Nobody is working right now"*, and no builder existed in-world — the colony misrepresenting what a thread is doing, which CONTRIBUTING names as the thing that matters most.

## The fix

- `capRoster` (new, pure, bare-node testable like `merge-state.js`): the cut is by status priority, stable within a status so a quiet scan moves nobody, with a guarantee that no chip status present in the scan ends up unclickable even when one loud status could fill the whole cap.
- Slot math runs cut-first: only leavers the cut did not re-adopt reserve a slot, and a leaver whose thread returns is revived in place instead of despawning mid-walk.
- Chip clicks skip mid-despawn leavers, and when astronauts are capped out they open the project card (which lists every thread) instead of dead-ending — cycling on repeat presses as before.
- One `projectKey` definition for the `'unknown'` zone grouping, used by the colony, card, legend, selection and hiding alike (the card and legend previously disagreed with the colony about project-less threads).

## Verified

- `npm test` 43/43 (10 new tests in `test/roster.test.mjs`, including the exact repro: 200 idle + 1 working under cap 90).
- Ran against the real 540-thread colony above: every non-zero chip now lands on an astronaut, crew count holds at the cap through status churn.
- Two adversarial AI review passes; all findings fixed in the follow-up commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
