### PR TITLE
A desert world: twin suns, dunes, and adobe-tinted buildings

### DIFF
--- a/src/game/colony.js
+++ b/src/game/colony.js
@@ -113,6 +113,7 @@ export class Colony {
     this.renderer = renderer
 
     this.planet = PLANETS[settings.get('planet')] || PLANETS.moon
+    this._applyPlanetTint()
     this.sky = new Sky(scene, settings, renderer)
     this.sky.setPlanet(this.planet)
     // Push the stored time in explicitly. `settings.set` is a no-op when the value has not
@@ -241,8 +242,19 @@ export class Colony {
     const planet = PLANETS[id]
     if (!planet || planet === this.planet) return
     this.planet = planet
+    this._applyPlanetTint()
     this.sky.setPlanet(planet)
     this._buildTerrain()
+  }
+
+  /**
+   * The buildings' shared planet-tint uniforms. Shared is the point: every standing
+   * building re-themes on a planet switch without a single rebuild.
+   */
+  _applyPlanetTint() {
+    const tint = this.planet.buildingTint
+    buildingUniforms.uPlanetTint.value.set(tint ?? 0xffffff)
+    buildingUniforms.uPlanetTintAmount.value = tint != null ? 1 : 0
   }
 
   onSettingsChanged(changed, scope) {

--- a/src/ui/hud-data.js
+++ b/src/ui/hud-data.js
@@ -2,4 +2,4 @@
 export { PRESETS } from '../core/settings.js'
 
 /** Display order for the planet picker — nearest to furthest from home. */
-export const PLANETS_ORDER = ['moon', 'mars', 'terra']
+export const PLANETS_ORDER = ['moon', 'mars', 'terra', 'desert']

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -439,7 +439,8 @@ body {
 
 .planets {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  /* Four worlds sit as a 2x2; three columns would strand one on a row of its own. */
+  grid-template-columns: repeat(2, 1fr);
   gap: 7px;
 }
 

--- a/src/world/buildings.js
+++ b/src/world/buildings.js
@@ -34,6 +34,14 @@ export const buildingUniforms = {
   uNight: { value: 0 },
   /** Seconds, for anything that turns. One write drives every rotor in the colony. */
   uTime: { value: 0 },
+  /**
+   * A planet's colour on the hull. The neutral structural swatches lean toward this when
+   * the amount is up — desert clay turns the same kit into adobe — and because it is
+   * shared, switching planet re-themes every standing building with two writes and no
+   * rebuild. Amount 0 is a true no-op, so the other worlds cost nothing.
+   */
+  uPlanetTint: { value: new THREE.Color(1, 1, 1) },
+  uPlanetTintAmount: { value: 0 },
 }
 
 /**
@@ -82,6 +90,13 @@ for (const [cell, [r, m]] of Object.entries(SURFACE)) {
 
 /** The one swatch the accent repaints, and the one that lights up after dark. */
 const ACCENT_MASK = cellMask([CELL.TRIM])
+
+/**
+ * The swatches the planet tint is allowed to touch: the neutral hull and frame greys.
+ * Everything with a colour of its own — trim, solar glass, the red — keeps it, or the
+ * repaint flattens a building into a single-tone lump.
+ */
+const PLANET_TINT_MASK = cellMask([CELL.WHITE, CELL.GREY, CELL.SLATE])
 
 // ── composition ───────────────────────────────────────────────────────────────────────
 
@@ -323,7 +338,10 @@ function decorate(material, uniforms) {
          uniform float uMinY;
          uniform vec3 uAccent;
          uniform float uNight;
+         uniform vec3 uPlanetTint;
+         uniform float uPlanetTintAmount;
          uniform float uCellAccent[ ${CELL_COUNT} ];
+         uniform float uCellPlanetTint[ ${CELL_COUNT} ];
          uniform float uCellRoughness[ ${CELL_COUNT} ];
          uniform float uCellMetalness[ ${CELL_COUNT} ];
 
@@ -350,6 +368,13 @@ function decorate(material, uniforms) {
       .replace(
         '#include <color_fragment>',
         `#include <color_fragment>
+         // The planet's own colour on the neutral hull swatches, before the accent gets
+         // its say — same luminance trick, so panels keep their shading as they change.
+         float tintAmount = uCellPlanetTint[ cell ] * uPlanetTintAmount;
+         if ( tintAmount > 0.0 ) {
+           float tintLum = dot( diffuseColor.rgb, vec3( 0.2126, 0.7152, 0.0722 ) );
+           diffuseColor.rgb = mix( diffuseColor.rgb, uPlanetTint * clamp( tintLum * 1.9, 0.3, 1.5 ), tintAmount );
+         }
          float accentAmount = uCellAccent[ cell ];
          if ( accentAmount > 0.0 ) {
            float lum = dot( diffuseColor.rgb, vec3( 0.2126, 0.7152, 0.0722 ) );
@@ -469,7 +494,10 @@ export function createBuilding({ seed = 1, accent = 0xc96442, kind = null } = {}
     uAccent: { value: new THREE.Color(accent) },
     uNight: buildingUniforms.uNight,
     uTime: buildingUniforms.uTime,
+    uPlanetTint: buildingUniforms.uPlanetTint,
+    uPlanetTintAmount: buildingUniforms.uPlanetTintAmount,
     uCellAccent: { value: ACCENT_MASK },
+    uCellPlanetTint: { value: PLANET_TINT_MASK },
     uCellRoughness: { value: ROUGHNESS },
     uCellMetalness: { value: METALNESS },
   }

--- a/src/world/planet.js
+++ b/src/world/planet.js
@@ -2,11 +2,11 @@ import * as THREE from 'three'
 import { atlasTexture, hasPart, part } from './kit.js'
 
 /**
- * The three worlds you can put the colony on, and the terrain generator that draws them.
+ * The worlds you can put the colony on, and the terrain generator that draws them.
  *
  * A planet is nothing but a bag of colours and a couple of switches — terrain, scatter, sky
- * and lighting all read from the same preset, so adding a fourth world is a data change
- * rather than a code change.
+ * and lighting all read from the same preset, so adding a world is a data change rather
+ * than a code change.
  */
 
 export const PLANETS = {
@@ -65,6 +65,30 @@ export const PLANETS = {
     companion: { name: 'Moon', color: 0xdcd8cc, size: 3.2, glow: 0xfff6e0 },
     dust: 0.25,
   },
+  desert: {
+    id: 'desert',
+    name: 'Karak',
+    blurb: 'Twin suns, endless dunes, and a spaceport that smells of hot metal.',
+    ground: { low: 0x8a6a42, high: 0xd6b078, tint: 0xe8cf9a },
+    rock: 0xa87848,
+    horizon: 0xe0a468,
+    sky: { top: 0x86aac2, bottom: 0xf0c48c },
+    fog: { color: 0xd8a878, near: 78, far: 200 },
+    sun: { color: 0xfff2cf, intensity: 2.5, night: 0.08 },
+    ambient: { sky: 0xe8c090, ground: 0x8a6038, intensity: 0.85 },
+    atmosphere: 0.8,
+    craters: 0,
+    roughness: 0.8,
+    // Dunes instead of hills: same field inside the colony, ridges beyond it.
+    terrain: 'dunes',
+    scatter: 'desert',
+    // The neutral hull swatches take on this clay, so the same kit reads as adobe here.
+    buildingTint: 0xc9a176,
+    // `sunTwin` puts the companion on the sun's own arc — a second, smaller sun that
+    // rises and sets with the first instead of hanging fixed in the sky.
+    companion: { name: 'Twin', color: 0xffd9a0, size: 2.4, glow: 0xffbe78, sunTwin: true },
+    dust: 1,
+  },
 }
 
 const GROUND_SIZE = 340
@@ -98,22 +122,7 @@ export function createTerrain(planet, detail, seed = 1337) {
     const z = pos.getZ(i)
     const dist = Math.hypot(x, z)
 
-    // Flat where the colony lives, then hills that ramp in over the next forty metres —
-    // so nothing ever builds on a slope but the horizon still has shape to it.
-    const outside = THREE.MathUtils.smoothstep(dist, COLONY_RADIUS - 6, COLONY_RADIUS + 40)
-    const gentle = fbm(noise, x * 0.035, z * 0.035, 3) * 0.5
-    const hills = fbm(noise, x * 0.012, z * 0.012, 4) * 9 + fbm(noise, x * 0.05, z * 0.05, 2) * 1.4
-    let y = gentle * planet.roughness * (1 - outside) + hills * outside * planet.roughness
-
-    for (const crater of craters) {
-      const d = Math.hypot(x - crater.x, z - crater.z)
-      if (d > crater.r * 1.5) continue
-      // A bowl with a raised rim — the rim is what makes it read as an impact.
-      const t = d / crater.r
-      if (t < 1) y -= (1 - t * t) * crater.depth
-      else y += (1 - Math.abs(t - 1.22) / 0.28) * crater.depth * 0.32
-    }
-
+    const y = sampleHeight(x, z, noise, craters, planet)
     pos.setY(i, y)
 
     // Colour: height-driven blend, mottled with a second noise band so it never bands.
@@ -149,15 +158,40 @@ export function createTerrain(planet, detail, seed = 1337) {
   return mesh
 }
 
+/**
+ * The relief beyond the colony. Hills for most worlds; on a `dunes` planet, ridged noise
+ * sampled in a squashed, rotated frame — 1-|fbm| folds the noise into sharp crests, and
+ * stretching one axis of the sample space makes every crest run the same way, which is
+ * what a wind-built dune field does.
+ */
+function farField(noise, x, z, planet) {
+  if (planet.terrain === 'dunes') {
+    const u = x * 0.9 + z * 0.44
+    const v = z * 0.9 - x * 0.44
+    const ridge = 1 - Math.abs(fbm(noise, u * 0.03, v * 0.009, 3))
+    // Squaring sharpens the crest and flattens the trough — the asymmetry that makes a
+    // dune a dune. A dash of isotropic detail keeps the slip faces from reading as glass.
+    return ridge * ridge * 7 + fbm(noise, x * 0.05, z * 0.05, 2) * 0.8
+  }
+  return fbm(noise, x * 0.012, z * 0.012, 4) * 9 + fbm(noise, x * 0.05, z * 0.05, 2) * 1.4
+}
+
+/**
+ * The one height field — the mesh is displaced by it and everything placed later samples
+ * it, so the two can never drift apart.
+ */
 function sampleHeight(x, z, noise, craters, planet) {
   const dist = Math.hypot(x, z)
+  // Flat where the colony lives, then relief that ramps in over the next forty metres —
+  // so nothing ever builds on a slope but the horizon still has shape to it.
   const outside = THREE.MathUtils.smoothstep(dist, COLONY_RADIUS - 6, COLONY_RADIUS + 40)
   const gentle = fbm(noise, x * 0.035, z * 0.035, 3) * 0.5
-  const hills = fbm(noise, x * 0.012, z * 0.012, 4) * 9 + fbm(noise, x * 0.05, z * 0.05, 2) * 1.4
-  let y = gentle * planet.roughness * (1 - outside) + hills * outside * planet.roughness
+  const far = farField(noise, x, z, planet)
+  let y = gentle * planet.roughness * (1 - outside) + far * outside * planet.roughness
   for (const crater of craters) {
     const d = Math.hypot(x - crater.x, z - crater.z)
     if (d > crater.r * 1.5) continue
+    // A bowl with a raised rim — the rim is what makes it read as an impact.
     const t = d / crater.r
     if (t < 1) y -= (1 - t * t) * crater.depth
     else y += (1 - Math.abs(t - 1.22) / 0.28) * crater.depth * 0.32
@@ -219,6 +253,16 @@ const SCATTER = {
     { part: 'Rock_2_G_Color1', weight: 1, size: [0.3, 0.7], sink: 0.25, tint: true },
     { part: 'Rock_3_L_Color1', weight: 2, size: [0.4, 0.9], sink: 0.12, tint: true },
     { part: 'Rock_3_Q_Color1', weight: 1, size: [0.25, 0.55], sink: 0.1, tint: true },
+  ],
+  // Sparse on purpose: a dune field crowded with props stops reading as a dune field.
+  // Rocks take the planet's ochre; the grass stays the pack's own straw-dry green.
+  desert: [
+    { part: 'Rock_1_D_Color1', weight: 4, size: [0.5, 1.2], sink: 0.35, tint: true },
+    { part: 'Rock_2_C_Color1', weight: 3, size: [0.5, 1.1], sink: 0.35, tint: true },
+    { part: 'Rock_3_E_Color1', weight: 2, size: [0.6, 1.4], sink: 0.2, tint: true },
+    { part: 'Rock_3_L_Color1', weight: 2, size: [0.4, 0.9], sink: 0.15, tint: true },
+    { part: 'Grass_2_D_Color1', weight: 3, size: [0.5, 1.0], sink: 0.06, upright: true },
+    { part: 'Bush_1_E_Color1', weight: 1, size: [0.35, 0.7], sink: 0.08, upright: true },
   ],
 }
 

--- a/src/world/sky.js
+++ b/src/world/sky.js
@@ -87,6 +87,13 @@ const SUN_AXIS = 0.72 // which way the sun tracks across the sky
  * the horizontal term is zero and the direction normalises to straight up regardless.
  */
 const SUN_APEX = 0.95
+/**
+ * How far a `sunTwin` companion trails the sun, in radians of azimuth — about 13°. Close
+ * enough to read as a pair, far enough that the two discs never merge into one blob.
+ * Azimuthal on purpose: rotating about the vertical keeps the twin's elevation equal to
+ * the sun's, so the pair rises and sets as one.
+ */
+const TWIN_SPREAD = 0.23
 /** Half-width of the shadow camera, in metres, centred on whatever you are looking at. */
 const SHADOW_EXTENT = 30
 /**
@@ -95,6 +102,8 @@ const SHADOW_EXTENT = 30
  * the frustum edge for edges that hold still.
  */
 const SHADOW_SNAP = 2
+
+const UP = new THREE.Vector3(0, 1, 0)
 
 export class Sky {
   constructor(scene, settings, renderer) {
@@ -355,9 +364,10 @@ export class Sky {
     this.companionBody.material.emissiveIntensity = 0.35
     this.companionHalo.material.uniforms.uColor.value.set(comp.glow)
     this.companion.scale.setScalar(comp.size)
-    // Parked high and off to one side, well away from where the sun tracks.
-    const dir = new THREE.Vector3(-0.55, 0.5, -0.66).normalize()
-    this.companion.position.copy(dir.multiplyScalar(300))
+    // Parked high and off to one side, well away from where the sun tracks. A `sunTwin`
+    // ignores the parking spot — `setTime` moves it onto the sun's own arc every frame.
+    this._companionOffset().set(-0.55, 0.5, -0.66).normalize().multiplyScalar(300)
+    this.companion.position.copy(this._compOff)
     this.companionHalo.scale.setScalar(2.2)
 
     this._envDirty = true
@@ -442,8 +452,21 @@ export class Sky {
     this.stars.material.uniforms.uOpacity.value = Math.pow(1 - day, 1.6) * (1 - planet.atmosphere * 0.35)
     this.stars.visible = this.settings.get('stars') && this.stars.material.uniforms.uOpacity.value > 0.01
 
-    this.companionHalo.material.uniforms.uStrength.value = 0.35 + (1 - day) * 0.65
-    this.companionBody.material.emissiveIntensity = 0.25 + (1 - day) * 0.55
+    if (planet.companion.sunTwin) {
+      // The twin lives on the sun's arc, a fixed azimuth behind it, so the two cross the
+      // sky as a pair. It shines *with* the day rather than against it, and fades across
+      // the horizon on the same ramp as the sun's disc — a second sun visible after its
+      // own sunset would give the game away.
+      this._companionOffset().copy(this.sunDir).applyAxisAngle(UP, TWIN_SPREAD).multiplyScalar(300)
+      const risen = THREE.MathUtils.smoothstep(this.sunDir.y, -0.06, 0.04)
+      this.companion.visible = risen > 0.01
+      this.companionHalo.material.uniforms.uStrength.value = (0.4 + day * 0.8) * risen
+      this.companionBody.material.emissiveIntensity = (0.5 + day * 1.4) * risen
+    } else {
+      this.companion.visible = true
+      this.companionHalo.material.uniforms.uStrength.value = 0.35 + (1 - day) * 0.65
+      this.companionBody.material.emissiveIntensity = 0.25 + (1 - day) * 0.55
+    }
 
     // Fog follows the horizon, or the whole world looks like it is behind glass at night.
     this.scene.fog.color.copy(bottom).lerp(this._c1.set(planet.fog.color), 0.55)


### PR DESCRIPTION
Fourth `PLANETS` entry (**Karak**): tan dune terrain, twin suns, adobe-tinted buildings, sparse desert scatter.

| Piece | How |
|---|---|
| Dunes | Ridged anisotropic noise variant behind a `terrain: 'dunes'` switch; shared-helper refactor makes mesh + sampler share one implementation (moon/mars/terra verified bit-identical) |
| Twin suns | `companion.sunTwin` — companion rides 13° off the sun's arc, halo/emissive track day instead of night |
| Adobe buildings | Shared `uPlanetTint` uniforms + WHITE/GREY/SLATE cell mask, luminance-preserving mix before the accent repaint — standing buildings re-theme with zero rebuild |
| Scatter | New sparse `desert` recipe (ochre rocks, dry scrub) |

Verified: `npm test` 33/33, `vite build` clean, node smoke check for terrain identity across the three original planets. Visual tuning (palette, dune amplitude, twin-sun readability) still needs a live browser pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
