### PR TITLE
Fix one Windows checkout arriving as two projects

### DIFF
--- a/server/scan.mjs
+++ b/server/scan.mjs
@@ -19,12 +19,22 @@ import { HARNESSES, detectedHarnesses, harnessById } from './harnesses/index.mjs
  * name is also the key a saved layout is stored under, so disambiguating unconditionally would
  * move every plot on everybody's map to fix something most people never hit.
  */
-function disambiguateProjects(threads) {
+export function disambiguateProjects(threads) {
   // Windows hands the same checkout back as `c:\…` from one transcript and `C:\…` from
   // another: the CLI's project-directory encoding keeps whatever case the drive letter was
   // given. Those are one path, not two — and counted as two they make an unambiguous name look
   // ambiguous, which renames a plot on a machine that has no collision at all.
-  const canonical = (p) => (/^[A-Za-z]:[\\/]/.test(p) ? p[0].toLowerCase() + p.slice(1) : p)
+  //
+  // Codex hands the same checkout back a third way: with the extended-length prefix, as
+  // `\\?\C:\…`. That does not begin with a drive letter, so the case fold below never reached
+  // it and one folder on disk arrived here as two paths — enough to make `geh` look ambiguous
+  // against itself and rename both plots to their full absolute paths. Drop the prefix first,
+  // but only where a drive follows it: `\\?\UNC\server\share` is a different animal, and
+  // folding its first character would be wrong.
+  const canonical = (p) => {
+    const s = /^\\\\\?\\[A-Za-z]:[\\/]/.test(p) ? p.slice(4) : p
+    return /^[A-Za-z]:[\\/]/.test(s) ? s[0].toLowerCase() + s.slice(1) : s
+  }
 
   const pathsByName = new Map()
   for (const t of threads) {

--- a/test/scan.test.mjs
+++ b/test/scan.test.mjs
@@ -1,0 +1,86 @@
+/**
+ * Project names: the disambiguation that should only fire when two checkouts really do collide.
+ *
+ * The interesting cases are all Windows, because Windows is where one folder on disk reaches the
+ * scanner spelled three different ways — `C:\…`, `c:\…`, and `\\?\C:\…`. Counted as three paths
+ * instead of one, a name that nothing collides with looks ambiguous against itself, and both
+ * plots get renamed to their full absolute paths on a machine that has no collision at all.
+ */
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { disambiguateProjects } from '../server/scan.mjs'
+
+const thread = (id, project, projectPath) => ({ id, project, projectPath })
+const names = (threads) => disambiguateProjects(threads).map((t) => t.project)
+
+test('one checkout spelled with and without the extended-length prefix is still one project', () => {
+  assert.deepEqual(
+    names([
+      thread('a', 'geh', '\\\\?\\C:\\Users\\me\\Documents\\Codex\\geh'),
+      thread('b', 'geh', 'C:\\Users\\me\\Documents\\Codex\\geh'),
+    ]),
+    ['geh', 'geh']
+  )
+})
+
+test('the drive letter alone never splits a project in two', () => {
+  assert.deepEqual(
+    names([
+      thread('a', 'foo', 'c:\\work\\foo'),
+      thread('b', 'foo', 'C:\\work\\foo'),
+    ]),
+    ['foo', 'foo']
+  )
+})
+
+test('all three spellings of one path collapse together', () => {
+  assert.deepEqual(
+    names([
+      thread('a', 'foo', '\\\\?\\C:\\work\\foo'),
+      thread('b', 'foo', 'c:\\work\\foo'),
+      thread('c', 'foo', 'C:\\work\\foo'),
+    ]),
+    ['foo', 'foo', 'foo']
+  )
+})
+
+test('two real checkouts of the same repo still separate', () => {
+  assert.deepEqual(
+    names([
+      thread('a', 'foo', 'C:\\work\\1\\foo'),
+      thread('b', 'foo', 'C:\\work\\2\\foo'),
+    ]),
+    ['1/foo', '2/foo']
+  )
+})
+
+test('a prefixed path and a real second checkout separate on the path, not the prefix', () => {
+  assert.deepEqual(
+    names([
+      thread('a', 'foo', '\\\\?\\C:\\work\\1\\foo'),
+      thread('b', 'foo', 'C:\\work\\2\\foo'),
+    ]),
+    ['1/foo', '2/foo']
+  )
+})
+
+test('a share is not a drive — \\\\?\\UNC\\… keeps its own identity', () => {
+  assert.deepEqual(
+    names([
+      thread('a', 'foo', '\\\\?\\UNC\\server\\share\\foo'),
+      thread('b', 'foo', 'C:\\work\\foo'),
+    ]),
+    ['share/foo', 'work/foo']
+  )
+})
+
+test('posix paths are untouched by any of it', () => {
+  assert.deepEqual(
+    names([
+      thread('a', 'foo', '/home/me/1/foo'),
+      thread('b', 'foo', '/home/me/2/foo'),
+    ]),
+    ['1/foo', '2/foo']
+  )
+})


### PR DESCRIPTION
## What

`canonical()` in `server/scan.mjs` now strips the Windows extended-length prefix (`\\?\`) before folding the drive letter, and `test/scan.test.mjs` covers the function for the first time.

## Why

Codex reports a thread's `cwd` with the extended-length prefix, as `\\?\C:\...`. `canonical()` exists to fold `c:\foo` and `C:\foo` into one path — the comment above it says exactly that — but its test requires the string to *begin* with a drive letter. A prefixed path never matched, so it passed through untouched.

That means one folder on disk reaches `disambiguateProjects()` as two distinct paths. Two paths under one name make that name look ambiguous against itself, so the collision branch fires on a machine that has no collision at all. The consequences are all user-visible:

- the repo is given two hex plots instead of one
- the HUD counts it twice (`5 REPOS` where there are 4)
- both plots lose their name and are relabelled with their full absolute paths

Observed on a real colony — two Codex threads in one folder, rendering as two zones named `C:/Users/.../geh` and `c:/Users/.../geh` instead of a single `geh`. After the fix: one zone, named `geh`, carrying both threads.

This is the class of bug CONTRIBUTING.md calls out as the priority — the colony misrepresenting what a thread is actually doing.

## Reviewer notes

- **The prefix is only stripped ahead of a drive letter.** `\\?\UNC\server\share` is a different animal and folding its first character would be wrong; there is a test pinning that.
- **No behaviour change for genuine collisions.** Two real sibling checkouts of the same repo still disambiguate to `1/foo` and `2/foo`. Tested.
- **Saved layouts.** Anyone who has already run an affected colony has orphaned plot keys in their `data/colony.json` under the old full-path names. They are harmless — the game creates the correct zone and routes around them — but they do occupy hex coordinates. I did not add a migration, on the reasoning that `DECISIONS.md` treats moving people's plots as the thing to avoid; happy to add one if you would rather sweep them.
- `disambiguateProjects` had to be exported to be testable. It had no coverage before.
- Test suite: 33 passing before, 40 after.
