### PR TITLE
Make the colony usable on a phone

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,13 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
+    <!-- `viewport-fit=cover` is what makes `env(safe-area-inset-*)` report anything but zero,
+         and the HUD's bottom rail has to clear the home indicator. `user-scalable=no` stays:
+         the page's own pinch is the camera's zoom, and the browser's would fight it. -->
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+    />
     <meta name="color-scheme" content="dark" />
     <title>Bot Crossing</title>
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>👨‍🚀</text></svg>" />

--- a/src/core/camera.js
+++ b/src/core/camera.js
@@ -75,6 +75,10 @@ export class CameraRig {
     this._mode = null
     this._last = new THREE.Vector2()
     this._pinch = 0
+    /** Onset state for a two-finger gesture, and which of the two it turned out to be. */
+    this._two = null
+    /** True from the moment a second finger lands until the last one lifts — see `wasClick`. */
+    this._multi = false
     this._moved = 0
     this._panAnchor = new THREE.Vector3()
     this._hasAnchor = false
@@ -128,8 +132,20 @@ export class CameraRig {
 
     if (this._pointers.size === 2) {
       this._mode = 'pinch'
+      this._multi = true
       this._pinch = this._pinchDistance()
-      this._grab(...this._pinchCentre())
+      const [cx, cy] = this._pinchCentre()
+      // Classified once, at onset, and then locked for the rest of the gesture. Re-deciding
+      // every frame makes a tilt stutter into a zoom the moment your fingers drift apart.
+      // Each finger's own starting point is what the decision is made from — see `_classify`.
+      for (const p of this._pointers.values()) {
+        p.x0 = p.x
+        p.y0 = p.y
+      }
+      this._two = { kind: null, cx, cy }
+      this.interacting = true
+      this.idleFor = 0
+      this._grab(cx, cy)
       return
     }
 
@@ -158,16 +174,7 @@ export class CameraRig {
 
     if (this._mode === 'pinch') {
       e.preventDefault()
-      const d = this._pinchDistance()
-      const [cx, cy] = this._pinchCentre()
-      if (this._pinch > 0 && d > 0) {
-        this.desiredDistance = THREE.MathUtils.clamp(this.desiredDistance * (this._pinch / d), MIN_DIST, MAX_DIST)
-        this.distance = this.desiredDistance
-        this._sync()
-      }
-      this._pinch = d
-      // Two fingers pan as well as zoom, both anchored on the point between them.
-      this._dragGround(cx, cy)
+      this._twoFinger()
       return
     }
 
@@ -187,6 +194,91 @@ export class CameraRig {
     if (this.suppressed) return
     e.preventDefault()
     this._dragGround(e.clientX, e.clientY)
+  }
+
+  /**
+   * Which of the two gestures this is, or null while it is still too early to say.
+   *
+   * Decided from the two fingers' own displacement vectors rather than from the separation
+   * and midpoint they imply. Those two summaries are only meaningful when both fingers are
+   * up to date, and they never are: every finger reports its own `pointermove`, so on the
+   * event that moves finger A the pair still holds finger B's previous position — and a
+   * parallel drag, sampled that way, looks exactly like a pinch for one event. Which is one
+   * event too many, because the decision is final.
+   *
+   * The vectors have no such problem. Fingers travelling the same way are a drag; fingers
+   * travelling opposite ways are a pinch; and that stays true no matter which of the two
+   * reported last.
+   */
+  _classify() {
+    const [p, q] = [...this._pointers.values()]
+    if (!p || !q) return null
+    const px = p.x - p.x0
+    const py = p.y - p.y0
+    const qx = q.x - q.x0
+    const qy = q.y - q.y0
+    const lp = Math.hypot(px, py)
+    const lq = Math.hypot(qx, qy)
+
+    if (lp >= 6 && lq >= 6) {
+      const cos = (px * qx + py * qy) / (lp * lq)
+      return cos > 0.5 ? 'orbit' : 'zoom'
+    }
+    // One finger planted and the other travelling is the commonest pinch of all — thumb
+    // still, index sliding — and it has no second vector to compare against. Distance is
+    // the only thing changing, so it can only be a zoom.
+    if (Math.max(lp, lq) >= 24) return 'zoom'
+    return null
+  }
+
+  /**
+   * The touch half of the navigation model, and the only way to reach tilt without a mouse.
+   *
+   * Two fingers do one of two things, decided by how they first move and then held for the
+   * rest of the gesture:
+   *
+   * - **Change their separation** — a pinch. Zooms, anchored on the point between them, the
+   *   way the wheel anchors on the cursor.
+   * - **Move together** — the touch spelling of right-drag. Horizontal turns the heading,
+   *   vertical tilts between overhead and the horizon, at the same rates and in the same
+   *   directions as the mouse, so the two inputs describe the same camera.
+   *
+   * They are mutually exclusive on purpose. A pinch always drifts a little sideways and a
+   * two-finger drag always breathes a little in and out, so a gesture that applied both at
+   * once would tilt every time you zoomed and zoom every time you tilted.
+   */
+  _twoFinger() {
+    const g = this._two
+    if (!g) return
+    const d = this._pinchDistance()
+    const [cx, cy] = this._pinchCentre()
+
+    if (!g.kind) {
+      g.kind = this._classify()
+      if (!g.kind) {
+        g.cx = cx
+        g.cy = cy
+        this._pinch = d
+        return
+      }
+    }
+
+    if (g.kind === 'orbit') {
+      this.desiredAzimuth -= (cx - g.cx) * 0.006
+      this.desiredPolar = THREE.MathUtils.clamp(this.desiredPolar - (cy - g.cy) * 0.005, MIN_POLAR, MAX_POLAR)
+    } else {
+      if (this._pinch > 0 && d > 0) {
+        this.desiredDistance = THREE.MathUtils.clamp(this.desiredDistance * (this._pinch / d), MIN_DIST, MAX_DIST)
+        this.distance = this.desiredDistance
+        this._sync()
+      }
+      // A pinch pans as well as zooms, both anchored on the point between the fingers.
+      this._dragGround(cx, cy)
+    }
+
+    g.cx = cx
+    g.cy = cy
+    this._pinch = d
   }
 
   /**
@@ -218,8 +310,11 @@ export class CameraRig {
       this.interacting = false
       this.suppressed = false
       this._hasAnchor = false
+      this._two = null
+      this._multi = false
     } else if (this._pointers.size === 1) {
       this._mode = 'pan'
+      this._two = null
       const [only] = this._pointers.values()
       this._last.set(only.x, only.y)
       this._grab(only.x, only.y)
@@ -263,9 +358,15 @@ export class CameraRig {
     t.y = 0
   }
 
-  /** True when the pointer went down and up without really moving — a click, not a drag. */
+  /**
+   * True when the pointer went down and up without really moving — a click, not a drag.
+   *
+   * A two-finger gesture is never a click, however still the fingers were: the pinch branch
+   * does not accumulate `_moved`, so without this the lift at the end of a tilt would read
+   * as a tap and select whatever happened to be under the last finger.
+   */
   get wasClick() {
-    return this._moved < 6
+    return !this._multi && this._moved < 6
   }
 
   /** Glide the view to a world point without yanking it — used when you pick an astronaut. */

--- a/src/main.js
+++ b/src/main.js
@@ -720,7 +720,13 @@ async function boot() {
     hud.toggleHelp(true)
     localStorage.setItem('botcrossing.seen-help', '1')
   } else {
-    hud.hint('Drag to move · click an astronaut · H hides everything', 5200)
+    const touch = matchMedia('(hover: none) and (pointer: coarse)').matches
+    hud.hint(
+      touch
+        ? 'Drag to move · pinch to zoom · two fingers to tilt · tap an astronaut'
+        : 'Drag to move · click an astronaut · H hides everything',
+      5200
+    )
   }
 }
 

--- a/src/ui/hud.js
+++ b/src/ui/hud.js
@@ -67,6 +67,17 @@ export class Hud {
     this.el.innerHTML = TEMPLATE
     root.appendChild(this.el)
 
+    // A sibling of the HUD, not a child of it: see `.ui-restore` in the stylesheet for why
+    // the one control that undoes "hide all UI" cannot live inside the layer it un-hides.
+    this.restoreEl = document.createElement('button')
+    this.restoreEl.type = 'button'
+    this.restoreEl.className = 'ui-restore'
+    this.restoreEl.title = 'Show the interface again'
+    this.restoreEl.setAttribute('aria-label', 'Show the interface again')
+    this.restoreEl.innerHTML = ICON.eyeOff
+    this.restoreEl.addEventListener('click', () => this.toggleUi(true))
+    root.appendChild(this.restoreEl)
+
     this.$ = (sel) => this.el.querySelector(sel)
 
     this._buildStats()
@@ -777,6 +788,7 @@ export class Hud {
   toggleUi(force) {
     this.visible = force ?? !this.visible
     this.el.classList.toggle('hidden', !this.visible)
+    this.restoreEl.classList.toggle('on', !this.visible)
     this.$('#btn-hide').innerHTML = this.visible ? ICON.eye : ICON.eyeOff
     this.actions.uiVisibility?.(this.visible)
     if (!this.visible) this.toggleHelp(false)
@@ -982,15 +994,26 @@ const TEMPLATE = `
   </div>
 </div>
 
-<div class="toasts"></div>
-<div class="fps panel"></div>
-<div class="hint-pill panel"></div>
+<!-- The three transient readouts share one wrapper so that, on any screen too small to give
+     them a corner each, they can be laid out as a single column instead of being talked out
+     of each other's way with hand-picked offsets. On a roomy screen the wrapper is
+     display:contents and they keep the corners they have always had. Toasts come last:
+     last in the column is nearest the thumb, and last in the DOM is on top. -->
+<div class="readouts">
+  <div class="fps panel"></div>
+  <div class="hint-pill panel"></div>
+  <div class="toasts"></div>
+</div>
 
 <div class="help">
   <div class="sheet panel">
     <h2>Bot Crossing</h2>
-    <p class="sub">Every coding-agent thread on this machine is an astronaut. They walk out of the ship, claim a plot for their repo, and build. Click one to open its thread; click a zone — its deck or its name — for the repo itself, and start a new conversation there. Hide a repo from that panel if you would rather not see it — its threads stay in your harness, and you can show it again from the list. Navigation works like Google Earth — drag the ground itself, right-drag to tilt, scroll to zoom in on whatever is under the cursor.</p>
-    <div class="cols">
+    <p class="sub">Every coding-agent thread on this machine is an astronaut. They walk out of the ship, claim a plot for their repo, and build. <span class="pointer-only">Click</span><span class="touch-only">Tap</span> one to open its thread; <span class="pointer-only">click</span><span class="touch-only">tap</span> a zone — its deck or its name — for the repo itself, and start a new conversation there. Hide a repo from that panel if you would rather not see it — its threads stay in your harness, and you can show it again from the list. Navigation works like Google Earth — <span class="pointer-only">drag the ground itself, right-drag to tilt, scroll to zoom in on whatever is under the cursor.</span><span class="touch-only">drag the ground itself, pinch to zoom in on whatever is between your fingers, and drag with two fingers to tilt and turn.</span></p>
+    <!-- Two versions of the same list, because the answer genuinely differs. A phone has no
+         keys to press, and a shortcut sheet that names ten of them is worse than none: it
+         reads as a list of things this device cannot do. On touch the gestures take the
+         navigation half, and everything else is a button you can see on screen. -->
+    <div class="cols pointer-only">
       <div>
         <div class="k"><span>Drag the ground</span><kbd>drag</kbd></div>
         <div class="k"><span>Tilt &amp; rotate</span><kbd>right-drag</kbd></div>
@@ -1015,14 +1038,28 @@ const TEMPLATE = `
         <div class="k"><span>This sheet</span><kbd>?</kbd></div>
       </div>
     </div>
+    <div class="cols touch-only">
+      <div>
+        <div class="k"><span>Move the ground</span><kbd>drag</kbd></div>
+        <div class="k"><span>Zoom</span><kbd>pinch</kbd></div>
+        <div class="k"><span>Tilt &amp; rotate</span><kbd>two fingers</kbd></div>
+        <div class="k"><span>Open a thread</span><kbd>tap it</kbd></div>
+        <div class="k"><span>Open a repo</span><kbd>tap its deck</kbd></div>
+        <div class="k"><span>Reset, next, orbit, planet, time</span><kbd>bottom bar</kbd></div>
+        <div class="k"><span>Screenshot, settings, hide</span><kbd>top right</kbd></div>
+      </div>
+    </div>
     <div style="margin-top:16px">
-      <div class="legend-row"><i class="badge" style="background:#1a2b46;color:#8fb4ee">?</i> waiting on your reply — click to open the thread</div>
+      <!-- One span around the whole line: the legend row is a flex box with a gap, so a bare
+           span in the middle of the text would become its own flex item and open a hole
+           either side of the word it varies. -->
+      <div class="legend-row"><i class="badge" style="background:#1a2b46;color:#8fb4ee">?</i> <span>waiting on your reply — <span class="pointer-only">click</span><span class="touch-only">tap</span> to open the thread</span></div>
       <div class="legend-row"><i class="badge" style="background:#3d1c1c;color:#e88b8b">!</i> the session hit an error</div>
       <div class="legend-row"><i class="badge" style="background:#16301f;color:#7fd39a">⚒</i> running right now, building</div>
       <div class="legend-row"><i class="badge" style="background:#332b12;color:#e6c67f">✓</i> its pull request landed</div>
       <div class="legend-row"><i class="badge" style="background:#1d1f2e;color:#a9a8c0">z</i> nothing for three days</div>
     </div>
-    <div style="margin-top:18px;display:flex;justify-content:flex-end">
+    <div class="help-actions">
       <button class="btn primary" id="btn-help-close">Got it</button>
     </div>
   </div>

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1611,8 +1611,36 @@ kbd {
     width: auto;
   }
 
-  /* 34px is a comfortable mouse target and a poor thumb one. Everything that can be tapped
-     goes up to 44, the smallest square a finger hits reliably. */
+  .stat {
+    height: 32px;
+    padding: 0 11px;
+  }
+
+  /* The card is placed in screen space by `placeCard`, which clamps to the window — but it
+     can only clamp a width that fits in the first place. */
+  .thread-pop {
+    width: min(284px, calc(100vw - 24px));
+  }
+  .thread-pop .pair {
+    flex-wrap: wrap;
+  }
+
+  /* One wide target beats a small one tucked in a corner, on the one control whose whole
+     job is getting out of this sheet. */
+  .help .help-actions .btn {
+    width: 100%;
+  }
+}
+
+/* ── tap targets ──────────────────────────────────────────────────────────────────── */
+
+/* 34px is a comfortable mouse target and a poor thumb one. Everything that can be tapped
+   goes up to 44, the smallest square a finger hits reliably.
+
+   Keyed on the pointer rather than on width, because a thumb is the same size on a tablet.
+   A width rule would leave a 768px iPad — a touch device by any measure, and one where the
+   sidebar is a full list of tappable rows — on targets picked for a mouse it does not have. */
+@media (hover: none) and (pointer: coarse) {
   .btn {
     height: 40px;
     min-width: 40px;
@@ -1633,10 +1661,6 @@ kbd {
   .rail .btn {
     width: 44px;
     height: 44px;
-  }
-  .stat {
-    height: 32px;
-    padding: 0 11px;
   }
   .side .repo,
   .side .hidden-toggle,
@@ -1668,21 +1692,6 @@ kbd {
   }
   .slider {
     height: 30px;
-  }
-
-  /* The card is placed in screen space by `placeCard`, which clamps to the window — but it
-     can only clamp a width that fits in the first place. */
-  .thread-pop {
-    width: min(284px, calc(100vw - 24px));
-  }
-  .thread-pop .pair {
-    flex-wrap: wrap;
-  }
-
-  /* One wide target beats a small one tucked in a corner, on the one control whose whole
-     job is getting out of this sheet. */
-  .help .help-actions .btn {
-    width: 100%;
   }
 }
 

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -79,6 +79,16 @@ body {
   /* How much room the sidebar takes. It is always there now, so this is what anything
      else on screen has to stay clear of. */
   --side: 334px;
+  /* How much of the right-hand edge is actually covered by a panel right now.
+     Deliberately not the same number as `--side`: that one is consumed by `placeCard`,
+     which wants 0 on a narrow screen so the thread card may use the full width, while the
+     toasts and the hint still have a 320px sidebar to keep out of. Settings slides the
+     sidebar aside rather than over it, so while it is open the pair covers twice as much. */
+  --right-panel: 334px;
+}
+
+.hud:has(.side.shifted) {
+  --right-panel: 654px;
 }
 
 .hud.hidden {
@@ -668,7 +678,11 @@ body {
   font-weight: 650;
   font-size: 14px;
   letter-spacing: -0.01em;
+  /* `min-width: 0` lets it shrink; without the ellipsis it just shrinks and spills, which
+     on a 320px screen is four buttons' worth of brand running under the buttons. */
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   flex: 1;
   min-width: 0;
 }
@@ -1144,10 +1158,27 @@ body {
 
 /* ── toasts + readouts ───────────────────────────────────────────────────────────── */
 
+/* No box of its own: each readout stays absolutely positioned against the HUD, in the
+   corner it has always used. The wrapper only becomes a layout box on a screen that cannot
+   spare three corners — see the stacking rules further down. */
+.readouts {
+  display: contents;
+}
+
+/* None of the three is a control, and `.panel` hands out `pointer-events: auto` to
+   everything that wears it. Left alone, a readout is a rectangle of dead ground you cannot
+   drag the colony through — the hint pill is 418px of exactly that, lying across the top of
+   the scene for the first five seconds of every visit. They are for reading, not touching. */
+.readouts,
+.readouts > *,
+.toast {
+  pointer-events: none;
+}
+
 .toasts {
   position: absolute;
   bottom: 14px;
-  right: calc(14px + var(--side));
+  right: calc(14px + var(--right-panel));
   display: flex;
   flex-direction: column;
   align-items: flex-end;
@@ -1158,7 +1189,7 @@ body {
   padding: 9px 13px;
   border-radius: 10px;
   font-size: 12.5px;
-  max-width: 320px;
+  max-width: min(320px, calc(100vw - 24px));
   animation: toast-in 260ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
@@ -1222,8 +1253,21 @@ body {
   display: grid;
 }
 
+.help.open {
+  /* Padding, not just `place-items`, so the sheet can never touch the screen edge and a
+     backdrop tap always has somewhere to land. */
+  padding: 16px;
+}
+
 .help .sheet {
-  width: min(560px, calc(100vw - 40px));
+  width: min(560px, 100%);
+  /* `dvh`, not `vh`: Safari's `vh` is the *large* viewport, so a `vh`-capped sheet is
+     taller than the visible page whenever the toolbar is showing, and the last thing in
+     it — "Got it" — sits under the toolbar with no way to reach it. */
+  max-height: calc(100dvh - 32px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
   padding: 22px 24px;
 }
 
@@ -1243,6 +1287,31 @@ body {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 4px 26px;
+}
+
+/* Only one of these two is ever true of the device reading it. */
+.help .touch-only,
+.help p.sub .touch-only,
+.help .legend-row .touch-only {
+  display: none;
+}
+
+@media (hover: none) and (pointer: coarse) {
+  .help .pointer-only {
+    display: none;
+  }
+  .help .touch-only {
+    display: grid;
+  }
+  .help p.sub .touch-only,
+  .help .legend-row .touch-only {
+    display: inline;
+  }
+  /* One column: there are only seven of these, and two columns of them on a phone squeeze
+     the labels until the `kbd` beside each one is pushed off the edge of the sheet. */
+  .help .cols.touch-only {
+    grid-template-columns: 1fr;
+  }
 }
 
 .help .k {
@@ -1282,6 +1351,12 @@ kbd {
   color: var(--muted);
 }
 
+.help .help-actions {
+  margin-top: 18px;
+  display: flex;
+  justify-content: flex-end;
+}
+
 .help .legend-row .badge {
   width: 20px;
   height: 20px;
@@ -1298,7 +1373,10 @@ kbd {
 .hint-pill {
   position: absolute;
   top: 78px;
-  left: 50%;
+  /* Centred on the colony rather than on the window, so it does not slide under whatever
+     is parked on the right-hand edge. */
+  left: calc(50% - var(--right-panel) / 2);
+  max-width: calc(100vw - var(--right-panel) - 28px);
   transform: translateX(-50%);
   padding: 8px 14px;
   font-size: 12.5px;
@@ -1386,8 +1464,11 @@ kbd {
   .side.shifted {
     transform: translateX(0);
   }
-  .rail {
-    display: none;
+  /* Settings covers the sidebar here rather than pushing it aside, so the pair occupies one
+     panel's width, not two. Without this the readouts are told to clear 654px of an edge
+     that only has 334px on it, and get squeezed into the rail. */
+  .hud:has(.side.shifted) {
+    --right-panel: 334px;
   }
   .stats {
     gap: 5px;
@@ -1397,6 +1478,65 @@ kbd {
   }
   .legend {
     max-width: calc(100vw - 28px);
+  }
+  /* The rail stays a column here — the sidebar is on the *right*, so the left edge was
+     always free and hiding the rail was never about room. What it cost was five actions —
+     reset, next, orbit, planet and time — each of which is keyboard-only otherwise, so on
+     a tablet or a phone in landscape they were simply gone.
+
+     Anchored to the top rather than centred: centred, a 243px column claims the whole left
+     edge of a 393px-tall landscape phone, and the bottom-left corner the readouts live in
+     stops existing. */
+  .rail {
+    top: 14px;
+    transform: none;
+  }
+}
+
+/* ── small screens: one column of readouts instead of three corners ────────────────── */
+
+/* Height matters as much as width here. A phone held sideways is 852px across — past every
+   width breakpoint in this file — and 393px tall, which is the dimension that is actually
+   scarce. Keying only on width leaves landscape phones with the desktop layout on a screen
+   a quarter of its height. */
+@media (max-width: 820px), (max-height: 560px) {
+  .readouts {
+    display: flex;
+    position: absolute;
+    bottom: 14px;
+    right: calc(14px + var(--right-panel));
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 8px;
+    /* The wrapper is only a lane; the readouts inside it keep their own hit targets. */
+    pointer-events: none;
+  }
+  /* Handing position back to the parent is what makes the column a column. */
+  .readouts > * {
+    position: static;
+    inset: auto;
+    transform: none;
+    max-width: 100%;
+  }
+  .readouts .toasts {
+    align-items: flex-end;
+  }
+}
+
+/* And a short viewport needs the rail out of the middle of its left edge for the same
+   reason a narrow one does — see the note on the rail above. */
+@media (max-height: 560px) {
+  .rail {
+    top: 14px;
+    transform: none;
+  }
+  /* Two 320px panels side by side is 654px of an 852px landscape phone. Settings covers
+     the sidebar here too, for the same reason it does on a narrow screen. */
+  .side.shifted {
+    transform: translateX(0);
+  }
+  .hud:has(.side.shifted) {
+    --right-panel: 334px;
   }
 }
 
@@ -1408,6 +1548,195 @@ kbd {
   .brand span,
   .stats .stat .lbl {
     display: none;
+  }
+
+  /* Nothing is left of the right-hand edge to avoid: the sidebar is a sheet across the top
+     now, so the toasts and the hint get the full width back. */
+  .hud,
+  .hud:has(.side.shifted) {
+    --right-panel: 0px;
+  }
+
+  /* The rail lies down along the bottom, where a thumb is. It can only do this once the
+     sidebar is out of the right-hand column — above this width the sidebar is still a
+     full-height panel and a bottom bar would run underneath it. */
+  .rail {
+    left: 50%;
+    top: auto;
+    bottom: calc(12px + env(safe-area-inset-bottom));
+    transform: translateX(-50%);
+    flex-direction: row;
+    gap: 2px;
+  }
+  /* The divider has to turn with the rail it divides. */
+  .rail .sep {
+    width: 1px;
+    height: 22px;
+    margin: 0 4px;
+    align-self: center;
+  }
+
+  /* The readout column runs full width and centred, and starts above the rail rather than
+     under it. */
+  .readouts {
+    left: 12px;
+    right: 12px;
+    bottom: calc(78px + env(safe-area-inset-bottom));
+    align-items: center;
+  }
+  .readouts .toasts {
+    align-items: center;
+  }
+  .hint-pill {
+    text-align: center;
+  }
+
+  /* The sidebar stops being a sidebar. At 320px on a 393px screen it is not a panel beside
+     the colony, it *is* the screen — so it becomes a sheet across the top and gives the
+     lower half back to the thing the app is for. */
+  .side {
+    top: calc(10px + env(safe-area-inset-top));
+    left: calc(10px + env(safe-area-inset-left));
+    right: calc(10px + env(safe-area-inset-right));
+    bottom: auto;
+    width: auto;
+    max-height: 46dvh;
+  }
+
+  .settings {
+    top: calc(10px + env(safe-area-inset-top));
+    left: calc(10px + env(safe-area-inset-left));
+    right: calc(10px + env(safe-area-inset-right));
+    bottom: calc(76px + env(safe-area-inset-bottom));
+    width: auto;
+  }
+
+  /* 34px is a comfortable mouse target and a poor thumb one. Everything that can be tapped
+     goes up to 44, the smallest square a finger hits reliably. */
+  .btn {
+    height: 40px;
+    min-width: 40px;
+  }
+  .btn.icon {
+    width: 40px;
+  }
+  .side .brandbar .btn,
+  .side .brandbar .btn.icon {
+    width: 38px;
+    min-width: 38px;
+    height: 38px;
+  }
+  .side .brandbar .btn svg {
+    width: 17px;
+    height: 17px;
+  }
+  .rail .btn {
+    width: 44px;
+    height: 44px;
+  }
+  .stat {
+    height: 32px;
+    padding: 0 11px;
+  }
+  .side .repo,
+  .side .hidden-toggle,
+  .side .thread {
+    min-height: 44px;
+  }
+  /* Three controls set their own height and so miss the blanket `.btn` bump above: the
+     card's close, the card's action row, and the sidebar's back. */
+  .thread-pop #btn-deselect,
+  .thread-pop #btn-deselect.icon {
+    width: 38px;
+    min-width: 38px;
+    height: 38px;
+  }
+  .thread-pop #btn-deselect svg {
+    width: 16px;
+    height: 16px;
+  }
+  .thread-pop .pair .btn,
+  .side .project-actions .btn {
+    height: 40px;
+  }
+  .side .back {
+    height: 38px;
+  }
+  .toggle {
+    transform: scale(1.15);
+    transform-origin: right center;
+  }
+  .slider {
+    height: 30px;
+  }
+
+  /* The card is placed in screen space by `placeCard`, which clamps to the window — but it
+     can only clamp a width that fits in the first place. */
+  .thread-pop {
+    width: min(284px, calc(100vw - 24px));
+  }
+  .thread-pop .pair {
+    flex-wrap: wrap;
+  }
+
+  /* One wide target beats a small one tucked in a corner, on the one control whose whole
+     job is getting out of this sheet. */
+  .help .help-actions .btn {
+    width: 100%;
+  }
+}
+
+/* Sticky rather than merely last, on any screen the sheet has to scroll on — which is a
+   question of height, not width: a phone in landscape is 852px across and still only fits
+   half the sheet. It stays a plain trailing row on a roomy screen, where the sheet fits
+   whole and this would add nothing but a seam and a strip of dead space. */
+@media (max-width: 600px), (max-height: 760px) {
+  .help .help-actions {
+    position: sticky;
+    /* Offset and padded by the sheet's own 22px bottom padding, so the button lands flush
+       on the scrollport's edge instead of floating 22px above it. */
+    bottom: -22px;
+    padding: 12px 0 22px;
+    background: linear-gradient(to top, var(--panel-solid) 62%, transparent);
+  }
+}
+
+/* ── the way back from "hide all UI" ──────────────────────────────────────────────── */
+
+/* H hides the chrome and H brings it back, which is a complete story only if there is a
+   keyboard in the room. On a phone the eye button hides the eye button, and nothing short
+   of a reload undoes it — so on touch, and only on touch, one small control survives.
+   It lives outside `.hud` because `.hud.hidden` zeroes that whole layer's opacity, and a
+   child cannot opt out of its parent's opacity. */
+.ui-restore {
+  position: absolute;
+  right: calc(14px + env(safe-area-inset-right));
+  bottom: calc(14px + env(safe-area-inset-bottom));
+  z-index: 20;
+  width: 44px;
+  height: 44px;
+  display: none;
+  place-items: center;
+  border-radius: 999px;
+  border: 1px solid var(--line-strong);
+  background: rgba(16, 17, 22, 0.7);
+  backdrop-filter: blur(18px) saturate(1.3);
+  -webkit-backdrop-filter: blur(18px) saturate(1.3);
+  box-shadow: var(--shadow);
+  color: var(--text);
+  padding: 0;
+  cursor: pointer;
+  opacity: 0.55;
+}
+
+.ui-restore svg {
+  width: 20px;
+  height: 20px;
+}
+
+@media (hover: none) and (pointer: coarse) {
+  .ui-restore.on {
+    display: grid;
   }
 }
 


### PR DESCRIPTION
Bot Crossing loads on a phone today, but it cannot really be navigated or operated
there. This is one change — touch support — in three parts, each of which is
independently a dead end on a device with no mouse and no keyboard.

<img src="https://raw.githubusercontent.com/lNastaran/bot-crossing/32a66ecb4b5738079f0397e8ea059b1d2a981994/shots/pr-phone-colony.png" width="300" alt="The colony on a 393x659 phone: sidebar as a top sheet, actions as a bottom bar">

**Tilt and rotate had no touch spelling at all.** They were right-drag only, so the
camera was stuck overhead on any device without a mouse. Two fingers moving together
now tilt and turn, at the same rates and directions as right-drag, so the two inputs
describe the same camera.

The pinch/orbit decision is made once at gesture onset and then locked, from the two
fingers' own displacement vectors rather than from the separation and midpoint they
imply. That last part matters more than it looks: each finger reports its own
`pointermove`, so on the event that moves finger A the pair still holds finger B's
previous position — and a parallel drag sampled that way looks exactly like a pinch
for one event, which is one event too many when the decision is final. Comparing
vectors is immune to which finger reported last. Thumb-planted/index-sliding has no
second vector to compare, so it falls back to distance and reads as a zoom, which is
what it always is.

`wasClick` also needed the multi-touch guard: the tilt branch never accumulates
`_moved`, so before this the lift at the end of a tilt read as a tap and selected
whatever happened to sit under the last finger.

Two fingers from the same starting view - dragged up to tilt, dragged sideways to turn:

| Before | Tilt | Rotate |
| --- | --- | --- |
| <img src="https://raw.githubusercontent.com/lNastaran/bot-crossing/32a66ecb4b5738079f0397e8ea059b1d2a981994/shots/pr-phone-gesture-before.png" width="230" alt="Reset view before the gesture"> | <img src="https://raw.githubusercontent.com/lNastaran/bot-crossing/32a66ecb4b5738079f0397e8ea059b1d2a981994/shots/pr-phone-tilt.png" width="230" alt="After a two-finger upward drag: camera tilted"> | <img src="https://raw.githubusercontent.com/lNastaran/bot-crossing/32a66ecb4b5738079f0397e8ea059b1d2a981994/shots/pr-phone-rotate.png" width="230" alt="After a two-finger sideways drag: camera turned"> |

**The rail was `display: none` below 900px.** That is five actions — reset, next,
orbit, planet, time — that are keyboard-only otherwise, so on a phone or tablet they
were simply gone. It becomes a bottom bar under 600px and stays a top-anchored column
above that. Hiding it was never about room, incidentally: the sidebar is on the right,
so the left edge was always free.

**"Hide all UI" was a one-way door without a keyboard.** The eye button hides the eye
button, and `H` is the only way back. One small restore control now survives on touch
only. It lives outside `.hud` because `.hud.hidden` zeroes that layer's opacity and a
child cannot opt out of its parent's.


<img src="https://raw.githubusercontent.com/lNastaran/bot-crossing/32a66ecb4b5738079f0397e8ea059b1d2a981994/shots/pr-phone-ui-hidden.png" width="300" alt="UI hidden on touch, with the one restore control still present">

Plus the responsive pass the above has to sit on:

- Help sheet capped to `100dvh` — not `vh`, which is Safari's *large* viewport, so a
  `vh`-capped sheet is taller than the visible page whenever the toolbar shows and
  "Got it" sits under it unreachable — with the action row sticky on any viewport the
  sheet must scroll on. The sheet also carries a touch copy of the navigation text and
  shortcut list, because a shortcut sheet naming ten keys on a device with none reads
  as a list of things it cannot do.

<img src="https://raw.githubusercontent.com/lNastaran/bot-crossing/32a66ecb4b5738079f0397e8ea059b1d2a981994/shots/pr-phone-help-scrolled.png" width="300" alt="Help sheet scrolled, with "Got it" sticky at the bottom edge">
- The three transient readouts (fps, hint, toasts) share a wrapper that is
  `display: contents` on a roomy screen — each keeps the corner it has always had — and
  becomes a single column on any screen that cannot spare three corners. They are also
  `pointer-events: none` now: `.panel` hands out `pointer-events: auto`, so the hint
  pill was 418px of dead ground you could not drag the colony through for the first
  five seconds of every visit.
- Safe-area insets, which need `viewport-fit=cover` on the meta tag to report anything
  but zero. `user-scalable=no` stays — the page's own pinch is the camera's zoom.
- Tap targets to 44px, keyed on `(hover: none) and (pointer: coarse)` rather than on
  width, because a thumb is the same size on a tablet.

Breakpoints key on height as well as width. A phone held sideways is 852px across —
past every width breakpoint in the file — and 393px tall, which is the dimension that
is actually scarce.

No new dependencies. Nothing new is written to disk.

## What I verified, and how

`npm test` — 33/33 green.

Everything else was exercised under real device emulation (Playwright + Chrome DevTools
`Input.dispatchTouchEvent`, iPhone/iPad device profiles with `hasTouch`), not a resized
desktop window, and asserted against the live `CameraRig`'s own state rather than by eye.

The colony in the screenshots is synthetic fixture data — invented repos under a
`/Users/dev/code` path — driven through the real `claude-code` and `codex` adapters by
pointing `HOME` and `CODEX_HOME` at a fabricated store. The scan path is the real one;
only the store underneath it is fake, so no private repo names appear in the images.

Gestures, on a 393×659 touch viewport:

| Gesture | Asserted | Result |
| --- | --- | --- |
| Spread two fingers | `desiredDistance` falls | 62.00 → 15.74, tilt unchanged |
| Close two fingers | `desiredDistance` rises | 15.74 → 66.36 |
| Two fingers dragged up | `desiredPolar` changes | 0.977 → 1.466, zoom unchanged |
| Two fingers dragged sideways | `desiredAzimuth` changes | 0.785 → 0.086, zoom unchanged |
| Thumb still, index sliding | reads as zoom, not tilt | 66.36 → 36.10, polar flat |
| One finger dragged | still pans | target moved 7.64 |
| Near-still two-finger lift | not a click | `wasClick === false` at both pointerups |
| One-finger tap | still a click | `wasClick === true` |

The last two are sampled inside a canvas `pointerup` listener, which is where selection
actually reads `wasClick` — the rig listens on `window`, so the canvas sees it first
while `_multi` is still set.

Layout and tap targets, on iPhone 15 Pro (393×659), iPhone SE (320×568), iPad Mini
(768×1024) and iPhone 15 Pro landscape (734×343). On every one: the help sheet fits the
viewport, "Got it" is inside it and passes an `elementFromPoint` hit test without
scrolling, the rail is fully on screen with ≥40px buttons, `env(safe-area-inset-*)`
resolves, the hint pill computes `pointer-events: none`, and hiding the UI reveals a
restore control that is hittable and brings it back. No console or page errors anywhere.

<img src="https://raw.githubusercontent.com/lNastaran/bot-crossing/32a66ecb4b5738079f0397e8ea059b1d2a981994/shots/pr-ipad-colony.png" width="420" alt="iPad Mini at 768x1024">

Desktop regression, 1600×1000 with no touch: left-drag pans, right-drag tilts *and*
rotates, wheel zooms, `H` hides and restores, `?` opens help. The sheet keeps its 560px
width and does not scroll; the action row computes `position: static`, not sticky; the
pointer shortcut columns show and the touch ones do not; `.readouts` computes
`display: contents` so each readout keeps its corner; the rail is still a vertical
column with upstream's 40×40 buttons; the touch restore control computes `display: none`.

<img src="https://raw.githubusercontent.com/lNastaran/bot-crossing/32a66ecb4b5738079f0397e8ea059b1d2a981994/shots/pr-desktop.png" width="700" alt="Desktop at 1600x1000: rail still a vertical column, readouts still in their corners">

## Scope

Deliberately only the touch work. Two other things are sitting in my tree and are not
here: a personal rename, and a multi-address/hostname binding change for serving to a
phone over a tailnet. The latter touches the local-server security boundary, so per
CONTRIBUTING it should come to you as an issue rather than a public PR, and I will open
one separately if it is of interest.

Screenshots live on the `pr-38-screenshots` branch of my fork rather than in this branch, to keep several megabytes of PNGs out of the diff under review.
