### PR TITLE
Drag a zone to new ground

### DIFF
--- a/src/game/colony.js
+++ b/src/game/colony.js
@@ -12,6 +12,7 @@ import {
   PLOT_PALETTE,
   PLOT_CELL,
 } from '../world/plots.js'
+import { translateCells } from '../world/plot-move.js'
 import { createBuilding, buildingUniforms, Scaffolds } from '../world/buildings.js'
 import { Ship } from '../world/ship.js'
 import { Astronauts } from '../agents/astronauts.js'
@@ -646,6 +647,48 @@ export class Colony {
 
   setHoveredPlot(plot) {
     this.hoveredPlot = plot || null
+  }
+
+  /** The zones actually on the map, name → cells — what a drag validates against. */
+  visibleLayout() {
+    const out = new Map()
+    for (const [name, plot] of this.plots) out.set(name, plot.cells)
+    return out
+  }
+
+  /**
+   * Translate one zone's remembered footprint. Deliberately nothing but the bookkeeping:
+   * the caller re-runs the roster pass, and the signature diff in `_syncPlots` is what
+   * tears the old plot down and raises it on the new ground — moving the group directly
+   * would leave every world coordinate baked into it (centres, slots, label) pointing at
+   * where the zone used to be.
+   */
+  movePlot(name, dq, dr) {
+    const cells = this.plotCells.get(name)
+    if (!cells || (!dq && !dr)) return
+    this.plotCells.set(name, translateCells(cells, dq, dr))
+  }
+
+  /**
+   * Cosmetic lift while a zone is being dragged. Safe to fake with a raw y-offset because
+   * nothing consults it — the real move is a rebuild on drop, and a cancelled drag sets it
+   * back to zero. Buildings ride along by position: they live in the world group, not the
+   * plot's, so raising the group alone would leave them standing on air.
+   */
+  setPlotLift(name, dy) {
+    const plot = this.plots.get(name)
+    if (!plot) return
+    plot.group.position.y = dy
+    if (plot.label) plot.label.position.y = 3.2 + dy
+    const faded = dy > 0
+    plot.group.traverse((o) => {
+      if (!o.isMesh) return
+      o.material.transparent = faded
+      o.material.opacity = faded ? 0.55 : 1
+    })
+    for (const entry of this.buildings.values()) {
+      if (entry.plot === name) entry.mesh.position.y = DECK_TOP + dy
+    }
   }
 
   /**

--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,8 @@ import { CameraRig } from './core/camera.js'
 import { Colony, STATUS_LABEL, STATUS_ORDER, statusFor, transcriptProgress } from './game/colony.js'
 import { Hud } from './ui/hud.js'
 import { PLANETS } from './world/planet.js'
+import { DECK_TOP, PLOT_CELL, hexToWorld, worldToHex } from './world/plots.js'
+import { moveIsValid } from './world/plot-move.js'
 import { loadKit } from './world/kit.js'
 import { crewRig, loadCrew } from './agents/crew.js'
 import { TIMES } from './world/sky.js'
@@ -444,7 +446,9 @@ engine.canvas.addEventListener('pointermove', (e) => {
   // Pointing at a quiet plot is what makes its name appear.
   const plot = plotUnder(e, p)
   colony.setHoveredPlot(plot)
-  engine.canvas.style.cursor = agent || plot ? 'pointer' : 'grab'
+  // A plot is grabbable as well as clickable, so it gets the hand rather than the finger:
+  // 'pointer' promised only a click and hid the hold-to-drag entirely.
+  engine.canvas.style.cursor = agent ? 'pointer' : 'grab'
 })
 
 /**
@@ -459,6 +463,180 @@ function plotUnder(e, p) {
   return ground ? colony.plotAt(ground.x, ground.z) : null
 }
 
+// ── plot dragging ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Hold-to-lift, on the same press that would otherwise pan. The two gestures share a
+ * button, and the split is time: move within the hold and it was a pan all along, keep
+ * still and the plot under the pointer picks up. Everything mid-carry is cosmetic — a
+ * y-offset and a ghost of the footprint — and the real move is a single `movePlot` plus
+ * one roster pass on the drop, so a cancelled drag has nothing to unwind but visuals.
+ */
+const HOLD_MS = 250
+/** How high a carried zone floats. Enough to read as "picked up", not enough to occlude. */
+const LIFT_Y = 1.1
+const GHOST_VALID = 0x59d98c
+const GHOST_INVALID = 0xd95f4f
+
+const drag = {
+  timer: 0, // pending long-press
+  candidate: null, // repo name under the pressed pointer
+  startX: 0,
+  startY: 0,
+  lifted: false,
+  name: null,
+  cells: null, // the zone's footprint at lift, root first
+  grab: null, // which lattice cell the press landed on — the drag is relative to it
+  dq: 0,
+  dr: 0,
+  valid: true,
+  swallowClick: false,
+  ghost: null, // { group, meshes, material, geometry }
+  pendingThreads: null, // a poll that landed mid-carry, applied on the drop
+}
+const dragGround = new THREE.Vector3()
+
+/** One flat hex per cell of the carried zone, shared geometry and material. */
+function buildGhost(count) {
+  const geometry = new THREE.CylinderGeometry(PLOT_CELL * 0.94, PLOT_CELL * 0.94, 0.05, 6)
+  geometry.rotateY(Math.PI / 6) // flat-top, in phase with the lattice — see HEX_PHASE in plots.js
+  const material = new THREE.MeshBasicMaterial({
+    color: GHOST_VALID,
+    transparent: true,
+    opacity: 0.32,
+    depthWrite: false,
+    blending: THREE.AdditiveBlending,
+  })
+  const group = new THREE.Group()
+  const meshes = []
+  for (let i = 0; i < count; i++) {
+    const mesh = new THREE.Mesh(geometry, material)
+    meshes.push(mesh)
+    group.add(mesh)
+  }
+  engine.scene.add(group)
+  drag.ghost = { group, meshes, material, geometry }
+}
+
+function placeGhost() {
+  const { meshes, material } = drag.ghost
+  drag.cells.forEach((c, i) => {
+    const { x, z } = hexToWorld(c.q + drag.dq, c.r + drag.dr)
+    // Just proud of the deck, which is itself proud of the roughest terrain.
+    meshes[i].position.set(x, DECK_TOP + 0.12, z)
+  })
+  material.color.setHex(drag.valid ? GHOST_VALID : GHOST_INVALID)
+}
+
+function disposeGhost() {
+  if (!drag.ghost) return
+  engine.scene.remove(drag.ghost.group)
+  drag.ghost.geometry.dispose()
+  drag.ghost.material.dispose()
+  drag.ghost = null
+}
+
+function cancelHold() {
+  clearTimeout(drag.timer)
+  drag.timer = 0
+  drag.candidate = null
+}
+
+function liftPlot() {
+  drag.timer = 0
+  const plot = colony.plots.get(drag.candidate)
+  drag.candidate = null
+  if (!plot) return // a poll rebuilt it out from under the hold — rare, and a lift of nothing
+  drag.lifted = true
+  drag.name = plot.name
+  drag.cells = plot.cells
+  // The drag is relative to the cell the press landed on, not to the zone's root: snapping
+  // the root under a cursor that grabbed the far corner would jump the zone half its own
+  // width on the first pixel of movement.
+  const g = rig.groundPoint(drag.startX, drag.startY, dragGround)
+  drag.grab = g ? worldToHex(g.x, g.z) : { ...plot.cells[0] }
+  drag.dq = 0
+  drag.dr = 0
+  drag.valid = true
+  // The pan gesture is already live under this press; `suppressed` is its escape hatch, and
+  // it self-clears on pointerup, so the rest of the press belongs to carrying the plot.
+  rig.suppressed = true
+  colony.setPlotLift(drag.name, LIFT_Y)
+  buildGhost(drag.cells.length)
+  placeGhost()
+  engine.canvas.style.cursor = 'grabbing'
+}
+
+/**
+ * Put the drag down, applying the move or not. Either way this ends in the standard
+ * "the map changed under the same roster" re-entry: `applyThreads` re-runs the roster pass,
+ * whose signature diff rebuilds the moved plot on its new ground, recomputes navigation and
+ * every crew site so the astronauts walk over rather than hammering at bare dirt, and whose
+ * layout diff writes the move to the colony file.
+ */
+function settleDrag(apply) {
+  colony.setPlotLift(drag.name, 0)
+  disposeGhost()
+  if (apply) colony.movePlot(drag.name, drag.dq, drag.dr)
+  const pending = drag.pendingThreads
+  drag.lifted = false
+  drag.pendingThreads = null
+  drag.name = null
+  drag.cells = null
+  drag.grab = null
+  if (apply || pending) applyThreads(pending || threads)
+  engine.canvas.style.cursor = 'grab'
+}
+
+engine.canvas.addEventListener('pointerdown', (e) => {
+  if (drag.timer) cancelHold()
+  if (drag.lifted) {
+    // A second finger mid-carry is the start of a pinch, not a drop: put the zone back.
+    settleDrag(false)
+    drag.swallowClick = true
+    return
+  }
+  // The camera reads these modifiers as "tilt and rotate" — that press is never a lift.
+  if (e.button !== 0 || e.ctrlKey || e.shiftKey || e.altKey || e.metaKey) return
+  const p = ndc(e)
+  if (colony.pick(p.x, p.y, p.aspect)) return // a press on an astronaut is a selection
+  const plot = plotUnder(e, p)
+  if (!plot) return
+  drag.candidate = plot.name
+  drag.startX = e.clientX
+  drag.startY = e.clientY
+  drag.timer = setTimeout(liftPlot, HOLD_MS)
+})
+
+// On window, like the camera's own listeners: a carry does not end at the canvas edge.
+window.addEventListener('pointermove', (e) => {
+  // The same 6px the camera's `wasClick` uses: past it this press was a pan all along.
+  if (drag.timer && Math.hypot(e.clientX - drag.startX, e.clientY - drag.startY) > 6) cancelHold()
+  if (!drag.lifted) return
+  if (!rig.groundPoint(e.clientX, e.clientY, dragGround)) return
+  const cell = worldToHex(dragGround.x, dragGround.z)
+  const dq = cell.q - drag.grab.q
+  const dr = cell.r - drag.grab.r
+  if (dq === drag.dq && dr === drag.dr) return
+  drag.dq = dq
+  drag.dr = dr
+  drag.valid = moveIsValid(colony.visibleLayout(), drag.name, dq, dr)
+  placeGhost()
+})
+
+window.addEventListener('pointerup', () => {
+  if (drag.timer) cancelHold()
+  if (drag.lifted) settleDrag(drag.valid && (drag.dq !== 0 || drag.dr !== 0))
+  // Cleared after the canvas's own pointerup has run — bubbling order is what lets the
+  // click handler still see it.
+  drag.swallowClick = false
+})
+
+window.addEventListener('pointercancel', () => {
+  if (drag.timer) cancelHold()
+  if (drag.lifted) settleDrag(false)
+})
+
 // Pressing on an astronaut used to suppress the camera, on the theory that grabbing one
 // should not also drag the world out from under it. But nothing is draggable *about* an
 // astronaut — a press is only ever the start of a selection or the start of a pan — so all
@@ -466,7 +644,9 @@ function plotUnder(e, p) {
 // on top of somebody. Selection is decided on release instead, where `wasClick` already
 // distinguishes a click from a drag.
 engine.canvas.addEventListener('pointerup', (e) => {
-  if (e.button !== 0 || !rig.wasClick) return
+  // A release that ends a lift is the end of a carry, not a click — even an unmoved one:
+  // long-pressing a plot and thinking better of it should not also open its sidebar.
+  if (e.button !== 0 || !rig.wasClick || drag.lifted || drag.swallowClick) return
   const p = ndc(e)
   const agent = colony.pick(p.x, p.y, p.aspect)
   if (agent) {
@@ -581,9 +761,16 @@ window.addEventListener('keydown', (e) => {
     case '_':
       rig.desiredDistance = Math.min(150, rig.desiredDistance * 1.22)
       break
-    // One step at a time, outward: the thread, then the zone it belongs to.
+    // One step at a time, outward: the drag in hand, the thread, then the zone.
     case 'Escape':
-      if (document.querySelector('.help.open')) hud.toggleHelp(false)
+      if (drag.lifted || drag.timer) {
+        cancelHold()
+        if (drag.lifted) {
+          settleDrag(false)
+          // The pointer is still down; the release that follows ends a dead gesture.
+          drag.swallowClick = true
+        }
+      } else if (document.querySelector('.help.open')) hud.toggleHelp(false)
       else if (selectedId) select(null, {})
       else if (selectedProject) actions.closeProject()
       break
@@ -593,6 +780,14 @@ window.addEventListener('keydown', (e) => {
 // ── data ──────────────────────────────────────────────────────────────────────────────
 
 function applyThreads(list) {
+  // Parked while a plot is in hand. `allocateCells` would leave the carried zone's cells
+  // alone, but a sibling that grew a thread still rebuilds — and any rebuild pass disposes
+  // whichever plots changed, which mid-carry means the lifted group can be torn down under
+  // the drag's own hands. Polls are 15s apart and a drag is seconds; the scan waits.
+  if (drag.lifted) {
+    drag.pendingThreads = list
+    return
+  }
   // A thread you have said you looked at stops counting as unread until it moves on again.
   // Done here rather than in `statusFor` so the card, the badge and the astronaut all agree.
   const viewed = state.viewedAt || {}

--- a/src/world/plot-move.js
+++ b/src/world/plot-move.js
@@ -1,0 +1,117 @@
+/**
+ * Moving a zone by hand: the rules a drop has to obey, plus the lattice facts they rest on.
+ *
+ * Split out of plots.js for the same reason merge-state.js exists: getting a drop rule wrong
+ * quietly corrupts somebody's colony — a zone parked on top of another, or an island the
+ * allocator responds to by re-laying the whole map from scratch — so the rules are pure and
+ * run under bare node, where plots.js cannot follow (its texture pipeline needs a document).
+ */
+
+export const HEX_DIRS = [
+  [1, 0],
+  [1, -1],
+  [0, -1],
+  [-1, 0],
+  [-1, 1],
+  [0, 1],
+]
+
+/** The lattice cell the ship owns. Nothing else may be placed there. */
+export const SHIP_CELL = { q: -2, r: 1 }
+
+export const ORIGIN = { q: 0, r: 0 }
+
+/**
+ * How many rings out the allocator's cell pool reaches. A cell past this is one the
+ * allocator does not know exists: a zone dropped there would pass every visible check, then
+ * lose its ground on the next roster pass when `allocateCells` cannot find its root in the
+ * pool and re-seeds it in the middle — the exact jump the drag is for preventing.
+ */
+export const POOL_RINGS = 12
+
+export const cellKey = (q, r) => `${q},${r}`
+
+/** Hex distance in axial coordinates: the cube distance, halved. */
+export function hexDistance(a, b) {
+  return (Math.abs(a.q - b.q) + Math.abs(a.q + a.r - b.q - b.r) + Math.abs(a.r - b.r)) / 2
+}
+
+/**
+ * Is the colony one landmass?
+ *
+ * Every zone is a contiguous blob of its own, but nothing has ever guaranteed the *union* of
+ * them is — that held only because zones seed outward in spiral order from the middle, which
+ * happens to leave no gaps when everybody who was ever placed is still on the map.
+ *
+ * Take repos away and the guarantee goes with it. The survivors keep the cells they held in the
+ * bigger layout, which is the whole point of the stickiness, but if the zones between them have
+ * gone those cells are now islands floating in the sea. That is what folding away dormant repos
+ * does the first time it runs.
+ *
+ * The ship's cell counts as walkable here even though nobody may claim it: a colony that
+ * happens to wrap around the ship is not two colonies.
+ */
+export function isConnected(out) {
+  const cells = new Map()
+  for (const [, list] of out) for (const c of list) cells.set(cellKey(c.q, c.r), c)
+  if (cells.size < 2) return true
+  const ship = cellKey(SHIP_CELL.q, SHIP_CELL.r)
+  const passable = new Set([...cells.keys(), ship])
+  const [start] = cells.keys()
+  const seen = new Set([start])
+  const queue = [cells.get(start)]
+  while (queue.length) {
+    const c = queue.pop()
+    for (const [dq, dr] of HEX_DIRS) {
+      const n = { q: c.q + dq, r: c.r + dr }
+      const k = cellKey(n.q, n.r)
+      if (!passable.has(k) || seen.has(k)) continue
+      seen.add(k)
+      queue.push(n)
+    }
+  }
+  // The ship is a stepping stone, not a member: it does not have to be reached for the colony
+  // to be whole, and it does not count toward what has to be.
+  seen.delete(ship)
+  return seen.size === cells.size
+}
+
+/** Slide a zone whole. Order is identity here: cells[0] stays the root wherever it lands. */
+export function translateCells(cells, dq, dr) {
+  return cells.map((c) => ({ q: c.q + dq, r: c.r + dr }))
+}
+
+/**
+ * May this zone move by (dq, dr)?
+ *
+ * Checked against the zones actually on the map rather than everything layout memory
+ * remembers: a hidden repo's old ground is fair game, exactly as it is when a visible
+ * neighbour grows into it. The identity move is valid by construction — a zone never
+ * collides with itself, because its own cells are not in the occupied set.
+ *
+ * @param layout Map of name → cells for every zone on the map, the moving one included.
+ */
+export function moveIsValid(layout, name, dq, dr) {
+  const cells = layout.get(name)
+  if (!cells?.length) return false
+  const moved = translateCells(cells, dq, dr)
+
+  const occupied = new Set()
+  for (const [id, list] of layout) {
+    if (id === name) continue
+    for (const c of list) occupied.add(cellKey(c.q, c.r))
+  }
+  const ship = cellKey(SHIP_CELL.q, SHIP_CELL.r)
+  for (const c of moved) {
+    const k = cellKey(c.q, c.r)
+    if (k === ship || occupied.has(k)) return false
+    if (hexDistance(c, ORIGIN) >= POOL_RINGS) return false
+  }
+
+  // The allocator throws the whole layout memory away when the colony fragments, so a drop
+  // that splits it would take every other zone's ground with it. Refused here, where it is
+  // one red ghost, rather than there, where it is a full re-layout.
+  const after = new Map(layout)
+  after.set(name, moved)
+  return isConnected(after)
+}

--- a/src/world/plots.js
+++ b/src/world/plots.js
@@ -3,6 +3,7 @@ import * as BufferGeometryUtils from 'three/addons/utils/BufferGeometryUtils.js'
 import { DECK_TEXTURE_SCALE, KERB_UV, deckSurface, kerbSurface } from './surfaces.js'
 import { atlasTexture, hasPart, part } from './kit.js'
 import { mulberry } from './planet.js'
+import { HEX_DIRS, SHIP_CELL, ORIGIN, POOL_RINGS, cellKey as key, hexDistance, isConnected } from './plot-move.js'
 
 /**
  * Project plots — the fenced-off sections of the map, one per repo.
@@ -57,17 +58,6 @@ const DECK_HEIGHT = DECK_TOP + DECK_SKIRT
 /** Building slots per cell: one in the middle and six around it. */
 const SLOTS_PER_CELL = 7
 const MAX_CELLS = 9
-/** The lattice cell the ship owns. Nothing else may be placed there. */
-const SHIP_CELL = { q: -2, r: 1 }
-
-const HEX_DIRS = [
-  [1, 0],
-  [1, -1],
-  [0, -1],
-  [-1, 0],
-  [-1, 1],
-  [0, 1],
-]
 
 /**
  * Edge j of a flat-top hexagon runs between the corners at 60j° and 60(j+1)°, so its
@@ -75,11 +65,8 @@ const HEX_DIRS = [
  */
 const EDGE_TO_DIR = [0, 5, 4, 3, 2, 1]
 
-const key = (q, r) => `${q},${r}`
-const ORIGIN = { q: 0, r: 0 }
-
 /** Flat-top axial hex → world. */
-function hexToWorld(q, r, size = CELL) {
+export function hexToWorld(q, r, size = CELL) {
   return { x: size * 1.5 * q, z: size * Math.sqrt(3) * (r + q / 2) }
 }
 
@@ -127,11 +114,6 @@ function hexRing(radius) {
 const cellsNeeded = (threadCount) =>
   Math.max(1, Math.min(MAX_CELLS, Math.ceil(threadCount / SLOTS_PER_CELL)))
 
-/** Hex distance in axial coordinates: the cube distance, halved. */
-function hexDistance(a, b) {
-  return (Math.abs(a.q - b.q) + Math.abs(a.q + a.r - b.q - b.r) + Math.abs(a.r - b.r)) / 2
-}
-
 /**
  * Hand out cells to projects, keeping every zone exactly where it already is.
  *
@@ -158,46 +140,6 @@ function hexDistance(a, b) {
  * @param previous Map of id → cells from the last pass (or a saved colony file).
  * @returns Map of id → cells.
  */
-/**
- * Is the colony one landmass?
- *
- * Every zone is a contiguous blob of its own, but nothing has ever guaranteed the *union* of
- * them is — that held only because zones seed outward in spiral order from the middle, which
- * happens to leave no gaps when everybody who was ever placed is still on the map.
- *
- * Take repos away and the guarantee goes with it. The survivors keep the cells they held in the
- * bigger layout, which is the whole point of the stickiness, but if the zones between them have
- * gone those cells are now islands floating in the sea. That is what folding away dormant repos
- * does the first time it runs.
- *
- * The ship's cell counts as walkable here even though nobody may claim it: a colony that
- * happens to wrap around the ship is not two colonies.
- */
-function isConnected(out) {
-  const cells = new Map()
-  for (const [, list] of out) for (const c of list) cells.set(key(c.q, c.r), c)
-  if (cells.size < 2) return true
-  const ship = key(SHIP_CELL.q, SHIP_CELL.r)
-  const passable = new Set([...cells.keys(), ship])
-  const [start] = cells.keys()
-  const seen = new Set([start])
-  const queue = [cells.get(start)]
-  while (queue.length) {
-    const c = queue.pop()
-    for (const [dq, dr] of HEX_DIRS) {
-      const n = { q: c.q + dq, r: c.r + dr }
-      const k = key(n.q, n.r)
-      if (!passable.has(k) || seen.has(k)) continue
-      seen.add(k)
-      queue.push(n)
-    }
-  }
-  // The ship is a stepping stone, not a member: it does not have to be reached for the colony
-  // to be whole, and it does not count toward what has to be.
-  seen.delete(ship)
-  return seen.size === cells.size
-}
-
 export function allocateCells(projects, previous = new Map()) {
   const laid = layOut(projects, previous)
   // Remembering where a zone sat is worth a great deal, right up until it leaves the colony
@@ -225,7 +167,7 @@ function layOut(projects, previous) {
   for (const project of projects) {
     for (const cell of previous.get(project.id) || []) farthest = Math.max(farthest, hexDistance(cell, ORIGIN))
   }
-  for (let ring = 0; (pool.length < total + 30 || ring <= farthest) && ring < 12; ring++) {
+  for (let ring = 0; (pool.length < total + 30 || ring <= farthest) && ring < POOL_RINGS; ring++) {
     for (const cell of hexRing(ring)) {
       const k = key(cell.q, cell.r)
       if (k === reserved) continue

--- a/test/plot-move.test.mjs
+++ b/test/plot-move.test.mjs
@@ -1,0 +1,66 @@
+/**
+ * The rules a hand-dragged zone obeys before it is allowed to land. Pure by design — see
+ * plot-move.js for why they live apart from the meshes.
+ */
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { SHIP_CELL, isConnected, moveIsValid, translateCells } from '../src/world/plot-move.js'
+
+const layout = (zones) => new Map(Object.entries(zones))
+
+// ── translation ───────────────────────────────────────────────────────────────
+
+test('cells translate as one body, root first', () => {
+  const moved = translateCells([{ q: 2, r: 3 }, { q: 3, r: 3 }, { q: 2, r: 4 }], 1, -2)
+  assert.deepEqual(moved, [{ q: 3, r: 1 }, { q: 4, r: 1 }, { q: 3, r: 2 }])
+})
+
+test('translation never reorders — the root is whichever cell was first', () => {
+  const cells = [{ q: 5, r: -1 }, { q: 4, r: 0 }]
+  assert.deepEqual(translateCells(cells, -5, 1)[0], { q: 0, r: 0 })
+  // And the input is untouched: the drag re-translates from the lifted footprint every move.
+  assert.deepEqual(cells[0], { q: 5, r: -1 })
+})
+
+// ── validity ──────────────────────────────────────────────────────────────────
+
+test('a move onto another zone\'s cell is refused', () => {
+  const zones = layout({ a: [{ q: 0, r: 0 }], b: [{ q: 1, r: 0 }] })
+  assert.equal(moveIsValid(zones, 'a', 1, 0), false)
+})
+
+test('a zone never collides with itself — the identity move is valid', () => {
+  const zones = layout({ a: [{ q: 0, r: 0 }, { q: 1, r: 0 }] })
+  assert.equal(moveIsValid(zones, 'a', 0, 0), true)
+})
+
+test('the ship\'s cell is refused even when nothing else claims it', () => {
+  const zones = layout({ a: [{ q: 0, r: 0 }, { q: 0, r: 1 }] })
+  assert.equal(moveIsValid(zones, 'a', SHIP_CELL.q, SHIP_CELL.r - 1), false)
+})
+
+test('a move that splits the colony into islands is refused', () => {
+  const zones = layout({ a: [{ q: 0, r: 0 }], b: [{ q: 1, r: 0 }] })
+  // (6, 5) is well inside the allocator's pool but touches nothing.
+  assert.equal(moveIsValid(zones, 'b', 5, 5), false)
+})
+
+test('a move to a free neighbouring cell is accepted', () => {
+  const zones = layout({ a: [{ q: 0, r: 0 }], b: [{ q: 1, r: 0 }] })
+  assert.equal(moveIsValid(zones, 'b', -1, 1), true)
+})
+
+test('a move past the allocator\'s pool is refused — it would lose its ground next pass', () => {
+  const zones = layout({ a: [{ q: 0, r: 0 }] })
+  assert.equal(moveIsValid(zones, 'a', 12, 0), false)
+  assert.equal(moveIsValid(zones, 'a', 11, 0), true)
+})
+
+// ── connectivity ──────────────────────────────────────────────────────────────
+
+test('the ship bridges two zones without counting as one', () => {
+  // Both cells neighbour the ship and nothing else: whole through it, split without it.
+  const bridged = layout({ a: [{ q: -2, r: 0 }], b: [{ q: -2, r: 2 }] })
+  assert.equal(isConnected(bridged), true)
+})


### PR DESCRIPTION
Hold a plot (deck or label) ~250ms to lift it; a hex ghost tracks the cursor — green where the zone may land, red where it may not. Drop translates the whole zone; Escape or an invalid drop restores it.

| Rule | Why |
|---|---|
| No overlap, no ship cell, stays inside the allocator's pool rings | A drop past the pool loses its ground on the next roster pass |
| Colony must stay connected | A fragmented layout makes `allocateCells` discard all layout memory and re-lay everything |
| Poll results parked while lifted | A sibling zone rebuild mid-gesture can dispose the carried plot's group |

Move persists through the existing `state.plots` save/merge path (built for exactly this, per its own comments). Rebuild reuses `applyThreads` → signature-diff, so navigation, scatter, labels, and crew re-targeting all ride the established path.

Verified: `npm test` 42/42 (9 new pure-logic tests in `test/plot-move.test.mjs`), `vite build` clean. Drag feel, ghost legibility, and the lift dim need a live browser pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
