### PR TITLE
Add a Business Tasks harness, a Fiji beach planet, and repo rename

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -4,10 +4,7 @@
     {
       "name": "bot-crossing",
       "runtimeExecutable": "npm",
-      "runtimeArgs": [
-        "run",
-        "dev"
-      ],
+      "runtimeArgs": ["run", "dev"],
       "port": 5274,
       "autoPort": true
     }

--- a/server/api.mjs
+++ b/server/api.mjs
@@ -56,6 +56,9 @@ const emptyState = () => ({
   seen: {},
   hiddenProjects: [],
   viewedAt: {},
+  // Display-name overrides, keyed by the real project name. Cosmetic only — every lookup
+  // that actually finds a repo's threads still keys on the real name, never this one.
+  projectNames: {},
   settings: null,
   updatedAt: 0,
 })
@@ -75,6 +78,7 @@ async function readState() {
       seen: asObject(raw.seen),
       hiddenProjects: asArray(raw.hiddenProjects).map(String).filter(Boolean),
       viewedAt: asObject(raw.viewedAt),
+      projectNames: asObject(raw.projectNames),
       settings: raw.settings && typeof raw.settings === 'object' ? raw.settings : null,
       updatedAt: Number(raw.updatedAt) || 0,
     }
@@ -110,6 +114,7 @@ async function writeState(next) {
     seen: asObject(next.seen),
     hiddenProjects: asArray(next.hiddenProjects).map(String).filter(Boolean),
     viewedAt: asObject(next.viewedAt),
+    projectNames: asObject(next.projectNames),
     settings: next.settings && typeof next.settings === 'object' ? next.settings : null,
     updatedAt: Date.now(),
   }

--- a/server/harnesses/business-tasks.mjs
+++ b/server/harnesses/business-tasks.mjs
@@ -1,0 +1,110 @@
+/**
+ * Harness adapter: Business Tasks — not a coding harness at all.
+ *
+ * Sherman's CEO/content system (Claude, in a separate chat session) hands off actionable items
+ * here the same way a coding agent hands off a thread: something exists, it needs a human, and
+ * clicking it should take you straight to where you act on it. `data/business-tasks.json` is
+ * that hand-off point — a small hand-edited (or Claude-edited) file, read-only from this side,
+ * exactly like a harness's own session records.
+ *
+ * Each task becomes one astronaut in its own "Business Tasks" zone. `unread: true` is what
+ * gives it the "?" — a task nobody has captured yet reads as unanswered, which is the truth.
+ * `lastActivityAt` is pinned to when the task was added rather than refreshed on every scan, so
+ * a task that sits uncaptured drifts toward the colony's own "asleep for a while" look instead
+ * of pretending to be freshly active — a task you're ignoring should look ignored.
+ *
+ * Read-only, no subprocess: see the ground rules in `server/harnesses/README.md`. This adapter
+ * never writes `data/business-tasks.json` — there is no delete route. `"done": true` marks a
+ * task finished; `"deleted": true` marks it withdrawn instead of finished. Both just drop the
+ * task out of `scanThreads()`; neither ever removes the entry from the file. Editing the file
+ * by hand (or asking Claude to) is the only way in or out, same as `newSession()` below says.
+ */
+import fsp from 'node:fs/promises'
+import path from 'node:path'
+import { exists } from '../lib/fsutil.mjs'
+
+const TASKS_FILE = process.env.BOT_CROSSING_BUSINESS_TASKS || path.join(process.cwd(), 'data', 'business-tasks.json')
+
+/** Prefixed, per the contract in `server/harnesses/README.md`. */
+const ID = (raw) => `business:${raw}`
+
+async function scanThreads() {
+  let raw
+  try {
+    raw = await fsp.readFile(TASKS_FILE, 'utf8')
+  } catch {
+    return []
+  }
+
+  let tasks
+  try {
+    tasks = JSON.parse(raw)
+  } catch {
+    // Being hand-edited mid-save is a normal thing to trip over — skip this pass, not the harness.
+    return []
+  }
+  if (!Array.isArray(tasks)) return []
+
+  const threads = []
+  for (const task of tasks) {
+    try {
+      if (!task || typeof task !== 'object' || !task.id || task.done || task.deleted) continue
+      const addedAt = Date.parse(task.addedAt) || Date.now()
+      threads.push({
+        id: ID(task.id),
+        title: String(task.title || 'Untitled task'),
+        preview: String(task.preview || ''),
+        project: 'Business Tasks',
+        projectPath: '',
+        worktree: '',
+        cwd: '',
+        gitBranch: '',
+        model: String(task.category || ''),
+        effort: '',
+        createdAt: addedAt,
+        lastActivityAt: addedAt,
+        lastFocusedAt: 0,
+        unread: true,
+        running: false,
+        hasError: false,
+        starred: false,
+        routine: false,
+        prState: '',
+        archived: false,
+        sizeBytes: 400 + String(task.preview || '').length * 20,
+        source: 'manual',
+        canOpen: Boolean(task.url),
+        ref: { url: task.url || '' },
+      })
+    } catch {
+      // One malformed task costs itself, not the rest of the list.
+    }
+  }
+  return threads
+}
+
+/** The URL is all this adapter ever hands back — `present()` on the server opens it generically. */
+function openThread(ref) {
+  if (!ref?.url) return { ok: false, error: 'This task has no page to open.' }
+  return { ok: true, url: ref.url }
+}
+
+function newSession() {
+  return {
+    ok: false,
+    error:
+      'Business tasks are managed by editing data/business-tasks.json directly — add one, set "done": true, or set "deleted": true to withdraw one. Nothing is ever removed from the file.',
+  }
+}
+
+const detect = () => exists(TASKS_FILE)
+
+export default {
+  id: 'business-tasks',
+  name: 'Business Tasks',
+  detect,
+  scanThreads,
+  openThread,
+  newSession,
+  paths: { TASKS_FILE },
+}

--- a/server/harnesses/index.mjs
+++ b/server/harnesses/index.mjs
@@ -9,8 +9,9 @@
 import claudeCode from './claude-code.mjs'
 import codex from './codex.mjs'
 import cursor from './cursor.mjs'
+import businessTasks from './business-tasks.mjs'
 
-export const HARNESSES = [claudeCode, codex, cursor]
+export const HARNESSES = [claudeCode, codex, cursor, businessTasks]
 
 export const harnessById = (id) => HARNESSES.find((h) => h.id === id) || null
 

--- a/src/core/settings.js
+++ b/src/core/settings.js
@@ -127,7 +127,7 @@ const DEFAULTS = {
   ...PRESETS.balanced.values,
 
   // World
-  planet: 'moon',
+  planet: 'fiji',
   /**
    * Fold away repos where every thread has been quiet for three days. On by default: with
    * several harnesses read at once the map otherwise fills with every checkout you have ever

--- a/src/game/colony.js
+++ b/src/game/colony.js
@@ -263,7 +263,10 @@ export class Colony {
    * ids — repo name for plots, session id for buildings — so a poll that changes nothing
    * moves nothing on screen.
    */
-  setThreads(threads, archivedIds = new Set(), hiddenProjects = new Set(), knownIds = new Set()) {
+  setThreads(threads, archivedIds = new Set(), hiddenProjects = new Set(), knownIds = new Set(), projectNames = {}) {
+    // Cosmetic only, read by `_syncPlots` below to decide what a plot's label prints — every
+    // lookup in this function that actually finds a repo's threads still keys on the real name.
+    this.projectNames = projectNames || {}
     const now = Date.now()
     const live = liveThreadsForColony(threads, archivedIds, hiddenProjects)
 
@@ -392,9 +395,22 @@ export class Colony {
     for (const [name, cells] of layout) wanted.set(name, `${name}:${cells.map((c) => `${c.q},${c.r}`).join('/')}`)
 
     // A plot is rebuilt whenever its own footprint moved, and left completely alone
-    // whenever it did not.
+    // whenever it did not — except its label, which is cheap to redraw on its own and is
+    // the one thing a rename touches without moving a single hex.
     for (const [name, plot] of this.plots) {
-      if (wanted.get(name) === plot.signature) continue
+      const displayName = this.projectNames[name] || name
+      if (wanted.get(name) === plot.signature && plot.displayName === displayName) continue
+      if (wanted.get(name) === plot.signature) {
+        if (plot.label) {
+          this.labelGroup.remove(plot.label)
+          plot.label.userData.dispose?.()
+        }
+        plot.label = createLabel(displayName, plot.accent)
+        plot.label.position.set(plot.labelAnchor.x, 3.2, plot.labelAnchor.z)
+        plot.displayName = displayName
+        this.labelGroup.add(plot.label)
+        continue
+      }
       this.plotGroup.remove(plot.group)
       if (plot.label) {
         this.labelGroup.remove(plot.label)
@@ -410,12 +426,14 @@ export class Colony {
       const cells = layout.get(name)
       if (!cells?.length) return
       const accent = this._pickAccent(name)
+      const displayName = this.projectNames[name] || name
       const plot = new Plot({ id: name, name, index, cells, accent })
       plot.signature = wanted.get(name)
+      plot.displayName = displayName
       this.plots.set(name, plot)
       this.plotGroup.add(plot.group)
 
-      const label = createLabel(name, accent)
+      const label = createLabel(displayName, accent)
       label.position.set(plot.labelAnchor.x, 3.2, plot.labelAnchor.z)
       plot.label = label
       this.labelGroup.add(label)

--- a/src/game/merge-state.js
+++ b/src/game/merge-state.js
@@ -126,6 +126,7 @@ export function mergeState(base, local, remote) {
     seen: mergeMap(b.seen, l.seen, r.seen),
     hiddenProjects: mergeSet(b.hiddenProjects, l.hiddenProjects, r.hiddenProjects),
     viewedAt: mergeMap(b.viewedAt, l.viewedAt, r.viewedAt),
+    projectNames: mergeMap(b.projectNames, l.projectNames, r.projectNames),
     settings: l.settings && typeof l.settings === 'object' ? l.settings : r.settings ?? null,
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -47,7 +47,16 @@ const engine = new Engine(settings).mount(app)
 const rig = new CameraRig(engine.camera, engine.canvas, settings)
 const colony = new Colony(engine.scene, settings, engine.camera, engine.renderer)
 
-let state = { archived: [], archivedAt: {}, opened: [], plots: {}, seen: {}, hiddenProjects: [], viewedAt: {} }
+let state = {
+  archived: [],
+  archivedAt: {},
+  opened: [],
+  plots: {},
+  seen: {},
+  hiddenProjects: [],
+  viewedAt: {},
+  projectNames: {},
+}
 let threads = []
 /** Last legend built for the bottom bar, kept so the open zone's chip can light up between polls. */
 let legendProjects = []
@@ -206,6 +215,23 @@ const actions = {
     queueSave()
     applyThreads(threads)
     hud.toast(`Showing ${name} again`)
+  },
+
+  // Cosmetic only: `name` (the repo's real folder/project name) stays the key everywhere a
+  // plot, a thread, or a harness is actually looked up. `projectNames` just says what to
+  // print instead of it. An empty or unchanged value clears the override rather than storing
+  // a no-op entry.
+  renameProject: (name, displayName) => {
+    if (!name) return
+    const trimmed = String(displayName || '').trim()
+    const current = { ...(state.projectNames || {}) }
+    if (!trimmed || trimmed === name) delete current[name]
+    else current[name] = trimmed.slice(0, 80)
+    state.projectNames = current
+    queueSave()
+    applyThreads(threads)
+    syncProject()
+    hud.toast(trimmed && trimmed !== name ? `Renamed to "${trimmed}"` : `Reset to "${name}"`)
   },
 
   copyProjectPath: async () => {
@@ -394,6 +420,7 @@ function syncProject() {
 
   hud.setProject({
     name: plot.name,
+    displayName: state.projectNames?.[plot.name] || plot.name,
     accent: plot.accent,
     path: pathForProject(plot.name),
     threads: list,
@@ -617,12 +644,13 @@ function applyThreads(list) {
   }
   if (firstSeen) queueSave()
 
-  const stats = colony.setThreads(list, archivedSet, hiddenSet, known)
+  const stats = colony.setThreads(list, archivedSet, hiddenSet, known, state.projectNames || {})
   hud.setStats(stats)
 
   legendProjects = colony.plotOrder
     .map((plot) => ({
       name: plot.name,
+      displayName: state.projectNames?.[plot.name] || plot.name,
       accent: plot.accent,
       count: list.filter((t) => !t.archived && !archivedSet.has(t.id) && t.project === plot.name).length,
       urgent: colony.urgentPlots?.has(plot.id) ?? false,

--- a/src/ui/hud-data.js
+++ b/src/ui/hud-data.js
@@ -2,4 +2,4 @@
 export { PRESETS } from '../core/settings.js'
 
 /** Display order for the planet picker — nearest to furthest from home. */
-export const PLANETS_ORDER = ['moon', 'mars', 'terra']
+export const PLANETS_ORDER = ['fiji', 'moon', 'mars', 'terra']

--- a/src/ui/hud.js
+++ b/src/ui/hud.js
@@ -44,6 +44,7 @@ const ICON = {
   copy: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"/><path d="M5 15H4a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v1"/></svg>`,
   locate: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"><circle cx="12" cy="12" r="3"/><circle cx="12" cy="12" r="7.6"/><path d="M12 1.8v2.6M12 19.6v2.6M1.8 12h2.6M19.6 12h2.6"/></svg>`,
   orbit: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><circle cx="12" cy="12" r="4"/><ellipse cx="12" cy="12" rx="10.2" ry="4.6" transform="rotate(-24 12 12)"/><circle cx="21" cy="8.2" r="1.5" fill="currentColor" stroke="none"/></svg>`,
+  edit: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4z"/></svg>`,
 }
 
 const STAT_DEFS = [
@@ -367,6 +368,17 @@ export class Hud {
     on('#btn-reveal', 'click', () => this.actions.revealProject?.())
     on('#btn-copy-path', 'click', () => this.actions.copyProjectPath?.())
     on('#btn-hide-project', 'click', () => this.actions.hideProject?.())
+    on('#btn-rename-project', 'click', () => this.startRenameProject())
+    on('.side .name-edit', 'keydown', (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault()
+        this.commitRenameProject(true)
+      } else if (e.key === 'Escape') {
+        e.preventDefault()
+        this.commitRenameProject(false)
+      }
+    })
+    on('.side .name-edit', 'blur', () => this.commitRenameProject(true))
     on('#btn-hidden-toggle', 'click', () => this.toggleHiddenList())
     on('#btn-locate', 'click', () => this.actions.focusProject?.(this.project?.name))
     on('#btn-close-project', 'click', () => this.actions.closeProject?.())
@@ -404,7 +416,7 @@ export class Hud {
    */
   setLegend(projects, activeName = null, hidden = [], folded = []) {
     const signature =
-      projects.map((p) => `${p.name}:${p.count}:${p.accent}:${p.urgent ? 1 : 0}`).join('|') +
+      projects.map((p) => `${p.name}:${p.displayName}:${p.count}:${p.accent}:${p.urgent ? 1 : 0}`).join('|') +
       `~${activeName}~` +
       hidden.map((p) => `${p.name}:${p.count}`).join('|') +
       `~${folded.length}`
@@ -414,14 +426,15 @@ export class Hud {
     const wrap = this.$('.projects')
     wrap.innerHTML = ''
     for (const p of projects) {
+      const label = p.displayName || p.name
       const b = document.createElement('button')
       b.type = 'button'
       b.className = 'repo'
-      b.title = `${p.count} thread${p.count === 1 ? '' : 's'} in ${p.name}`
+      b.title = `${p.count} thread${p.count === 1 ? '' : 's'} in ${label}`
       b.setAttribute('aria-pressed', String(p.name === activeName))
       b.innerHTML =
         `<i class="swatch" style="background:${hex(p.accent)};color:${hex(p.accent)}"></i>` +
-        `<span class="n">${escapeHtml(p.name)}</span>` +
+        `<span class="n">${escapeHtml(label)}</span>` +
         (p.urgent ? '<i class="alarm"></i>' : '') +
         `<span class="count">${p.count}</span>`
       b.addEventListener('click', () => this.actions.pickProject?.(p.name))
@@ -507,7 +520,8 @@ export class Hud {
     // nothing is happening keeps whatever "4m ago" it was first drawn with, for as long as
     // you leave the panel open.
     const signature =
-      `${project.name}~${project.path}~${project.accent}~${project.selectedId}~${Math.floor(Date.now() / 60000)}~` +
+      `${project.name}~${project.displayName}~${project.path}~${project.accent}~${project.selectedId}~` +
+      `${Math.floor(Date.now() / 60000)}~` +
       project.threads.map((t) => `${t.id}:${t.status}:${t.title}:${t.lastActivityAt}`).join('|')
     panel.classList.add('drilled')
     if (this._last.project === signature) return
@@ -516,7 +530,7 @@ export class Hud {
     const swatch = this.$('.side .who .swatch')
     swatch.style.background = hex(project.accent)
     swatch.style.color = hex(project.accent) // the halo is `currentColor`
-    this.$('.side .name').textContent = project.name
+    this.$('.side .name').textContent = project.displayName || project.name
     const path = this.$('.side .path')
     path.textContent = project.path ? shortPath(project.path) : 'folder unknown'
     path.title = project.path || ''
@@ -565,6 +579,26 @@ export class Hud {
     }
     list.scrollTop = scroll
     if (!project.selectedId) this._scrolledTo = null
+  }
+
+  /** Swap the name plate for a text field pre-filled with what it currently shows. */
+  startRenameProject() {
+    if (!this.project) return
+    const input = this.$('.side .name-edit')
+    input.value = this.$('.side .name').textContent
+    this.$('.side .name').hidden = true
+    input.hidden = false
+    input.focus()
+    input.select()
+  }
+
+  /** `save` false (Escape) discards the edit; true (Enter, or losing focus) applies it. */
+  commitRenameProject(save) {
+    const input = this.$('.side .name-edit')
+    if (input.hidden) return // Enter already committed before blur fired for the same edit.
+    input.hidden = true
+    this.$('.side .name').hidden = false
+    if (save && this.project) this.actions.renameProject?.(this.project.name, input.value)
   }
 
   /**
@@ -932,8 +966,10 @@ const TEMPLATE = `
         <i class="swatch"></i>
         <div class="text">
           <div class="name"></div>
+          <input class="name-edit" type="text" maxlength="80" hidden />
           <div class="path"></div>
         </div>
+        <button class="btn icon ghost" id="btn-rename-project" title="Rename this repo (display only)">${ICON.edit}</button>
         <button class="btn icon ghost" id="btn-locate" title="Fly to this zone">${ICON.locate}</button>
       </div>
       <div class="project-actions">

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -986,6 +986,33 @@ body {
   white-space: nowrap;
 }
 
+.side .name-edit {
+  display: block;
+  width: 100%;
+  font: inherit;
+  font-weight: 650;
+  font-size: 15px;
+  letter-spacing: -0.01em;
+  color: inherit;
+  background: transparent;
+  border: 1px solid var(--line-strong);
+  border-radius: 6px;
+  padding: 1px 6px;
+  margin: -2px 0;
+}
+
+/* `display: block` above outranks the UA `[hidden]{display:none}` rule on specificity
+   alone (two classes beat one attribute selector) — without this, `input.hidden = true`
+   stops hiding anything the moment the block rule above exists. */
+.side .name-edit[hidden] {
+  display: none;
+}
+
+.side .name-edit:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
 .side .path {
   font-size: 11px;
   color: var(--dim);

--- a/src/world/planet.js
+++ b/src/world/planet.js
@@ -65,6 +65,27 @@ export const PLANETS = {
     companion: { name: 'Moon', color: 0xdcd8cc, size: 3.2, glow: 0xfff6e0 },
     dust: 0.25,
   },
+  fiji: {
+    id: 'fiji',
+    name: 'Fiji',
+    blurb: 'White sand, warm water, palm shade at noon.',
+    ground: { low: 0xdfc48a, high: 0xf6e8bd, tint: 0xffe9a8 },
+    rock: 0xc98a5e,
+    // Fallback flora (this world has no palm assets to load — see `scatter: 'tropical'`
+    // below) tints by this instead of `rock`, so canopies read as green, not driftwood tan.
+    foliage: 0x2f8f5b,
+    horizon: 0x2fb6c9,
+    sky: { top: 0x2f8fd0, bottom: 0xbdeee0 },
+    fog: { color: 0xbfeee2, near: 110, far: 240 },
+    sun: { color: 0xfff6da, intensity: 2.6, night: 0.15 },
+    ambient: { sky: 0x9fe3e0, ground: 0xd9b878, intensity: 1.05 },
+    atmosphere: 0.7,
+    craters: 0,
+    roughness: 0.55,
+    scatter: 'tropical',
+    companion: { name: 'Daymoon', color: 0xeaeaea, size: 2.6, glow: 0xffffff },
+    dust: 0,
+  },
 }
 
 const GROUND_SIZE = 340
@@ -222,7 +243,11 @@ const SCATTER = {
   ],
 }
 
-/** The fallback when the kit has not loaded: the primitives this used to be made of. */
+/**
+ * The fallback when the kit has not loaded: the primitives this used to be made of. Also the
+ * *only* look `scatter: 'tropical'` ever gets — there is no palm in the pack, so that recipe
+ * is treated as permanently kit-less rather than pretending an atlas part exists.
+ */
 function fallbackShapes(isFlora) {
   const shapes = isFlora
     ? [new THREE.IcosahedronGeometry(0.5, 0), new THREE.ConeGeometry(0.42, 1.5, 5), new THREE.SphereGeometry(0.5, 6, 4)]
@@ -232,7 +257,11 @@ function fallbackShapes(isFlora) {
         new THREE.TetrahedronGeometry(0.72, 0),
       ]
   for (const g of shapes) g.computeVertexNormals()
-  return shapes.map((geo) => ({ geo, sink: 0.25, size: [0.28, 0.83], tint: true, upright: false }))
+  // Rock-fallback shapes still tint by `planet.rock` (`tint`); flora-fallback shapes tint by
+  // `planet.foliage` instead (`foliage`) so a planet can ask for green canopies over tan rock
+  // rather than one rock-coloured blob for everything. `foliage` defaults to `rock` below when
+  // a planet does not set one, so Moon/Mars/Terra render exactly as before.
+  return shapes.map((geo) => ({ geo, sink: 0.25, size: [0.28, 0.83], tint: !isFlora, foliage: isFlora, upright: false }))
 }
 
 export function createScatter(planet, density, keepClear = [], seed = 4242) {
@@ -242,9 +271,10 @@ export function createScatter(planet, density, keepClear = [], seed = 4242) {
   if (count <= 0) return group
 
   const rand = mulberry(seed)
-  const isFlora = planet.scatter === 'flora'
+  const isTropical = planet.scatter === 'tropical'
+  const isFlora = planet.scatter === 'flora' || isTropical
   const recipe = SCATTER[planet.scatter] || SCATTER.rocks
-  const ready = recipe.every((r) => hasPart(r.part, 'forest'))
+  const ready = !isTropical && recipe.every((r) => hasPart(r.part, 'forest'))
 
   const kinds = ready
     ? recipe.map((r) => ({ ...r, geo: part(r.part, 'forest'), weight: r.weight }))
@@ -268,6 +298,7 @@ export function createScatter(planet, density, keepClear = [], seed = 4242) {
   )
 
   const rock = new THREE.Color(planet.rock)
+  const foliage = new THREE.Color(planet.foliage ?? planet.rock)
   const dummy = new THREE.Object3D()
   const color = new THREE.Color()
   const fill = new Array(kinds.length).fill(0)
@@ -318,7 +349,8 @@ export function createScatter(planet, density, keepClear = [], seed = 4242) {
     // Foliage keeps the colour it was painted; rock takes the planet's. The tint is lifted
     // because it *multiplies* the atlas rather than replacing it — the pack's stone is a
     // mid grey, and rust times mid grey is a much darker rust than the ground it sits on.
-    if (kind.tint) color.copy(rock).multiplyScalar(1.55)
+    if (kind.foliage) color.copy(foliage).multiplyScalar(1.55)
+    else if (kind.tint) color.copy(rock).multiplyScalar(1.55)
     else color.setRGB(1, 1, 1)
     color.offsetHSL((rand() - 0.5) * 0.03, (rand() - 0.5) * 0.08, (rand() - 0.5) * 0.14)
     mesh.setColorAt(slot, color)


### PR DESCRIPTION
## Summary
- **Business Tasks harness** (`server/harnesses/business-tasks.mjs`): surfaces manually-defined action items from `data/business-tasks.json` as astronauts in their own zone, so non-coding to-dos get the same clickable treatment as a real coding thread. Read-only like every other harness - `"done"` and `"deleted"` flags both just drop a task out of the colony; nothing is ever removed from the file, and there is no delete API route.
- **Fiji planet** (`src/world/planet.js`): a new selectable planet alongside Luna/Mars/Terra, following the existing data-driven preset pattern, and set as the default. The bundled art pack has no palm assets, so its vegetation renders through the existing kit-less fallback path; a `foliage` tint field was added (defaulting to `rock` for full backward compatibility) so that fallback can render green canopies instead of one rock-toned blob.
- **Repo rename**: a cosmetic-only `projectNames` override in `colony.json`, editable from a pencil icon next to a repo name in the sidebar. The real project name stays the key everywhere a plot or thread is actually looked up (plots, archive, threads) - only the sidebar label and the in-world floating plate change.

## Test plan
- [x] `node --check` on every modified server/frontend file
- [x] `npm run dev`, confirmed `business-tasks` shows `detected: true` in `/api/harnesses` and its 3 seed tasks flow through `/api/threads`
- [x] Selected a Business Tasks astronaut in the live UI, clicked Open, confirmed it launches the linked URL
- [x] Switched to Fiji via Tab-cycle and the Settings panel; confirmed sand/turquoise terrain and green-tinted fallback vegetation render, distinct from Terra
- [x] Renamed a real project via the new pencil icon, confirmed the sidebar label, the in-world floating plate, and persistence across a reload all update correctly; reverted the test rename

Generated with Claude Code (https://claude.com/claude-code)